### PR TITLE
Introduce Reduce keyword for stream reduction operations

### DIFF
--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -62,8 +62,8 @@ string_enum! { Clause
     Match = "match",
     Group = "group",
     Fetch = "fetch",
-    Get = "get",
     With = "with",
+    Reduce = "reduce",
 }
 
 string_enum! { Modifier
@@ -147,7 +147,7 @@ string_enum! { Annotation
     Values = "values",
 }
 
-string_enum! { Aggregate
+string_enum! { ReduceOperator
     Check = "check",
     First = "first",
     Count = "count",

--- a/rust/parser/test/aggregate.rs
+++ b/rust/parser/test/aggregate.rs
@@ -11,7 +11,7 @@ use crate::parse_query;
 fn test_parsing_aggregate_std() {
     let query = r#"match
 $x isa movie;
-std($x);"#;
+reduce std($x);"#;
     let parsed = parse_query(query).unwrap();
     // let expected = typeql_match!(var("x").isa("movie")).std(cvar("x"));
     assert_valid_eq_repr!(expected, parsed, query);
@@ -41,7 +41,7 @@ fn test_aggregate_count_query() {
     let query = r#"match
 ($x, $y) isa friendship;
 select $x, $y;
-count($x);"#;
+reduce count($x);"#;
     let parsed = parse_query(query).unwrap();
     //     let expected = typeql_match!(rel("x").links("y").isa("friendship")).get_fixed([var("x"), cvar("y")]).count();
     assert_valid_eq_repr!(expected, parsed, query);
@@ -52,7 +52,7 @@ fn when_comparing_count_query_using_typeql_and_rust_typeql_they_are_equivalent()
     let query = r#"match
 $x isa movie,
     has title "Godfather";
-count($x);"#;
+reduce count($x);"#;
     let parsed = parse_query(query).unwrap();
     //     let expected = typeql_match!(var("x").isa("movie").has(("title", "Godfather"))).count();
     assert_valid_eq_repr!(expected, parsed, query);

--- a/rust/parser/test/fetch.rs
+++ b/rust/parser/test/fetch.rs
@@ -24,7 +24,7 @@ fetch {
         "entry single 3":
             match
             $x has name $n;
-            count($n);,
+            reduce count($n);,
         "entry object": {
             "all": { $x.* }
         },

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -167,10 +167,10 @@ fn when_parsing_query_with_comments_they_are_ignored() {
     let query = r#"match
 # there's a comment here
 $x isa###WOW HERES ANOTHER###
-movie; count($x);"#;
+movie; reduce count($x);"#;
     let uncommented = r#"match
 $x isa movie;
-count($x);"#;
+reduce count($x);"#;
     let parsed = parse_query(query).unwrap();
     // let expected = typeql_match!(var("x").isa("movie")).count();
     assert_valid_eq_repr!(expected, parsed, uncommented);

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -44,10 +44,10 @@ var_order = { var ~ ORDER? }
 
 // REDUCE ======================================================================
 
-operator_reduce = { reduce ~ SEMICOLON }
+operator_reduce = { REDUCE ~ reduce ~ SEMICOLON }
 reduce = { CHECK
          | reduce_first
-         | reduce_value ~ ( COMMA ~ reduce_value )*
+         | reduce_value ~ ( COMMA ~ reduce_value )* ~ COMMA?
          }
 
 reduce_first = { FIRST ~ PAREN_OPEN ~ vars ~ PAREN_CLOSE }
@@ -78,8 +78,8 @@ statement = { statement_type | statement_thing_var | statement_single | statemen
 
 // TYPE STATEMENTS =============================================================
 
-statement_type = { kind ~ type_ref_any ~ ( type_constraint ~ ( COMMA ~ type_constraint )* )?
-                 | type_ref_any ~ type_constraint ~ ( COMMA ~ type_constraint )* 
+statement_type = { kind ~ type_ref_any ~ ( type_constraint ~ ( COMMA ~ type_constraint )* ~ COMMA? )?
+                 | type_ref_any ~ type_constraint ~ ( COMMA ~ type_constraint )* ~ COMMA?
                  }
 type_constraint = { type_constraint_base ~ annotations? }
 type_constraint_base = { sub_constraint | value_type_constraint | label_constraint
@@ -100,9 +100,9 @@ plays_constraint = { PLAYS ~ type_ref ~ ( AS ~ type_ref )? }
 // THING STATEMENTS ============================================================
 
 statement_thing = { statement_thing_var | statement_relation_anonymous }
-statement_relation_anonymous = { relation ~ thing_constraint? ~ ( COMMA ~ thing_constraint )* }
+statement_relation_anonymous = { relation ~ thing_constraint? ~ ( COMMA ~ thing_constraint )* ~ COMMA? }
 
-statement_thing_var = { var ~ thing_constraint ~ ( COMMA ~ thing_constraint )*
+statement_thing_var = { var ~ COMMA? ~ thing_constraint ~ ( COMMA ~ thing_constraint )* ~ COMMA?
                       | var ~ ( value_literal | expression_struct ) ~ isa_constraint
                       | var ~ comparison ~ isa_constraint
                       }
@@ -117,7 +117,7 @@ has_constraint = { HAS ~ type_ref_list ~ ( comparison | expression_list | var )
                  }
 links_constraint = { LINKS ~ relation }
 
-relation = { PAREN_OPEN ~ role_player ~ ( COMMA ~ role_player )* ~ PAREN_CLOSE } // A list of role players in a Relations
+relation = { PAREN_OPEN ~ role_player ~ ( COMMA ~ role_player )* ~ COMMA? ~ PAREN_CLOSE } // A list of role players in a Relations
 role_player = { type_ref_list ~ COLON ~ var
               | type_ref ~ COLON ~ var
               | var
@@ -138,7 +138,7 @@ statement_assignment = { assignment_left ~ ASSIGN ~ expression }
 assignment_left = { vars_assignment | struct_destructor }
 statement_in = { vars_assignment ~ IN ~ ( expression_function | expression_list ) }
 
-vars_assignment = { var_assignment ~ ( COMMA ~ var_assignment )* }
+vars_assignment = { var_assignment ~ ( COMMA ~ var_assignment )* ~ COMMA? }
 var_assignment = { var_optional | var }
 
 comparison = { comparator ~ expression_value }
@@ -159,10 +159,10 @@ list_index = { SQ_BRACKET_OPEN ~ expression_value ~ SQ_BRACKET_CLOSE }
 
 expression_function = { expression_function_name ~ PAREN_OPEN ~ expression_arguments? ~ PAREN_CLOSE }
 expression_function_name = { builtin_func_name | identifier }
-expression_arguments = { expression ~ ( COMMA ~ expression )* }
+expression_arguments = { expression ~ ( COMMA ~ expression )* ~ COMMA? }
 
 expression_list = { expression_list_subrange | expression_list_new }
-expression_list_new = { SQ_BRACKET_OPEN ~ expression_value ~ ( COMMA ~ expression_value )* ~ SQ_BRACKET_CLOSE }
+expression_list_new = { SQ_BRACKET_OPEN ~ expression_value ~ ( COMMA ~ expression_value )* ~ COMMA? ~ SQ_BRACKET_CLOSE }
 expression_list_subrange = { var ~ list_range }
 list_range = { SQ_BRACKET_OPEN ~ expression_value ~ DOUBLE_DOT ~ expression_value ~ SQ_BRACKET_CLOSE }
 
@@ -177,7 +177,7 @@ fetch_some = { fetch_single | fetch_object | fetch_list }
 
 fetch_object = { CURLY_OPEN ~ fetch_body  ~ CURLY_CLOSE }
 fetch_body = { fetch_object_entries | fetch_attributes_all }
-fetch_object_entries = { fetch_object_entry ~ ( COMMA ~ fetch_object_entry )* }
+fetch_object_entries = { fetch_object_entry ~ ( COMMA ~ fetch_object_entry )* ~ COMMA? }
 fetch_object_entry = { fetch_key ~ COLON ~ fetch_some }
 fetch_key = { quoted_string_literal }
 
@@ -203,7 +203,7 @@ definable = { ( definition_type ~ SEMICOLON ) | definition_function | definition
 
 // TYPE DEFINITION =============================================================
 
-definition_type = { kind? ~ label ~ ( ( annotations | type_capability ) ~ ( COMMA ~ type_capability )* )? }
+definition_type = { kind? ~ label ~ COMMA? ~ ( ( annotations | type_capability ) ~ ( COMMA ~ type_capability )* ~ COMMA? )? }
 type_capability = { type_capability_base ~ annotations? }
 type_capability_base = { sub_declaration | value_type_declaration | alias_declaration
                        | owns_declaration | plays_declaration | relates_declaration
@@ -226,21 +226,20 @@ definition_function = { FUN ~ function_signature ~ COLON ~ clause_match ~ operat
 
 function_signature = { identifier ~ PAREN_OPEN ~ function_arguments ~ PAREN_CLOSE ~ ARROW ~ function_output }
 
-function_arguments = { ( function_argument ~ ( COMMA ~ function_argument )* )? }
+function_arguments = { ( function_argument ~ ( COMMA ~ function_argument )* ~ COMMA? )? }
 function_argument = { var ~ COLON ~ named_type_any }
 
 function_output = { function_output_stream | function_output_single }
-function_output_stream = { CURLY_OPEN ~ named_type_any ~ ( COMMA ~ named_type_any )* ~ CURLY_CLOSE }
-function_output_single = { named_type_any ~ ( COMMA ~ named_type_any )* }
+function_output_stream = { CURLY_OPEN ~ named_type_any ~ ( COMMA ~ named_type_any )* ~ COMMA? ~ CURLY_CLOSE }
+function_output_single = { named_type_any ~ ( COMMA ~ named_type_any )* ~ COMMA? }
 
-return_statement = { RETURN ~ ( return_statement_stream | return_statement_single ) ~ SEMICOLON }
+return_statement = { RETURN ~ ( return_statement_stream | reduce ) ~ SEMICOLON }
 return_statement_stream = { CURLY_OPEN ~ vars ~ CURLY_CLOSE }
-return_statement_single = { ( var | reduce ) ~ ( COMMA ~ ( var | reduce ) )* }
 
 // STRUCT DEFINITION ===========================================================
 
 definition_struct = { STRUCT ~ identifier ~ COLON ~ definition_struct_fields ~ SEMICOLON }
-definition_struct_fields = { definition_struct_field ~ ( COMMA ~ definition_struct_field )* }
+definition_struct_fields = { definition_struct_field ~ ( COMMA ~ definition_struct_field )* ~ COMMA? }
 definition_struct_field = { identifier ~ VALUE ~ struct_field_value_type }
 
 struct_field_value_type = { value_type_optional | value_type }
@@ -348,7 +347,7 @@ cardinality_exact = { integer_literal }
 annotation_regex = { ANNOTATION_REGEX ~ PAREN_OPEN ~ quoted_string_literal ~ PAREN_CLOSE }
 annotation_subkey = { ANNOTATION_SUBKEY ~ PAREN_OPEN ~ identifier ~ PAREN_CLOSE }
 annotation_range = { ANNOTATION_RANGE ~ PAREN_OPEN ~ range ~ PAREN_CLOSE }
-annotation_values = { ANNOTATION_VALUES ~ PAREN_OPEN ~ value_literal ~ ( COMMA ~ value_literal )* ~ PAREN_CLOSE }
+annotation_values = { ANNOTATION_VALUES ~ PAREN_OPEN ~ value_literal ~ ( COMMA ~ value_literal )* ~ COMMA? ~ PAREN_CLOSE }
 
 range = { range_full | range_from | range_to }
 range_from = { range_bound ~ DOUBLE_DOT }
@@ -390,6 +389,7 @@ PUT = @{ "put" ~ WB }
 UPDATE = @{ "update" ~ WB }
 DELETE = @{ "delete" ~ WB }
 
+REDUCE = @{ "reduce" ~ WB }
 CHECK = @{ "check" ~ WB }
 FIRST = @{ "first" ~ WB }
 

--- a/rust/query/pipeline/stage/fetch.rs
+++ b/rust/query/pipeline/stage/fetch.rs
@@ -7,12 +7,12 @@
 use std::{fmt, fmt::Formatter};
 
 use crate::{
-    common::{Span, token},
+    common::{token, Span},
     expression::{Expression, FunctionCall},
     pretty::{indent, Pretty},
     query::Pipeline,
-    TypeRefAny,
-    value::StringLiteral, Variable,
+    value::StringLiteral,
+    TypeRefAny, Variable,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -56,11 +56,11 @@ impl Pretty for FetchEntry {
             FetchEntry::Object(entry) => {
                 write!(f, " ")?;
                 Pretty::fmt(entry, indent_level, f)
-            },
+            }
             FetchEntry::List(entry) => {
                 write!(f, " ")?;
                 Pretty::fmt(entry, indent_level, f)
-            },
+            }
             FetchEntry::Single(entry) => Pretty::fmt(entry, indent_level, f),
         }
     }
@@ -215,11 +215,11 @@ impl Pretty for FetchSingle {
             FetchSingle::Attribute(single) => {
                 write!(f, " ")?;
                 Pretty::fmt(single, indent_level, f)
-            },
+            }
             FetchSingle::Expression(single) => {
                 write!(f, " ")?;
                 Pretty::fmt(single, indent_level, f)
-            },
+            }
             FetchSingle::Subquery(single) => {
                 writeln!(f, "")?;
                 Pretty::fmt(single, indent_level + 1, f)

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -8,11 +8,10 @@ use std::fmt::{self, Write};
 
 use crate::{
     common::{token, Span},
-    pretty::Pretty,
+    pretty::{indent, Pretty},
     util::write_joined,
     variable::Variable,
 };
-use crate::pretty::indent;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Reduce {
@@ -23,12 +22,13 @@ pub enum Reduce {
 
 impl Pretty for Reduce {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        indent(indent_level, f)?;
+        write!(f, "{} ", token::Clause::Reduce)?;
         match self {
             Self::Check(inner) => Pretty::fmt(inner, indent_level, f),
             Self::First(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Value(inner) => {
                 if !inner.is_empty() {
-                    indent(indent_level, f)?;
                     let first = &inner[0];
                     Pretty::fmt(first, indent_level, f)?;
                     for element in &inner[1..] {
@@ -71,7 +71,7 @@ impl Pretty for Check {}
 
 impl fmt::Display for Check {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{};", token::Aggregate::Check)
+        write!(f, "{};", token::ReduceOperator::Check)
     }
 }
 
@@ -91,7 +91,7 @@ impl Pretty for First {}
 
 impl fmt::Display for First {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}(", token::Aggregate::First)?;
+        write!(f, "{}(", token::ReduceOperator::First)?;
         write_joined!(f, ", ", self.variables)?;
         f.write_str(");")?;
         Ok(())
@@ -138,7 +138,7 @@ impl Pretty for Count {}
 
 impl fmt::Display for Count {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}(", token::Aggregate::Count)?;
+        write!(f, "{}(", token::ReduceOperator::Count)?;
         write_joined!(f, ", ", self.variables)?;
         f.write_str(")")?;
         Ok(())
@@ -148,13 +148,13 @@ impl fmt::Display for Count {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Stat {
     span: Option<Span>,
-    pub aggregate: token::Aggregate,
+    pub reduce_operator: token::ReduceOperator,
     pub variable: Variable,
 }
 
 impl Stat {
-    pub fn new(span: Option<Span>, aggregate: token::Aggregate, variable: Variable) -> Self {
-        Self { span, aggregate, variable }
+    pub fn new(span: Option<Span>, aggregate: token::ReduceOperator, variable: Variable) -> Self {
+        Self { span, reduce_operator: aggregate, variable }
     }
 }
 
@@ -162,6 +162,6 @@ impl Pretty for Stat {}
 
 impl fmt::Display for Stat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}({})", self.aggregate, self.variable)
+        write!(f, "{}({})", self.reduce_operator, self.variable)
     }
 }

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -217,19 +217,7 @@ pub enum SingleOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ReturnSingle {
-    span: Option<Span>,
-    pub outputs: Vec<SingleOutput>,
-}
-
-impl ReturnSingle {
-    pub fn new(span: Option<Span>, outputs: Vec<SingleOutput>) -> Self {
-        Self { span, outputs }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReturnStatement {
     Stream(ReturnStream),
-    Single(ReturnSingle),
+    Reduce(Reduce),
 }


### PR DESCRIPTION
## Usage and product changes

We introduce the missing `reduce` keyword for operations like `min/max/count` aggregations, as well as `first()` and `check`. However, we do not require the `reduce` keyword for function return statements:

```
match
  ...
reduce count($x);
```
in a function would be;
```
define 
fun test(...) -> long:
  match ...
  return count($x);
```

We also allow trailing commas throughout the grammar, though they are ignored, to allow the user to generate queries more simply:
```
match
  $x, isa person, has name $n, ... ; #equivalent to the user-friendly syntax: $x isa person, has name, ...;
```

## Implementation
