### PR TITLE
[3.0] Change plays override from label to named_type to allow both scoped and not scoped labels

### DIFF
--- a/rust/parser/define/type_.rs
+++ b/rust/parser/define/type_.rs
@@ -8,7 +8,7 @@ use crate::{
     common::{error::TypeQLError, Spanned},
     parser::{
         annotation::visit_annotations,
-        type_::{visit_label, visit_label_list, visit_label_scoped, visit_value_type},
+        type_::{visit_label, visit_label_list, visit_label_scoped, visit_named_type, visit_value_type},
         visit_kind, IntoChildNodes, Node, Rule, RuleMatcher,
     },
     schema::definable::type_::{
@@ -131,7 +131,7 @@ fn visit_plays_declaration(node: Node<'_>) -> Plays {
 
     let role = visit_label_scoped(children.consume_expected(Rule::label_scoped));
     let overridden = if children.try_consume_expected(Rule::AS).is_some() {
-        Some(visit_label(children.consume_expected(Rule::label)))
+        Some(visit_named_type(children.consume_expected(Rule::named_type)))
     } else {
         None
     };

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -210,7 +210,7 @@ value_type_declaration = { VALUE ~ value_type }
 owns_declaration = { OWNS ~ label_list
                    | OWNS ~ label ~ ( AS ~ label )?
                    }
-plays_declaration = { PLAYS ~ label_scoped ~ ( AS ~ label )? }
+plays_declaration = { PLAYS ~ label_scoped ~ ( AS ~ named_type )? }
 relates_declaration = { RELATES ~ label_list
                       | RELATES ~ label ~ ( AS ~ label )?
                       }

--- a/rust/schema/definable/type_/capability.rs
+++ b/rust/schema/definable/type_/capability.rs
@@ -159,11 +159,11 @@ impl fmt::Display for Relates {
 pub struct Plays {
     span: Option<Span>,
     pub role: ScopedLabel,
-    pub overridden: Option<Label>,
+    pub overridden: Option<NamedType>,
 }
 
 impl Plays {
-    pub fn new(span: Option<Span>, role: ScopedLabel, overridden: Option<Label>) -> Self {
+    pub fn new(span: Option<Span>, role: ScopedLabel, overridden: Option<NamedType>) -> Self {
         Self { span, role, overridden }
     }
 }


### PR DESCRIPTION
## Usage and product changes

Previously, we could only use not scoped labels (names without scopes) in `as` of `plays`. However, it can cause troubles while reading the schema by a human eye:
```
define
relation family relates father;
relation fathership relates father;

entity person plays family:father, plays fathership:father;

# It is fine: we can't have another "relates father" in family or fathership
relation subfamily sub family, relates subfather as father;
relation subfathership sub fathership, relates subfather as father;

# It creates more questions as subperson can play multiple `father`s
entity subperson sub person, plays subfamily:subfather as father, plays subfathership:subfather as father;
```

This PR allows us to use both
`entity subperson sub person, plays subfamily:subfather as family:father, plays subfathership:subfather as fathership:father;`
and 
`
entity subperson sub person, plays subfamily:subfather as father, plays subfathership:subfather as father;`
based on users' preferences.

## Implementation
We use `named_type` for simplicity. However, it includes not only scoped labels and labels, but also builtin types, so the grammar becomes less strict.

We decide to move forward with this solution as:
* it is simpler and faster while not totally wrong, and the additional filtering is done on the server side;
* we are probably going to remove `plays as` soon, and this PR is mostly needed for compatibility with the current state of the server. However, we can discuss if we are happy with `named_type` in case we'll have the same issue when implementing the new "hiding" syntax.