### PR TITLE
Make fields for expression public & Add finer literal parsing

### DIFF
--- a/rust/annotation.rs
+++ b/rust/annotation.rs
@@ -9,9 +9,8 @@ use std::fmt::{self, Write};
 use crate::{
     common::{identifier::Identifier, token, Span},
     util::write_joined,
-    value::{StringLiteral, Literal},
+    value::{IntegerLiteral, Literal, StringLiteral},
 };
-use crate::value::IntegerLiteral;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Annotation {

--- a/rust/annotation.rs
+++ b/rust/annotation.rs
@@ -78,9 +78,9 @@ impl Cardinality {
 
 impl fmt::Display for Cardinality {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "@{}({}..", token::Annotation::Cardinality, self.min.integral)?;
+        write!(f, "@{}({}..", token::Annotation::Cardinality, self.min.value)?;
         if let Some(max) = &self.max {
-            write!(f, "{}", max.integral)?;
+            write!(f, "{}", max.value)?;
         }
         f.write_char(')')?;
         Ok(())

--- a/rust/annotation.rs
+++ b/rust/annotation.rs
@@ -9,8 +9,9 @@ use std::fmt::{self, Write};
 use crate::{
     common::{identifier::Identifier, token, Span},
     util::write_joined,
-    value::Literal,
+    value::{StringLiteral, Literal},
 };
+use crate::value::IntegerLiteral;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Annotation {
@@ -65,21 +66,21 @@ impl fmt::Display for Abstract {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Cardinality {
     span: Option<Span>,
-    min: Literal,
-    max: Option<Literal>,
+    min: IntegerLiteral,
+    max: Option<IntegerLiteral>,
 }
 
 impl Cardinality {
-    pub fn new(span: Option<Span>, min: Literal, max: Option<Literal>) -> Self {
+    pub fn new(span: Option<Span>, min: IntegerLiteral, max: Option<IntegerLiteral>) -> Self {
         Self { span, min, max }
     }
 }
 
 impl fmt::Display for Cardinality {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "@{}({}..", token::Annotation::Cardinality, self.min)?;
+        write!(f, "@{}({}..", token::Annotation::Cardinality, self.min.integral)?;
         if let Some(max) = &self.max {
-            write!(f, "{}", max)?;
+            write!(f, "{}", max.integral)?;
         }
         f.write_char(')')?;
         Ok(())
@@ -185,18 +186,18 @@ impl fmt::Display for Range {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Regex {
     span: Option<Span>,
-    regex: Literal,
+    regex: StringLiteral,
 }
 
 impl Regex {
-    pub fn new(span: Option<Span>, regex: Literal) -> Self {
+    pub fn new(span: Option<Span>, regex: StringLiteral) -> Self {
         Self { span, regex }
     }
 }
 
 impl fmt::Display for Regex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "@{}({})", token::Annotation::Regex, self.regex)
+        write!(f, "@{}({})", token::Annotation::Regex, self.regex.value)
     }
 }
 

--- a/rust/parser/annotation.rs
+++ b/rust/parser/annotation.rs
@@ -4,15 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use super::{
-    visit_identifier, visit_integer_literal, visit_quoted_string_literal, visit_value_literal, IntoChildNodes, Node,
-    Rule, RuleMatcher,
-};
+use super::{visit_identifier, IntoChildNodes, Node, Rule, RuleMatcher};
 use crate::{
     annotation::{
         Abstract, Annotation, Cardinality, Cascade, Distinct, Independent, Key, Range, Regex, Subkey, Unique, Values,
     },
     common::{error::TypeQLError, Spanned},
+    parser::literal::{visit_integer_literal, visit_quoted_string_literal, visit_value_literal},
     value::Literal,
 };
 

--- a/rust/parser/annotation.rs
+++ b/rust/parser/annotation.rs
@@ -114,7 +114,7 @@ fn visit_annotation_regex(node: Node<'_>) -> Regex {
     children.consume_expected(Rule::ANNOTATION_REGEX);
     let regex = visit_quoted_string_literal(children.consume_expected(Rule::quoted_string_literal));
     debug_assert_eq!(children.try_consume_any(), None);
-    Regex::new(span, regex)
+    Regex::new(span, regex.value)
 }
 
 fn visit_annotation_values(node: Node<'_>) -> Values {

--- a/rust/parser/annotation.rs
+++ b/rust/parser/annotation.rs
@@ -114,7 +114,7 @@ fn visit_annotation_regex(node: Node<'_>) -> Regex {
     children.consume_expected(Rule::ANNOTATION_REGEX);
     let regex = visit_quoted_string_literal(children.consume_expected(Rule::quoted_string_literal));
     debug_assert_eq!(children.try_consume_any(), None);
-    Regex::new(span, regex.value)
+    Regex::new(span, regex)
 }
 
 fn visit_annotation_values(node: Node<'_>) -> Values {

--- a/rust/parser/annotation.rs
+++ b/rust/parser/annotation.rs
@@ -4,13 +4,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use super::{visit_identifier, IntoChildNodes, Node, Rule, RuleMatcher};
+use super::{
+    literal::{visit_integer_literal, visit_quoted_string_literal, visit_value_literal},
+    visit_identifier, IntoChildNodes, Node, Rule, RuleMatcher,
+};
 use crate::{
     annotation::{
         Abstract, Annotation, Cardinality, Cascade, Distinct, Independent, Key, Range, Regex, Subkey, Unique, Values,
     },
     common::{error::TypeQLError, Spanned},
-    parser::literal::{visit_integer_literal, visit_quoted_string_literal, visit_value_literal},
     value::Literal,
 };
 

--- a/rust/parser/expression.rs
+++ b/rust/parser/expression.rs
@@ -97,7 +97,7 @@ fn visit_list_index(node: Node<'_>) -> Expression {
 
 pub(super) fn visit_expression_struct(node: Node<'_>) -> Literal {
     debug_assert_eq!(node.as_rule(), Rule::expression_struct);
-    Literal::new(node.span(), None, node.as_str().to_owned()) // TODO parse properly
+    Literal::new(node.span(), None, todo!()) // TODO parse properly
 }
 
 fn visit_expression_parenthesis(node: Node<'_>) -> Paren {

--- a/rust/parser/expression.rs
+++ b/rust/parser/expression.rs
@@ -6,12 +6,13 @@
 
 use pest::pratt_parser::{Assoc, Op, PrattParser};
 
-use super::{visit_identifier, visit_value_literal, visit_var, IntoChildNodes, Node, Rule, RuleMatcher};
+use super::{visit_identifier, visit_var, IntoChildNodes, Node, Rule, RuleMatcher};
 use crate::{
     common::{error::TypeQLError, token, Spanned},
     expression::{
         BuiltinFunctionName, Expression, FunctionCall, FunctionName, List, ListIndex, ListIndexRange, Operation, Paren,
     },
+    parser::literal::visit_value_literal,
     value::{Literal, StructLiteral, ValueLiteral},
 };
 

--- a/rust/parser/expression.rs
+++ b/rust/parser/expression.rs
@@ -6,13 +6,12 @@
 
 use pest::pratt_parser::{Assoc, Op, PrattParser};
 
-use super::{visit_identifier, visit_var, IntoChildNodes, Node, Rule, RuleMatcher};
+use super::{literal::visit_value_literal, visit_identifier, visit_var, IntoChildNodes, Node, Rule, RuleMatcher};
 use crate::{
     common::{error::TypeQLError, token, Spanned},
     expression::{
         BuiltinFunctionName, Expression, FunctionCall, FunctionName, List, ListIndex, ListIndexRange, Operation, Paren,
     },
-    parser::literal::visit_value_literal,
     value::{Literal, StructLiteral, ValueLiteral},
 };
 

--- a/rust/parser/expression.rs
+++ b/rust/parser/expression.rs
@@ -12,7 +12,7 @@ use crate::{
     expression::{
         BuiltinFunctionName, Expression, FunctionCall, FunctionName, List, ListIndex, ListIndexRange, Operation, Paren,
     },
-    value::Literal,
+    value::{Literal, ValueLiteral},
 };
 
 pub(super) fn visit_expression_function(node: Node<'_>) -> FunctionCall {
@@ -97,7 +97,7 @@ fn visit_list_index(node: Node<'_>) -> Expression {
 
 pub(super) fn visit_expression_struct(node: Node<'_>) -> Literal {
     debug_assert_eq!(node.as_rule(), Rule::expression_struct);
-    Literal::new(node.span(), todo!()) // TODO parse properly
+    Literal::new(node.span(), ValueLiteral::Struct(node.as_str().to_owned())) // TODO parse properly
 }
 
 fn visit_expression_parenthesis(node: Node<'_>) -> Paren {

--- a/rust/parser/expression.rs
+++ b/rust/parser/expression.rs
@@ -97,7 +97,7 @@ fn visit_list_index(node: Node<'_>) -> Expression {
 
 pub(super) fn visit_expression_struct(node: Node<'_>) -> Literal {
     debug_assert_eq!(node.as_rule(), Rule::expression_struct);
-    Literal::new(node.span(), None, todo!()) // TODO parse properly
+    Literal::new(node.span(), todo!()) // TODO parse properly
 }
 
 fn visit_expression_parenthesis(node: Node<'_>) -> Paren {

--- a/rust/parser/expression.rs
+++ b/rust/parser/expression.rs
@@ -12,7 +12,7 @@ use crate::{
     expression::{
         BuiltinFunctionName, Expression, FunctionCall, FunctionName, List, ListIndex, ListIndexRange, Operation, Paren,
     },
-    value::{Literal, ValueLiteral},
+    value::{Literal, StructLiteral, ValueLiteral},
 };
 
 pub(super) fn visit_expression_function(node: Node<'_>) -> FunctionCall {
@@ -97,7 +97,8 @@ fn visit_list_index(node: Node<'_>) -> Expression {
 
 pub(super) fn visit_expression_struct(node: Node<'_>) -> Literal {
     debug_assert_eq!(node.as_rule(), Rule::expression_struct);
-    Literal::new(node.span(), ValueLiteral::Struct(node.as_str().to_owned())) // TODO parse properly
+    Literal::new(node.span(), ValueLiteral::Struct(StructLiteral { inner: node.as_str().to_owned() }))
+    // TODO parse properly
 }
 
 fn visit_expression_parenthesis(node: Node<'_>) -> Paren {

--- a/rust/parser/literal.rs
+++ b/rust/parser/literal.rs
@@ -1,0 +1,118 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::{
+    common::{error::TypeQLError, Spanned},
+    parser::{IntoChildNodes, Node, Rule, RuleMatcher},
+    value::{
+        BooleanLiteral, DateFragment, DateLiteral, DateTimeLiteral, DateTimeTZLiteral, IntegerLiteral, Literal, Sign,
+        SignedDecimalLiteral, SignedIntegerLiteral, StringLiteral, TimeFragment, TimeZone, ValueLiteral,
+    },
+};
+
+pub(super) fn visit_value_literal(node: Node<'_>) -> Literal {
+    debug_assert_eq!(node.as_rule(), Rule::value_literal);
+    let span = node.span();
+    let child = node.into_child();
+    let value_literal = match child.as_rule() {
+        Rule::quoted_string_literal => ValueLiteral::String(visit_quoted_string_literal(child)),
+        Rule::boolean_literal => ValueLiteral::Boolean(BooleanLiteral { value: child.as_str().to_owned() }),
+        Rule::signed_integer => ValueLiteral::Integer(visit_signed_integer(child)),
+        Rule::signed_decimal => ValueLiteral::Decimal(visit_signed_decimal(child)),
+
+        Rule::datetime_tz_literal => ValueLiteral::DateTimeTz(visit_datetime_tz_literal(child)),
+        Rule::datetime_literal => ValueLiteral::DateTime(visit_datetime_literal(child)),
+        Rule::date_literal => ValueLiteral::Date(visit_date_literal(child)),
+
+        _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
+    };
+    Literal::new(span, value_literal)
+}
+
+fn visit_sign(node: Node<'_>) -> Sign {
+    debug_assert_eq!(node.as_rule(), Rule::sign);
+    match node.as_str() {
+        "+" => Sign::Plus,
+        "-" => Sign::Minus,
+        _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: node.to_string() }),
+    }
+}
+
+pub(super) fn visit_integer_literal(node: Node<'_>) -> IntegerLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::integer_literal);
+    IntegerLiteral { value: node.as_str().to_owned() }
+}
+
+pub(super) fn visit_quoted_string_literal(node: Node<'_>) -> StringLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::quoted_string_literal);
+    StringLiteral { value: node.as_str().to_owned() }
+}
+
+fn visit_signed_integer(node: Node<'_>) -> SignedIntegerLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::signed_integer);
+    let mut children = node.into_children().collect::<Vec<_>>();
+    let integral = children.pop().unwrap();
+    let sign = children.pop().map(|node| visit_sign(node));
+    debug_assert_eq!(integral.as_rule(), Rule::integer_literal);
+    SignedIntegerLiteral { sign, integral: integral.as_str().to_owned() }
+}
+
+fn visit_signed_decimal(node: Node<'_>) -> SignedDecimalLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::signed_decimal);
+    let mut children = node.into_children().collect::<Vec<_>>();
+    let decimal = children.pop().unwrap().as_str().to_owned();
+    let sign = children.pop().map(|node| visit_sign(node));
+    SignedDecimalLiteral { sign, decimal }
+}
+
+fn visit_datetime_tz_literal(node: Node<'_>) -> DateTimeTZLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::datetime_tz_literal);
+    let mut children = node.into_children();
+    let date = visit_date_fragment(children.consume_expected(Rule::date_fragment));
+    let time = visit_time(children.consume_expected(Rule::time));
+    let tz_node = children.consume_any();
+    let timezone = match tz_node.as_rule() {
+        Rule::iana_timezone => TimeZone::IANA(tz_node.as_str().to_owned()),
+        Rule::iso8601_timezone_offset => TimeZone::ISO(tz_node.as_str().to_owned()),
+        _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: tz_node.to_string() }),
+    };
+    DateTimeTZLiteral { date, time, timezone }
+}
+
+fn visit_datetime_literal(node: Node<'_>) -> DateTimeLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::datetime_literal);
+    let mut children = node.into_children();
+    let date = visit_date_fragment(children.consume_expected(Rule::date_fragment));
+    let time = visit_time(children.consume_expected(Rule::time));
+    DateTimeLiteral { date, time }
+}
+
+fn visit_date_literal(node: Node<'_>) -> DateLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::date_literal);
+    let date = visit_date_fragment(node.into_child());
+    DateLiteral { date }
+}
+
+fn visit_date_fragment(node: Node<'_>) -> DateFragment {
+    debug_assert_eq!(node.as_rule(), Rule::date_fragment);
+    let mut children = node.into_children();
+    let year = children.consume_expected(Rule::year).as_str().to_owned();
+    let month = children.consume_expected(Rule::month).as_str().to_owned();
+    let day = children.consume_expected(Rule::day).as_str().to_owned();
+    DateFragment { year, month, day }
+}
+
+fn visit_time(node: Node<'_>) -> TimeFragment {
+    debug_assert_eq!(node.as_rule(), Rule::time);
+    let children = node.into_children().collect::<Vec<_>>();
+    let (hour, minute, second) = (
+        children[0].as_str().to_owned(),
+        children[1].as_str().to_owned(),
+        children.get(2).map(|node| node.as_str().to_owned()),
+    );
+    let second_fraction = children.get(3).map(|node| node.as_str().to_owned());
+    TimeFragment { hour, minute, second, second_fraction }
+}

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -348,7 +348,7 @@ fn visit_signed_integer(node: Node<'_>) -> SignedIntegerLiteral {
     debug_assert_eq!(node.as_rule(), Rule::signed_integer);
     let mut children = node.into_children().collect::<Vec<_>>();
     let integral = children.pop().unwrap();
-    let sign = children.pop().map(|node| visit_sign(node)).unwrap_or(Sign::Plus);
+    let sign = children.pop().map(|node| visit_sign(node));
     debug_assert_eq!(integral.as_rule(), Rule::integer_literal);
     SignedIntegerLiteral { sign, integral: integral.as_str().to_owned() }
 }
@@ -357,7 +357,7 @@ fn visit_signed_decimal(node: Node<'_>) -> SignedDecimalLiteral {
     debug_assert_eq!(node.as_rule(), Rule::signed_decimal);
     let mut children = node.into_children().collect::<Vec<_>>();
     let decimal = children.pop().unwrap().as_str().to_owned();
-    let sign = children.pop().map(|node| visit_sign(node)).unwrap_or(Sign::Plus);
+    let sign = children.pop().map(|node| visit_sign(node));
     SignedDecimalLiteral { sign, decimal }
 }
 

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -355,25 +355,11 @@ fn visit_signed_integer(node: Node<'_>) -> SignedIntegerLiteral {
 }
 
 fn visit_signed_decimal(node: Node<'_>) -> SignedDecimalLiteral {
-    debug_assert_eq!(node.as_rule(), Rule::signed_integer);
+    debug_assert_eq!(node.as_rule(), Rule::signed_decimal);
     let mut children = node.into_children().collect::<Vec<_>>();
-    todo!()
-    // let decimal_node = children.pop().unwrap();
-    // let sign = children.pop().map(|node| visit_sign(node)).unwrap_or(Sign::Plus);
-    //
-    // let mut number = decimal_node.into_children().collect::<Vec<_>>();
-    // let (integral, fractional) = (number[0].as_str().to_owned(), number[1].as_str().to_owned());
-    // let (exponent_sign, exponent) = match number.len() {
-    //     3 => (Sign::Plus, number.pop().unwrap()),
-    //     4 => {
-    //         let exponent = number.pop().unwrap();
-    //         let exponent_sign = visit_sign(number.pop().unwrap());
-    //         (exponent_sign, exponent)
-    //     },
-    //     _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: decimal_node.to_string() }),
-    // };
-    //
-    // SignedDecimalLiteral { sign, integral, fractional, exponent: (exponent_sign, exponent) }
+    let decimal = children.pop().unwrap().as_str().to_owned();
+    let sign = children.pop().map(|node| visit_sign(node)).unwrap_or(Sign::Plus);
+    SignedDecimalLiteral { sign, decimal }
 }
 
 fn visit_datetime_tz_literal(node: Node<'_>) -> DateTimeTZLiteral {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -23,8 +23,8 @@ use crate::{
     schema::definable,
     type_::{BuiltinValueType, Label, List, Optional, ReservedLabel, ScopedLabel, Type},
     value::{
-        BooleanLiteral, DateFragment, DateLiteral, DateTimeLiteral, DateTimeTZLiteral, IntegerLiteral,
-        Literal, Sign, SignedDecimalLiteral, SignedIntegerLiteral, StringLiteral, TimeFragment, TimeZone, ValueLiteral,
+        BooleanLiteral, DateFragment, DateLiteral, DateTimeLiteral, DateTimeTZLiteral, IntegerLiteral, Literal, Sign,
+        SignedDecimalLiteral, SignedIntegerLiteral, StringLiteral, TimeFragment, TimeZone, ValueLiteral,
     },
     variable::Variable,
     Result,

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -21,10 +21,6 @@ use crate::{
     query::{Query, SchemaQuery},
     schema::definable,
     type_::{BuiltinValueType, Label, List, Optional, ReservedLabel, ScopedLabel, Type},
-    value::{
-        BooleanLiteral, DateFragment, DateLiteral, DateTimeLiteral, DateTimeTZLiteral, IntegerLiteral, Literal, Sign,
-        SignedDecimalLiteral, SignedIntegerLiteral, StringLiteral, TimeFragment, TimeZone, ValueLiteral,
-    },
     variable::Variable,
     Result,
 };
@@ -37,6 +33,7 @@ mod redefine;
 mod statement;
 mod undefine;
 
+mod literal;
 #[cfg(test)]
 mod test;
 
@@ -304,108 +301,4 @@ fn visit_value_type_primitive(node: Node<'_>) -> BuiltinValueType {
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     };
     BuiltinValueType::new(span, token)
-}
-
-fn visit_value_literal(node: Node<'_>) -> Literal {
-    debug_assert_eq!(node.as_rule(), Rule::value_literal);
-    let span = node.span();
-    let child = node.into_child();
-    let value_literal = match child.as_rule() {
-        Rule::quoted_string_literal => ValueLiteral::String(visit_quoted_string_literal(child)),
-        Rule::boolean_literal => ValueLiteral::Boolean(BooleanLiteral { value: child.as_str().to_owned() }),
-        Rule::signed_integer => ValueLiteral::Integer(visit_signed_integer(child)),
-        Rule::signed_decimal => ValueLiteral::Decimal(visit_signed_decimal(child)),
-
-        Rule::datetime_tz_literal => ValueLiteral::DateTimeTz(visit_datetime_tz_literal(child)),
-        Rule::datetime_literal => ValueLiteral::DateTime(visit_datetime_literal(child)),
-        Rule::date_literal => ValueLiteral::Date(visit_date_literal(child)),
-
-        _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
-    };
-    Literal::new(span, value_literal)
-}
-
-fn visit_sign(node: Node<'_>) -> Sign {
-    debug_assert_eq!(node.as_rule(), Rule::sign);
-    match node.as_str() {
-        "+" => Sign::Plus,
-        "-" => Sign::Minus,
-        _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: node.to_string() }),
-    }
-}
-
-fn visit_integer_literal(node: Node<'_>) -> IntegerLiteral {
-    debug_assert_eq!(node.as_rule(), Rule::integer_literal);
-    IntegerLiteral { value: node.as_str().to_owned() }
-}
-
-fn visit_quoted_string_literal(node: Node<'_>) -> StringLiteral {
-    debug_assert_eq!(node.as_rule(), Rule::quoted_string_literal);
-    StringLiteral { value: node.as_str().to_owned() }
-}
-
-fn visit_signed_integer(node: Node<'_>) -> SignedIntegerLiteral {
-    debug_assert_eq!(node.as_rule(), Rule::signed_integer);
-    let mut children = node.into_children().collect::<Vec<_>>();
-    let integral = children.pop().unwrap();
-    let sign = children.pop().map(|node| visit_sign(node));
-    debug_assert_eq!(integral.as_rule(), Rule::integer_literal);
-    SignedIntegerLiteral { sign, integral: integral.as_str().to_owned() }
-}
-
-fn visit_signed_decimal(node: Node<'_>) -> SignedDecimalLiteral {
-    debug_assert_eq!(node.as_rule(), Rule::signed_decimal);
-    let mut children = node.into_children().collect::<Vec<_>>();
-    let decimal = children.pop().unwrap().as_str().to_owned();
-    let sign = children.pop().map(|node| visit_sign(node));
-    SignedDecimalLiteral { sign, decimal }
-}
-
-fn visit_datetime_tz_literal(node: Node<'_>) -> DateTimeTZLiteral {
-    debug_assert_eq!(node.as_rule(), Rule::datetime_tz_literal);
-    let mut children = node.into_children();
-    let date = visit_date_fragment(children.consume_expected(Rule::date_fragment));
-    let time = visit_time(children.consume_expected(Rule::time));
-    let tz_node = children.consume_any();
-    let timezone = match tz_node.as_rule() {
-        Rule::iana_timezone => TimeZone::IANA(tz_node.as_str().to_owned()),
-        Rule::iso8601_timezone_offset => TimeZone::ISO(tz_node.as_str().to_owned()),
-        _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: tz_node.to_string() }),
-    };
-    DateTimeTZLiteral { date, time, timezone }
-}
-
-fn visit_datetime_literal(node: Node<'_>) -> DateTimeLiteral {
-    debug_assert_eq!(node.as_rule(), Rule::datetime_literal);
-    let mut children = node.into_children();
-    let date = visit_date_fragment(children.consume_expected(Rule::date_fragment));
-    let time = visit_time(children.consume_expected(Rule::time));
-    DateTimeLiteral { date, time }
-}
-
-fn visit_date_literal(node: Node<'_>) -> DateLiteral {
-    debug_assert_eq!(node.as_rule(), Rule::date_literal);
-    let date = visit_date_fragment(node.into_child());
-    DateLiteral { date }
-}
-
-fn visit_date_fragment(node: Node<'_>) -> DateFragment {
-    debug_assert_eq!(node.as_rule(), Rule::date_fragment);
-    let mut children = node.into_children();
-    let year = children.consume_expected(Rule::year).as_str().to_owned();
-    let month = children.consume_expected(Rule::month).as_str().to_owned();
-    let day = children.consume_expected(Rule::day).as_str().to_owned();
-    DateFragment { year, month, day }
-}
-
-fn visit_time(node: Node<'_>) -> TimeFragment {
-    debug_assert_eq!(node.as_rule(), Rule::time);
-    let children = node.into_children().collect::<Vec<_>>();
-    let (hour, minute, second) = (
-        children[0].as_str().to_owned(),
-        children[1].as_str().to_owned(),
-        children.get(2).map(|node| node.as_str().to_owned()),
-    );
-    let second_fraction = children.get(3).map(|node| node.as_str().to_owned());
-    TimeFragment { hour, minute, second, second_fraction }
 }

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 
 use super::{
     define::function::visit_definition_function,
+    literal::visit_integer_literal,
     statement::{
         thing::{visit_relation, visit_statement_thing},
         visit_statement,
@@ -20,7 +21,6 @@ use crate::{
         token::{Aggregate, Order},
         Spanned,
     },
-    parser::literal::visit_integer_literal,
     pattern::{Conjunction, Disjunction, Negation, Optional, Pattern},
     query::{
         pipeline::{

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -12,7 +12,7 @@ use super::{
         thing::{visit_relation, visit_statement_thing},
         visit_statement,
     },
-    visit_integer_literal, visit_label, visit_var, visit_vars, IntoChildNodes, Node, Rule, RuleMatcher,
+    visit_label, visit_var, visit_vars, IntoChildNodes, Node, Rule, RuleMatcher,
 };
 use crate::{
     common::{
@@ -20,6 +20,7 @@ use crate::{
         token::{Aggregate, Order},
         Spanned,
     },
+    parser::literal::visit_integer_literal,
     pattern::{Conjunction, Disjunction, Negation, Optional, Pattern},
     query::{
         pipeline::{

--- a/rust/parser/statement/thing.rs
+++ b/rust/parser/statement/thing.rs
@@ -4,14 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use super::visit_comparison;
 use crate::{
     common::{error::TypeQLError, Spanned},
     expression::Expression,
     parser::{
         expression::{visit_expression_list, visit_expression_struct, visit_expression_value},
         literal::visit_value_literal,
-        statement::visit_type_ref,
+        statement::{visit_comparison, visit_type_ref},
         visit_label_list, visit_var, visit_var_list, IntoChildNodes, Node, Rule, RuleMatcher,
     },
     statement::{

--- a/rust/parser/statement/thing.rs
+++ b/rust/parser/statement/thing.rs
@@ -10,8 +10,9 @@ use crate::{
     expression::Expression,
     parser::{
         expression::{visit_expression_list, visit_expression_struct, visit_expression_value},
+        literal::visit_value_literal,
         statement::visit_type_ref,
-        visit_label_list, visit_value_literal, visit_var, visit_var_list, IntoChildNodes, Node, Rule, RuleMatcher,
+        visit_label_list, visit_var, visit_var_list, IntoChildNodes, Node, Rule, RuleMatcher,
     },
     statement::{
         thing::{

--- a/rust/query/pipeline/stage/modifier.rs
+++ b/rust/query/pipeline/stage/modifier.rs
@@ -13,10 +13,9 @@ use crate::{
     },
     pretty::Pretty,
     util::write_joined,
-    value::Literal,
+    value::{IntegerLiteral, Literal},
     variable::Variable,
 };
-use crate::value::IntegerLiteral;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct OrderedVariable {

--- a/rust/query/pipeline/stage/modifier.rs
+++ b/rust/query/pipeline/stage/modifier.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     pretty::Pretty,
     util::write_joined,
-    value::{IntegerLiteral, Literal},
+    value::IntegerLiteral,
     variable::Variable,
 };
 

--- a/rust/query/pipeline/stage/modifier.rs
+++ b/rust/query/pipeline/stage/modifier.rs
@@ -16,6 +16,7 @@ use crate::{
     value::Literal,
     variable::Variable,
 };
+use crate::value::IntegerLiteral;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct OrderedVariable {
@@ -91,11 +92,11 @@ impl fmt::Display for Filter {
 #[derive(Debug, Eq, PartialEq)]
 pub struct Offset {
     span: Option<Span>,
-    offset: Literal,
+    offset: IntegerLiteral,
 }
 
 impl Offset {
-    pub fn new(span: Option<Span>, offset: Literal) -> Self {
+    pub fn new(span: Option<Span>, offset: IntegerLiteral) -> Self {
         Self { span, offset }
     }
 }
@@ -111,11 +112,11 @@ impl fmt::Display for Offset {
 #[derive(Debug, Eq, PartialEq)]
 pub struct Limit {
     span: Option<Span>,
-    limit: Literal,
+    limit: IntegerLiteral,
 }
 
 impl Limit {
-    pub fn new(span: Option<Span>, limit: Literal) -> Self {
+    pub fn new(span: Option<Span>, limit: IntegerLiteral) -> Self {
         Self { span, limit }
     }
 }

--- a/rust/statement/comparison.rs
+++ b/rust/statement/comparison.rs
@@ -15,8 +15,8 @@ use crate::{
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ComparisonStatement {
     span: Option<Span>,
-    lhs: Expression,
-    comparison: Comparison,
+    pub lhs: Expression,
+    pub comparison: Comparison,
 }
 
 impl ComparisonStatement {

--- a/rust/typeql.rs
+++ b/rust/typeql.rs
@@ -22,7 +22,7 @@ pub mod schema;
 pub mod statement;
 pub mod type_;
 mod util;
-mod value;
+pub mod value;
 mod variable;
 
 use schema::definable::Struct;
@@ -35,7 +35,6 @@ pub use crate::{
     schema::definable::{Definable, Function},
     statement::Statement,
     type_::{Label, ScopedLabel, Type, TypeAny},
-    value::Literal,
     variable::Variable,
 };
 

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -4,7 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::{self, Formatter, Write, write};
+use std::fmt::{self, Formatter, Write};
+
 use crate::{
     common::{error::TypeQLError, Span, Spanned},
     pretty::Pretty,
@@ -118,6 +119,7 @@ pub enum ValueLiteral {
     DateTimeTz(DateTimeTZLiteral),
     Duration(DurationLiteral),
     String(StringLiteral),
+    Struct(String), // TODO
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -157,6 +159,7 @@ impl fmt::Display for ValueLiteral {
             ValueLiteral::DateTimeTz(value) => fmt::Display::fmt(value, f),
             ValueLiteral::Duration(value) => fmt::Display::fmt(value, f),
             ValueLiteral::String(value) => fmt::Display::fmt(value, f),
+            ValueLiteral::Struct(value) => fmt::Display::fmt(value, f),
         }
     }
 }
@@ -193,12 +196,10 @@ impl fmt::Display for TimeFragment {
         let (hour, minute) = (self.hour.as_str(), self.minute.as_str());
         match &self.second {
             None => write!(f, "{hour}:{minute}"),
-            Some(second) => {
-                match &self.second_fraction {
-                    None => write!(f, "{hour}:{minute}:{second}"),
-                    Some(second_fraction) => write!(f, "{hour}:{minute}:{second}.{second_fraction}"),
-                }
-            }
+            Some(second) => match &self.second_fraction {
+                None => write!(f, "{hour}:{minute}:{second}"),
+                Some(second_fraction) => write!(f, "{hour}:{minute}:{second}.{second_fraction}"),
+            },
         }
     }
 }
@@ -248,39 +249,38 @@ impl fmt::Display for BooleanLiteral {
     }
 }
 
-
 impl fmt::Display for SignedIntegerLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        std::fmt::Display::fmt(&self.sign, f)?;
+        fmt::Display::fmt(&self.sign, f)?;
         f.write_str(self.integral.as_str())
     }
 }
 
 impl fmt::Display for SignedDecimalLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        std::fmt::Display::fmt(&self.sign, f)?;
+        fmt::Display::fmt(&self.sign, f)?;
         f.write_str(self.decimal.as_str())
     }
 }
 
 impl fmt::Display for DateLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        std::fmt::Display::fmt(&self.date, f)
+        fmt::Display::fmt(&self.date, f)
     }
 }
 
 impl fmt::Display for DateTimeLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        std::fmt::Display::fmt(&self.date, f)?;
-        std::fmt::Display::fmt(&self.time, f)
+        fmt::Display::fmt(&self.date, f)?;
+        fmt::Display::fmt(&self.time, f)
     }
 }
 
 impl fmt::Display for DateTimeTZLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        std::fmt::Display::fmt(&self.date, f)?;
-        std::fmt::Display::fmt(&self.time, f)?;
-        std::fmt::Display::fmt(&self.timezone, f)?;
+        fmt::Display::fmt(&self.date, f)?;
+        fmt::Display::fmt(&self.time, f)?;
+        fmt::Display::fmt(&self.timezone, f)?;
         Ok(())
     }
 }
@@ -294,7 +294,7 @@ impl fmt::Display for DurationLiteral {
                 f.write_str("W")?;
             }
             DurationLiteral::DateAndTime(date, time) => {
-                std::fmt::Display::fmt(date, f)?;
+                fmt::Display::fmt(date, f)?;
                 match time {
                     None => {}
                     Some(time) => write!(f, "T{time}")?,

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -315,7 +315,7 @@ impl fmt::Display for StructLiteral {
 }
 
 impl StringLiteral {
-    pub fn get_unescaped(escaped_string: &str) -> Result<String> {
+    pub fn unescape(escaped_string: &str) -> Result<String> {
         let bytes = escaped_string.as_bytes();
         // it's a bug if these fail; either in the parser or the builder
         assert_eq!(bytes[0], bytes[bytes.len() - 1]);

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -50,7 +50,7 @@ impl Tag {
 pub struct Literal {
     span: Option<Span>,
     pub tag: Option<Tag>,
-    inner: String, // TODO this can be smarter
+    pub inner: String, // TODO this can be smarter
 }
 
 impl Literal {

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -4,8 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt;
-use std::fmt::{Debug, Formatter};
+use std::{
+    fmt,
+    fmt::{Debug, Formatter},
+};
 
 use crate::{
     common::{error::TypeQLError, Span, Spanned},
@@ -13,61 +15,26 @@ use crate::{
     Result,
 };
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum Tag {
-    Boolean,
-    Long,
-    Double,
-    Decimal,
-    Date,
-    DateTime,
-    DateTimeTZ,
-    Duration,
-    String,
-    // larger groupings when ambiguous
-    Integral,   // Long OR Fractional
-    Fractional, // Double OR Decimal
-}
-
-impl Tag {
-    fn name(&self) -> &'static str {
-        match self {
-            Self::Boolean => "Boolean",
-            Self::Long => "Long",
-            Self::Double => "Double",
-            Self::Decimal => "Decimal",
-            Self::Date => "Date",
-            Self::DateTime => "DateTime",
-            Self::DateTimeTZ => "DateTimeTZ",
-            Self::Duration => "Duration",
-            Self::String => "String",
-            Self::Integral => "Integral",
-            Self::Fractional => "Fractional",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct BooleanLiteral {
-    pub(crate) value: String,
+    pub value: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct StringLiteral {
-    pub(crate) value: String,
+    pub value: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IntegerLiteral {
-    pub(crate) value: String,
+    pub value: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Sign {
     Plus,
-    Minus
+    Minus,
 }
-
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SignedIntegerLiteral {
@@ -75,13 +42,12 @@ pub struct SignedIntegerLiteral {
     pub integral: String,
 }
 
-
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SignedDecimalLiteral {
     pub sign: Sign,
     pub integral: String,
     pub fractional: Option<String>,
-    pub exponent: Option<(Sign,String)>
+    pub exponent: Option<(Sign, String)>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -120,13 +86,13 @@ pub struct DateLiteral {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TimeZone {
     IANA(String, String),
-    ISO(String)
+    ISO(String),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DurationLiteral {
     pub date: Option<DurationDate>,
-    pub time: Option<DurationTime>
+    pub time: Option<DurationTime>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -164,13 +130,12 @@ pub enum ValueLiteral {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Literal {
     span: Option<Span>,
-    pub tag: Option<Tag>,
     pub inner: ValueLiteral, // TODO this can be smarter
 }
 
 impl Literal {
-    pub(crate) fn new(span: Option<Span>, category: Option<Tag>, inner: ValueLiteral) -> Self {
-        Self { span, tag: category, inner }
+    pub(crate) fn new(span: Option<Span>, inner: ValueLiteral) -> Self {
+        Self { span, inner }
     }
 }
 
@@ -183,7 +148,7 @@ impl Spanned for Literal {
 impl Pretty for Literal {}
 
 impl fmt::Display for Literal {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -92,21 +92,21 @@ pub enum DurationLiteral {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct StructLiteral {
-    // TODO
+    pub inner: String, // TODO
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DurationDate {
-    years: Option<String>,
-    months: Option<String>,
-    days: Option<String>,
+    pub years: Option<String>,
+    pub months: Option<String>,
+    pub days: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DurationTime {
-    hours: Option<String>,
-    minutes: Option<String>,
-    seconds: Option<String>,
+    pub hours: Option<String>,
+    pub minutes: Option<String>,
+    pub seconds: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -119,7 +119,7 @@ pub enum ValueLiteral {
     DateTimeTz(DateTimeTZLiteral),
     Duration(DurationLiteral),
     String(StringLiteral),
-    Struct(String), // TODO
+    Struct(StructLiteral),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -302,6 +302,12 @@ impl fmt::Display for DurationLiteral {
             }
         }
         Ok(())
+    }
+}
+
+impl fmt::Display for StructLiteral {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.inner.as_str())
     }
 }
 

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -8,6 +8,8 @@ use std::{
     fmt,
     fmt::{Debug, Formatter},
 };
+use std::fmt::Write;
+use std::path::Display;
 
 use crate::{
     common::{error::TypeQLError, Span, Spanned},
@@ -45,9 +47,7 @@ pub struct SignedIntegerLiteral {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SignedDecimalLiteral {
     pub sign: Sign,
-    pub integral: String,
-    pub fractional: Option<String>,
-    pub exponent: Option<(Sign, String)>,
+    pub decimal: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -165,9 +165,20 @@ impl fmt::Display for StringLiteral {
     }
 }
 
+impl fmt::Display for Sign {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Sign::Plus => f.write_char('+'),
+            Sign::Minus => f.write_char('-'),
+        }
+    }
+}
+
 impl fmt::Display for SignedDecimalLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        todo!()
+        std::fmt::Display::fmt(&self.sign, f)?;
+        f.write_str(self.decimal.as_str())?;
+        Ok(())
     }
 }
 

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -315,7 +315,7 @@ impl fmt::Display for StructLiteral {
 }
 
 impl StringLiteral {
-    pub fn parse_to_string(escaped_string: &str) -> Result<String> {
+    pub fn get_unescaped(escaped_string: &str) -> Result<String> {
         let bytes = escaped_string.as_bytes();
         // it's a bug if these fail; either in the parser or the builder
         assert_eq!(bytes[0], bytes[bytes.len() - 1]);

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -35,13 +35,13 @@ pub enum Sign {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SignedIntegerLiteral {
-    pub sign: Sign,
+    pub sign: Option<Sign>,
     pub integral: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SignedDecimalLiteral {
-    pub sign: Sign,
+    pub sign: Option<Sign>,
     pub decimal: String,
 }
 
@@ -251,14 +251,18 @@ impl fmt::Display for BooleanLiteral {
 
 impl fmt::Display for SignedIntegerLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.sign, f)?;
+        if let Some(sign) = &self.sign {
+            fmt::Display::fmt(sign, f)?;
+        }
         f.write_str(self.integral.as_str())
     }
 }
 
 impl fmt::Display for SignedDecimalLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.sign, f)?;
+        if let Some(sign) = &self.sign {
+            fmt::Display::fmt(sign, f)?;
+        }
         f.write_str(self.decimal.as_str())
     }
 }
@@ -271,8 +275,7 @@ impl fmt::Display for DateLiteral {
 
 impl fmt::Display for DateTimeLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.date, f)?;
-        fmt::Display::fmt(&self.time, f)
+        write!(f, "{}T{}", &self.date, &self.time)
     }
 }
 

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -130,7 +130,7 @@ pub enum ValueLiteral {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Literal {
     span: Option<Span>,
-    pub inner: ValueLiteral, // TODO this can be smarter
+    pub inner: ValueLiteral,
 }
 
 impl Literal {

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::{self, Formatter, Write};
+use std::fmt::{self, Formatter};
 
 use crate::{
     common::{error::TypeQLError, Span, Spanned},

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -5,6 +5,7 @@
  */
 
 use std::fmt;
+use std::fmt::{Debug, Formatter};
 
 use crate::{
     common::{error::TypeQLError, Span, Spanned},
@@ -129,6 +130,11 @@ pub struct DurationLiteral {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+pub struct StructLiteral {
+    // TODO
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DurationDate {
     Years(String),
     Months(String),
@@ -148,9 +154,9 @@ pub enum ValueLiteral {
     Boolean(BooleanLiteral),
     Integer(SignedIntegerLiteral),
     Decimal(SignedDecimalLiteral),
-    Date(DateFragment),
-    DateTime(DateFragment, TimeFragment),
-    DateTimeTz(DateFragment, TimeFragment, TimeZone),
+    Date(DateLiteral),
+    DateTime(DateTimeLiteral),
+    DateTimeTz(DateTimeTZLiteral),
     Duration(DurationLiteral),
     String(StringLiteral),
 }
@@ -178,7 +184,25 @@ impl Pretty for Literal {}
 
 impl fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.inner)
+        self.inner.fmt(f)
+    }
+}
+
+impl fmt::Display for IntegerLiteral {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.value.as_str())
+    }
+}
+
+impl fmt::Display for StringLiteral {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.value.as_str())
+    }
+}
+
+impl fmt::Display for SignedDecimalLiteral {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        todo!()
     }
 }
 

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -47,23 +47,124 @@ impl Tag {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BooleanLiteral {
+    pub(crate) value: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct StringLiteral {
+    pub(crate) value: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct IntegerLiteral {
+    pub(crate) value: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Sign {
+    Plus,
+    Minus
+}
+
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SignedIntegerLiteral {
+    pub sign: Sign,
+    pub integral: String,
+}
+
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SignedDecimalLiteral {
+    pub sign: Sign,
+    pub integral: String,
+    pub fractional: Option<String>,
+    pub exponent: Option<(Sign,String)>
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DateFragment {
+    pub year: String,
+    pub month: String,
+    pub day: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct TimeFragment {
+    pub hour: String,
+    pub minute: String,
+    pub second: Option<String>,
+    pub second_fraction: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DateTimeTZLiteral {
+    pub date: DateFragment,
+    pub time: TimeFragment,
+    pub timezone: TimeZone,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DateTimeLiteral {
+    pub date: DateFragment,
+    pub time: TimeFragment,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DateLiteral {
+    pub date: DateFragment,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum TimeZone {
+    IANA(String, String),
+    ISO(String)
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DurationLiteral {
+    pub date: Option<DurationDate>,
+    pub time: Option<DurationTime>
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum DurationDate {
+    Years(String),
+    Months(String),
+    Weeks(String),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum DurationTime {
+    Days(String),
+    Hours(String),
+    Minutes(String),
+    Seconds(String),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ValueLiteral {
+    Boolean(BooleanLiteral),
+    Integer(SignedIntegerLiteral),
+    Decimal(SignedDecimalLiteral),
+    Date(DateFragment),
+    DateTime(DateFragment, TimeFragment),
+    DateTimeTz(DateFragment, TimeFragment, TimeZone),
+    Duration(DurationLiteral),
+    String(StringLiteral),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Literal {
     span: Option<Span>,
     pub tag: Option<Tag>,
-    pub inner: String, // TODO this can be smarter
+    pub inner: ValueLiteral, // TODO this can be smarter
 }
 
 impl Literal {
-    pub(crate) fn new(span: Option<Span>, category: Option<Tag>, inner: String) -> Self {
+    pub(crate) fn new(span: Option<Span>, category: Option<Tag>, inner: ValueLiteral) -> Self {
         Self { span, tag: category, inner }
-    }
-
-    pub fn parse_to_string(&self) -> Result<String> {
-        if self.tag.is_some_and(|cat| cat != Tag::String) {
-            Err(TypeQLError::InvalidLiteral { expected_variant: "String", variant: self.tag.unwrap().name() }.into())
-        } else {
-            parse_string(&self.inner)
-        }
     }
 }
 


### PR DESCRIPTION
## Usage and product changes
Make fields for expression public + Add finer literal parsing

## Implementation
We now recurse to the leaves of the grammar when parsing literals. The literals hold the parts instead of a single string. 