### PR TITLE
Allow type declarations without capabilities

### DIFF
--- a/rust/annotation.rs
+++ b/rust/annotation.rs
@@ -65,7 +65,7 @@ impl fmt::Display for Abstract {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Cardinality {
     span: Option<Span>,
-    range: CardinalityRange,
+    pub range: CardinalityRange,
 }
 
 impl Cardinality {
@@ -195,7 +195,7 @@ impl fmt::Display for Range {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Regex {
     span: Option<Span>,
-    regex: StringLiteral,
+    pub regex: StringLiteral,
 }
 
 impl Regex {
@@ -213,7 +213,7 @@ impl fmt::Display for Regex {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Subkey {
     span: Option<Span>,
-    ident: Identifier,
+    pub ident: Identifier,
 }
 
 impl Subkey {
@@ -248,7 +248,7 @@ impl fmt::Display for Unique {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Values {
     span: Option<Span>,
-    values: Vec<Literal>,
+    pub values: Vec<Literal>,
 }
 
 impl Values {

--- a/rust/annotation.rs
+++ b/rust/annotation.rs
@@ -167,8 +167,8 @@ impl fmt::Display for Key {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Range {
     span: Option<Span>,
-    min: Option<Literal>,
-    max: Option<Literal>,
+    pub min: Option<Literal>,
+    pub max: Option<Literal>,
 }
 
 impl Range {

--- a/rust/parser/define/type_.rs
+++ b/rust/parser/define/type_.rs
@@ -24,8 +24,9 @@ pub(super) fn visit_definition_type(node: Node<'_>) -> Type {
     let mut children = node.into_children();
     let kind = children.try_consume_expected(Rule::kind).map(visit_kind);
     let label = visit_label(children.consume_expected(Rule::label));
+    let annotations = children.try_consume_expected(Rule::annotations).map(visit_annotations).unwrap_or_default();
     let traits = children.map(visit_type_capability).collect();
-    Type::new(span, kind, label, traits)
+    Type::new(span, kind, label, annotations, traits)
 }
 
 pub(in crate::parser) fn visit_type_capability(node: Node<'_>) -> Capability {

--- a/rust/parser/redefine.rs
+++ b/rust/parser/redefine.rs
@@ -9,10 +9,10 @@ use super::{
 };
 use crate::{
     common::Spanned,
+    parser::annotation::visit_annotations,
     query::schema::Redefine,
     schema::definable::{Definable, Type},
 };
-use crate::parser::annotation::visit_annotations;
 
 pub(super) fn visit_query_redefine(node: Node<'_>) -> Redefine {
     debug_assert_eq!(node.as_rule(), Rule::query_redefine);
@@ -28,8 +28,10 @@ fn visit_redefinable(node: Node<'_>) -> Definable {
     let kind = children.try_consume_expected(Rule::kind).map(visit_kind);
     let label = visit_label(children.consume_expected(Rule::label));
     let annotations = children.try_consume_expected(Rule::annotations).map(visit_annotations).unwrap_or_default();
-    let capabilities = children.try_consume_expected(Rule::type_capability)
-        .map(|node| vec![visit_type_capability(node)]).unwrap_or_default();
+    let capabilities = children
+        .try_consume_expected(Rule::type_capability)
+        .map(|node| vec![visit_type_capability(node)])
+        .unwrap_or_default();
     debug_assert_eq!(children.try_consume_any(), None);
     Definable::TypeDeclaration(Type::new(span, kind, label, annotations, capabilities))
 }

--- a/rust/parser/redefine.rs
+++ b/rust/parser/redefine.rs
@@ -12,6 +12,7 @@ use crate::{
     query::schema::Redefine,
     schema::definable::{Definable, Type},
 };
+use crate::parser::annotation::visit_annotations;
 
 pub(super) fn visit_query_redefine(node: Node<'_>) -> Redefine {
     debug_assert_eq!(node.as_rule(), Rule::query_redefine);
@@ -26,7 +27,9 @@ fn visit_redefinable(node: Node<'_>) -> Definable {
     let mut children = node.into_children();
     let kind = children.try_consume_expected(Rule::kind).map(visit_kind);
     let label = visit_label(children.consume_expected(Rule::label));
-    let capability = visit_type_capability(children.consume_expected(Rule::type_capability));
+    let annotations = children.try_consume_expected(Rule::annotations).map(visit_annotations).unwrap_or_default();
+    let capabilities = children.try_consume_expected(Rule::type_capability)
+        .map(|node| vec![visit_type_capability(node)]).unwrap_or_default();
     debug_assert_eq!(children.try_consume_any(), None);
-    Definable::TypeDeclaration(Type::new(span, kind, label, vec![capability]))
+    Definable::TypeDeclaration(Type::new(span, kind, label, annotations, capabilities))
 }

--- a/rust/parser/test/aggregate.rs
+++ b/rust/parser/test/aggregate.rs
@@ -52,7 +52,7 @@ fn when_comparing_count_query_using_typeql_and_rust_typeql_they_are_equivalent()
     let query = r#"match
 $x isa movie,
     has title "Godfather";
-count();"#;
+count($x);"#;
     let parsed = parse_query(query).unwrap();
     //     let expected = typeql_match!(var("x").isa("movie").has(("title", "Godfather"))).count();
     assert_valid_eq_repr!(expected, parsed, query);

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -167,10 +167,10 @@ fn when_parsing_query_with_comments_they_are_ignored() {
     let query = r#"match
 # there's a comment here
 $x isa###WOW HERES ANOTHER###
-movie; count();"#;
+movie; count($x);"#;
     let uncommented = r#"match
 $x isa movie;
-count();"#;
+count($x);"#;
     let parsed = parse_query(query).unwrap();
     // let expected = typeql_match!(var("x").isa("movie")).count();
     assert_valid_eq_repr!(expected, parsed, uncommented);

--- a/rust/parser/test/schema_queries.rs
+++ b/rust/parser/test/schema_queries.rs
@@ -10,7 +10,7 @@ use crate::parse_query;
 #[test]
 fn test_define_query_with_owns_overrides() {
     let query = r#"define
-triangle sub entity;
+entity triangle;
 triangle owns side-length;
 triangle-right-angled sub triangle;
 triangle-right-angled owns hypotenuse-length as side-length;"#;
@@ -27,8 +27,8 @@ triangle-right-angled owns hypotenuse-length as side-length;"#;
 #[test]
 fn test_define_query_with_relates_overrides() {
     let query = r#"define
-pokemon sub entity;
-evolves sub relation;
+entity pokemon;
+relation evolves;
 evolves relates from,
     relates to;
 evolves-final sub evolves;
@@ -49,11 +49,11 @@ evolves-final relates from-final as from;"#;
 #[test]
 fn test_define_query_with_plays_overrides() {
     let query = r#"define
-pokemon sub entity;
-evolves sub relation;
-evolves relates from,
+entity pokemon;
+relation evolves;
+relation evolves relates from,
     relates to;
-evolves-final sub evolves;
+relation evolves-final sub evolves;
 evolves-final relates from-final as from;
 pokemon plays evolves-final:from-final as from;"#;
 
@@ -76,10 +76,8 @@ pokemon plays evolves-final:from-final as from;"#;
 #[test]
 fn test_define_query() {
     let query = r#"define
-pokemon sub entity;
-evolution sub relation;
-evolves-from sub role;
-evolves-to sub role;
+entity pokemon;
+relation evolution;
 evolves relates from,
     relates to;
 pokemon plays evolves:from,
@@ -128,8 +126,8 @@ owns name from pokemon;"#;
 #[test]
 fn test_define_abstract_entity_query() {
     let query = r#"define
-concrete-type sub entity;
-abstract-type sub entity @abstract;"#;
+entity concrete-type;
+entity abstract-type @abstract;"#;
     let parsed = parse_query(query).unwrap();
     // let expected = define!(type_("concrete-type").sub("entity"), type_("abstract-type").sub("entity"));
     assert_valid_eq_repr!(expected, parsed, query);
@@ -138,8 +136,7 @@ abstract-type sub entity @abstract;"#;
 #[test]
 fn test_define_value_type_query() {
     let query = r#"define
-my-type sub attribute,
-    value long;"#;
+attribute my-type value long;"#;
     let parsed = parse_query(query).unwrap();
     // let expected = define!(type_("my-type").sub("attribute").value(ValueType::Long));
     assert_valid_eq_repr!(expected, parsed, query);
@@ -148,8 +145,7 @@ my-type sub attribute,
 #[test]
 fn define_attribute_type_regex() {
     let query = r#"define
-digit sub attribute,
-    value string @regex("\d");"#;
+attribute digit value string @regex("\d");"#;
     let parsed = parse_query(query).unwrap();
     // let expected = define!(type_("digit").sub("attribute").regex(r"\d"));
     assert_valid_eq_repr!(expected, parsed, query);
@@ -158,10 +154,7 @@ digit sub attribute,
 #[test]
 fn when_parsing_as_in_define_result_is_same_as_sub() {
     let query = r#"define
-parent sub role;
-child sub role;
-parenthood sub relation,
-    relates parent,
+relation parenthood relates parent,
     relates child;
 fatherhood sub parenthood,
     relates father as parent,

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -198,7 +198,7 @@ definable = { ( definition_type ~ SEMICOLON ) | definition_function | definition
 
 // TYPE DEFINITION =============================================================
 
-definition_type = { kind? ~ label ~ (annotations | type_capability)? ~ ( COMMA ~ type_capability )* }
+definition_type = { kind? ~ label ~ ( ( annotations | type_capability ) ~ ( COMMA ~ type_capability )* )? }
 type_capability = { type_capability_base ~ annotations? }
 type_capability_base = { sub_declaration | value_type_declaration | alias_declaration
                        | owns_declaration | plays_declaration | relates_declaration

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -198,7 +198,7 @@ definable = { ( definition_type ~ SEMICOLON ) | definition_function | definition
 
 // TYPE DEFINITION =============================================================
 
-definition_type = { kind? ~ label ~ ( type_capability ~ ( COMMA ~ type_capability )* )? }
+definition_type = { kind? ~ label ~ annotations? ~ ( type_capability ~ ( COMMA ~ type_capability )* )? }
 type_capability = { type_capability_base ~ annotations? }
 type_capability_base = { sub_declaration | value_type_declaration | alias_declaration
                        | owns_declaration | plays_declaration | relates_declaration
@@ -246,7 +246,7 @@ struct_destructor_value = { var | struct_destructor }
 // REDEFINE QUERY ==============================================================
 
 query_redefine = { REDEFINE ~ ( redefinable ~ SEMICOLON )+ }
-redefinable = { kind? ~ label ~ type_capability }
+redefinable = { kind? ~ label ~ ( annotations | type_capability ) }
 
 // UNDEFINE QUERY ==============================================================
 

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -198,7 +198,7 @@ definable = { ( definition_type ~ SEMICOLON ) | definition_function | definition
 
 // TYPE DEFINITION =============================================================
 
-definition_type = { kind? ~ label ~ annotations? ~ ( type_capability ~ ( COMMA ~ type_capability )* )? }
+definition_type = { kind? ~ label ~ (annotations | type_capability)? ~ ( COMMA ~ type_capability )* }
 type_capability = { type_capability_base ~ annotations? }
 type_capability_base = { sub_declaration | value_type_declaration | alias_declaration
                        | owns_declaration | plays_declaration | relates_declaration

--- a/rust/query/pipeline/stage/insert.rs
+++ b/rust/query/pipeline/stage/insert.rs
@@ -15,7 +15,7 @@ use crate::{
 #[derive(Debug, Eq, PartialEq)]
 pub struct Insert {
     span: Option<Span>,
-    statements: Vec<Statement>,
+    pub statements: Vec<Statement>,
 }
 
 impl Insert {

--- a/rust/schema/definable/type_/mod.rs
+++ b/rust/schema/definable/type_/mod.rs
@@ -22,6 +22,7 @@ pub struct Type {
     span: Option<Span>,
     pub kind: Option<token::Kind>,
     pub label: Label,
+    pub annotations: Vec<Annotation>,
     pub capabilities: Vec<Capability>,
 }
 
@@ -30,13 +31,14 @@ impl Type {
         span: Option<Span>,
         kind: Option<token::Kind>,
         label: Label,
+        annotations: Vec<Annotation>,
         capabilities: Vec<Capability>,
     ) -> Self {
-        Self { span, kind, label, capabilities }
+        Self { span, kind, label, annotations, capabilities }
     }
 
     pub fn build(label: Label) -> Self {
-        Self::new(None, None, label, Vec::new())
+        Self::new(None, None, label, Vec::new(), Vec::new())
     }
 }
 

--- a/rust/schema/definable/type_/mod.rs
+++ b/rust/schema/definable/type_/mod.rs
@@ -56,7 +56,7 @@ impl Pretty for Type {
         write!(f, "{}", self.label)?;
         let rest = if !self.annotations.is_empty() {
             for annotation in &self.annotations {
-                write!(f, " {}", annotation)?; // Possibly empty
+                write!(f, " {}", annotation)?;
             }
             self.capabilities.as_slice()
         } else {

--- a/rust/schema/definable/type_/mod.rs
+++ b/rust/schema/definable/type_/mod.rs
@@ -54,13 +54,23 @@ impl Pretty for Type {
             write!(f, "{} ", kind)?;
         }
         write!(f, "{}", self.label)?;
-        if let Some((first, rest)) = self.capabilities.split_first() {
-            write!(f, " {}", first)?;
-            for cap in rest {
-                writeln!(f, ",")?;
-                indent(indent_level, f)?;
-                write!(f, "{}", cap)?;
+        let rest = if !self.annotations.is_empty() {
+            for annotation in &self.annotations {
+                write!(f, " {}", annotation)?; // Possibly empty
             }
+            self.capabilities.as_slice()
+        } else {
+            if let Some((first, rest)) = self.capabilities.split_first() {
+                write!(f, " {}", first)?;
+                rest
+            } else {
+                self.capabilities.as_slice()
+            }
+        };
+        for cap in rest {
+            writeln!(f, ",")?;
+            indent(indent_level, f)?;
+            write!(f, "{}", cap)?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Usage and product changes
Updates the grammar to allow standalone type-declarations.

## Implementation
This change arises from changing `mytype sub entity` to `entity mytype`. 
* Type annotations are now directly on the declaration  rather than on the `sub` capability.

Makes a few fields pub as well.