### PR TITLE
Backslash escape character is always stripped

### DIFF
--- a/java/common/util/Strings.java
+++ b/java/common/util/Strings.java
@@ -25,6 +25,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 import java.util.Locale;
+
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.INDENTATION;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.NEW_LINE;
 
@@ -38,12 +39,24 @@ public class Strings {
         return regex.replaceAll("/", "\\\\/");
     }
 
+    public static String unescapeString(String string) {
+        return string.replaceAll("\\\\(.)", "$1");
+    }
+
+    public static String escapeString(String string) {
+        return string.replaceAll("(\\\\|\")", "\\\\$1");
+    }
+
     /**
      * @param string a string to quote and escape
      * @return a string, surrounded with double quotes and escaped
      */
     public static String quoteString(String string) {
         return "\"" + string + "\"";
+    }
+
+    public static String unquoteString(String string) {
+        return string.substring(1, string.length() - 1);
     }
 
     public static String indent(Object object) {

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -716,7 +716,7 @@ public class Parser extends TypeQLBaseVisitor {
     // LITERAL INPUT VALUES ====================================================
 
     public String getRegex(TerminalNode string) {
-        return unescapeRegex(unquoteString(string.getText()));
+        return unescapeRegex(unescapeString(unquoteString(string.getText())));
     }
 
     @Override

--- a/java/parser/Parser.java
+++ b/java/parser/Parser.java
@@ -76,6 +76,8 @@ import static com.vaticle.typedb.common.collection.Collections.pair;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.ILLEGAL_GRAMMAR;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.ILLEGAL_STATE;
 import static com.vaticle.typeql.lang.common.util.Strings.unescapeRegex;
+import static com.vaticle.typeql.lang.common.util.Strings.unescapeString;
+import static com.vaticle.typeql.lang.common.util.Strings.unquoteString;
 import static com.vaticle.typeql.lang.pattern.variable.UnboundVariable.hidden;
 import static java.util.stream.Collectors.toList;
 import static org.antlr.v4.runtime.atn.PredictionMode.LL_EXACT_AMBIG_DETECTION;
@@ -714,7 +716,7 @@ public class Parser extends TypeQLBaseVisitor {
     // LITERAL INPUT VALUES ====================================================
 
     public String getRegex(TerminalNode string) {
-        return unescapeRegex(unquoteString(string));
+        return unescapeRegex(unquoteString(string.getText()));
     }
 
     @Override
@@ -767,13 +769,8 @@ public class Parser extends TypeQLBaseVisitor {
         assert start != null && end != null;
         assert start.equals(TypeQLToken.Char.QUOTE_DOUBLE) || start.equals(TypeQLToken.Char.QUOTE_SINGLE);
         assert end.equals(TypeQLToken.Char.QUOTE_DOUBLE) || end.equals(TypeQLToken.Char.QUOTE_SINGLE);
-
-        // Remove surrounding quotes
-        return unquoteString(string);
-    }
-
-    private String unquoteString(TerminalNode string) {
-        return string.getText().substring(1, string.getText().length() - 1);
+        // Remove surrounding quotes and backslash escapes
+        return unescapeString(unquoteString(str));
     }
 
     private long getLong(TerminalNode number) {

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -954,7 +954,6 @@ public class ParserTest {
         final String attributeValue = "This has \"double quotes\" and a single-quoted backslash: '\\'";
         final String escapedValue = attributeValue.replace("\\", "\\\\").replace("\"", "\\\"");
 
-
         final String query = "insert\n" +
                 "$_ isa movie,\n" +
                 "    has title \"" + escapedValue + "\";";
@@ -1273,7 +1272,7 @@ public class ParserTest {
     public void defineAttributeTypeRegex() {
         final String query = "define\n" +
                 "digit sub attribute,\n" +
-                "    regex '\\d';";
+                "    regex '\\\\d';";
         TypeQLDefine parsed = parseQuery(query);
         TypeQLDefine expected = define(type("digit").sub("attribute").regex("\\d"));
         assertQueryEquals(expected, parsed, query.replace("'", "\""));
@@ -1281,7 +1280,7 @@ public class ParserTest {
 
     @Test
     public void undefineAttributeTypeRegex() {
-        final String query = "undefine\ndigit regex '\\d';";
+        final String query = "undefine\ndigit regex '\\\\d';";
         TypeQLUndefine parsed = parseQuery(query);
         TypeQLUndefine expected = undefine(type("digit").regex("\\d"));
         assertQueryEquals(expected, parsed, query.replace("'", "\""));
@@ -1289,7 +1288,7 @@ public class ParserTest {
 
     @Test
     public void regexPredicateParsesCharacterClassesCorrectly() {
-        final String query = "match\n$x like '\\d';";
+        final String query = "match\n$x like '\\\\d';";
         TypeQLMatch parsed = parseQuery(query);
         TypeQLMatch expected = match(var("x").like("\\d"));
         assertQueryEquals(expected, parsed, query.replace("'", "\""));
@@ -1299,7 +1298,7 @@ public class ParserTest {
     public void regexPredicateParsesQuotesCorrectly() {
         final String query = "match\n$x like '\\\"';";
         TypeQLMatch parsed = parseQuery(query);
-        TypeQLMatch expected = match(var("x").like("\\\""));
+        TypeQLMatch expected = match(var("x").like("\""));
         assertQueryEquals(expected, parsed, query.replace("'", "\""));
     }
 
@@ -1307,13 +1306,13 @@ public class ParserTest {
     public void regexPredicateParsesBackslashesCorrectly() {
         final String query = "match\n$x like '\\\\';";
         TypeQLMatch parsed = parseQuery(query);
-        TypeQLMatch expected = match(var("x").like("\\\\"));
+        TypeQLMatch expected = match(var("x").like("\\"));
         assertQueryEquals(expected, parsed, query.replace("'", "\""));
     }
 
     @Test
     public void regexPredicateParsesNewlineCorrectly() {
-        final String query = "match\n$x like '\\n';";
+        final String query = "match\n$x like '\\\\n';";
         TypeQLMatch parsed = parseQuery(query);
         TypeQLMatch expected = match(var("x").like("\\n"));
         assertQueryEquals(expected, parsed, query.replace("'", "\""));
@@ -1321,7 +1320,7 @@ public class ParserTest {
 
     @Test
     public void regexPredicateParsesForwardSlashesCorrectly() {
-        final String query = "match\n$x like '\\/';";
+        final String query = "match\n$x like '\\\\/';";
         TypeQLMatch parsed = parseQuery(query);
         TypeQLMatch expected = match(var("x").like("/"));
         assertQueryEquals(expected, parsed, query.replace("'", "\""));

--- a/java/parser/test/ParserTest.java
+++ b/java/parser/test/ParserTest.java
@@ -24,6 +24,7 @@ package com.vaticle.typeql.lang.parser.test;
 import com.vaticle.typeql.lang.TypeQL;
 import com.vaticle.typeql.lang.common.TypeQLArg;
 import com.vaticle.typeql.lang.common.exception.TypeQLException;
+import com.vaticle.typeql.lang.common.util.Strings;
 import com.vaticle.typeql.lang.pattern.Conjunction;
 import com.vaticle.typeql.lang.pattern.Pattern;
 import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
@@ -950,17 +951,17 @@ public class ParserTest {
 
     @Test
     public void testEscapeString() {
-        // ANTLR will see this as a string that looks like:
-        // "This has \"double quotes\" and a single-quoted backslash: '\\'"
-        final String input = "This has \\\"double quotes\\\" and a single-quoted backslash: \\'\\\\\\'";
+        final String attributeValue = "This has \"double quotes\" and a single-quoted backslash: '\\'";
+        final String escapedValue = attributeValue.replace("\\", "\\\\").replace("\"", "\\\"");
+
 
         final String query = "insert\n" +
                 "$_ isa movie,\n" +
-                "    has title \"" + input + "\";";
+                "    has title \"" + escapedValue + "\";";
         TypeQLInsert parsed = TypeQL.parseQuery(query).asInsert();
-        TypeQLInsert expected = insert(var().isa("movie").has("title", input));
+        TypeQLInsert built = insert(var().isa("movie").has("title", attributeValue));
 
-        assertQueryEquals(expected, parsed, query);
+        assertQueryEquals(built, parsed, query);
     }
 
 

--- a/java/pattern/constraint/ThingConstraint.java
+++ b/java/pattern/constraint/ThingConstraint.java
@@ -651,7 +651,7 @@ public abstract class ThingConstraint extends Constraint<BoundVariable> {
                 StringBuilder operation = new StringBuilder();
 
                 if (predicate().equals(LIKE)) {
-                    operation.append(LIKE).append(SPACE).append(quoteString(escapeRegex(value())));
+                    operation.append(LIKE).append(SPACE).append(quoteString(escapeString(escapeRegex(value()))));
                 } else if (predicate().equals(EQ)) {
                     operation.append(quoteString(escapeString(value())));
                 } else {

--- a/java/pattern/constraint/ThingConstraint.java
+++ b/java/pattern/constraint/ThingConstraint.java
@@ -64,6 +64,7 @@ import static com.vaticle.typeql.lang.common.exception.ErrorMessage.MISSING_CONS
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.MISSING_CONSTRAINT_RELATION_PLAYER;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.MISSING_CONSTRAINT_VALUE;
 import static com.vaticle.typeql.lang.common.util.Strings.escapeRegex;
+import static com.vaticle.typeql.lang.common.util.Strings.escapeString;
 import static com.vaticle.typeql.lang.common.util.Strings.quoteString;
 import static com.vaticle.typeql.lang.pattern.variable.UnboundVariable.hidden;
 
@@ -652,9 +653,9 @@ public abstract class ThingConstraint extends Constraint<BoundVariable> {
                 if (predicate().equals(LIKE)) {
                     operation.append(LIKE).append(SPACE).append(quoteString(escapeRegex(value())));
                 } else if (predicate().equals(EQ)) {
-                    operation.append(quoteString(value()));
+                    operation.append(quoteString(escapeString(value())));
                 } else {
-                    operation.append(predicate()).append(SPACE).append(quoteString(value()));
+                    operation.append(predicate()).append(SPACE).append(quoteString(escapeString(value())));
                 }
 
                 return operation.toString();

--- a/java/pattern/constraint/TypeConstraint.java
+++ b/java/pattern/constraint/TypeConstraint.java
@@ -55,6 +55,7 @@ import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_ATTR
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.INVALID_CASTING;
 import static com.vaticle.typeql.lang.common.exception.ErrorMessage.MISSING_PATTERNS;
 import static com.vaticle.typeql.lang.common.util.Strings.escapeRegex;
+import static com.vaticle.typeql.lang.common.util.Strings.escapeString;
 import static com.vaticle.typeql.lang.common.util.Strings.quoteString;
 import static com.vaticle.typeql.lang.pattern.variable.UnboundVariable.hidden;
 
@@ -380,7 +381,7 @@ public abstract class TypeConstraint extends Constraint<TypeVariable> {
 
         @Override
         public String toString() {
-            return REGEX.toString() + SPACE + quoteString(escapeRegex(regex().pattern()));
+            return REGEX.toString() + SPACE + quoteString(escapeString(escapeRegex(regex().pattern())));
         }
 
         @Override

--- a/java/query/test/TypeQLQueryTest.java
+++ b/java/query/test/TypeQLQueryTest.java
@@ -114,7 +114,7 @@ public class TypeQLQueryTest {
     @Test
     public void testEscapeStrings() {
         assertEquals("insert\n$x \"hello\nworld\";", TypeQL.insert(var("x").eq("hello\nworld")).toString());
-        assertEquals("insert\n$x \"hello\\nworld\";", TypeQL.insert(var("x").eq("hello\\nworld")).toString());
+        assertEquals("insert\n$x \"hello\\\\nworld\";", TypeQL.insert(var("x").eq("hello\\nworld")).toString());
     }
 
     @Test


### PR DESCRIPTION
# DO NOT MERGE (see comment)

## What is the goal of this PR?

We address various String escaping difficulties by which the user could not get a raw string containing a quote, or a backslash, into TypeDB without also serialising an escape character into the database. This is contrary to the existing database conventions.

We now expect that a user can insert any dataset into TypeDB by applying the following operation to their raw input strings:
```
escaped_data = raw_data.replace("\\", "\\\\").replace("\"", "\\\"")
insert_query = "insert $x isa person, has data \"" + escaped_data + "\""
```

This process will replace each `\` character with a `\\` sequence, and then replace each `"` with an `\"` sequence. This will ensure that by the time the query is parsed, the user's raw data is held in memory on the server side.

**Example**
If `raw_data` above contains `hello " world \ `, then the `escaped_data` will contain `hello \" world \\ `. After the query is submitted to the server and parsed, the data value held for attribute `data` will be `hello " world \ ` and this is the value that will be persisted into the database.


## What are the changes implemented in this PR?

* TypeQL establishes `\` as the official escape character
* Align behaviour with database convention: console query strings that include attribute values with escapes, remove those escape characters during parsing.
* When parsing a String attribute or Regex string, any backslash character is replaced its following character
* When printing out parsed queries, we escape strings and regexes according to the reverse convention: include a backslash before each existing backslash and double quote character.
* Previously, we broke user expectations set by other databases: the users escaped `"` and `\`, but we always kept the escape character after parsing - as a result the user data _plus_ backslashes ended up stored on disk.


### Existing database conventions:

Let's split query languages into two domains: console languages, and programmatic languages.

Programmatic languages include parametrised queries, for example in SQL a query can exclude attribute values, and pass them to the server separately to the parametrised query. This means escaping is never needed (and protects against SQL injection attacks) because a String attribute is passed directly to the server as a string. TypeDB does not yet support parametrised queries. As a result, we must always construct query strings that are parsed by the parser in full. Neo4j and MongoDB have their own parametrised input mechanisms that behave similarly.

Console languages are languages whose queries must be inputted entirely as strings. All TypeQL queries are provided as strings, so let's define them as console languages. Console languages all have an escape mechanism to input quoting into string attribute values. SQL and Neo4j have console languages available that use different conventions:

SQL uses the quoting character itself as the escape character:
```
select 'it''s escaped'
```
This will be parsed as `it's escaped` and utilised in the query exection. The escaping `'` is removed.

Neo4J uses backslashes:
```
CREATE (n:Node {name:"hello \" world \\ "}) 
RETURN n.name

n.name
hello " world \
```
In this case, the parsed value removes the escape character `\` in both usages.

We can see that existing console languages use the _convention of stripping the escape characters from the input_, which TypeQL now matches.
