### PR TITLE
Rename override to specialise. Remove specialisations for owns and plays

### DIFF
--- a/rust/parser/define/type_.rs
+++ b/rust/parser/define/type_.rs
@@ -97,7 +97,7 @@ fn visit_owns_declaration(node: Node<'_>) -> Owns {
     Owns::new(span, owned)
 }
 
-fn visit_relates_declaration(node: Node<'_>) -> Relates {
+pub(in crate::parser) fn visit_relates_declaration(node: Node<'_>) -> Relates {
     debug_assert_eq!(node.as_rule(), Rule::relates_declaration);
     let span = node.span();
     let mut children = node.into_children();

--- a/rust/parser/statement/type_.rs
+++ b/rust/parser/statement/type_.rs
@@ -111,14 +111,8 @@ fn visit_owns_constraint(node: Node<'_>) -> Owns {
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     };
 
-    let overridden = if children.try_consume_expected(Rule::AS).is_some() {
-        Some(visit_type_ref(children.consume_expected(Rule::type_ref)))
-    } else {
-        None
-    };
-
     debug_assert_eq!(children.try_consume_any(), None);
-    Owns::new(span, owned, overridden)
+    Owns::new(span, owned)
 }
 
 fn visit_relates_constraint(node: Node<'_>) -> Relates {
@@ -134,14 +128,14 @@ fn visit_relates_constraint(node: Node<'_>) -> Relates {
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     };
 
-    let overridden = if children.try_consume_expected(Rule::AS).is_some() {
+    let specialised = if children.try_consume_expected(Rule::AS).is_some() {
         Some(visit_type_ref(children.consume_expected(Rule::type_ref)))
     } else {
         None
     };
 
     debug_assert_eq!(children.try_consume_any(), None);
-    Relates::new(span, related, overridden)
+    Relates::new(span, related, specialised)
 }
 
 fn visit_plays_constraint(node: Node<'_>) -> Plays {
@@ -151,12 +145,7 @@ fn visit_plays_constraint(node: Node<'_>) -> Plays {
     children.skip_expected(Rule::PLAYS);
 
     let role = visit_type_ref(children.consume_expected(Rule::type_ref));
-    let overridden = if children.try_consume_expected(Rule::AS).is_some() {
-        Some(visit_type_ref(children.consume_expected(Rule::type_ref)))
-    } else {
-        None
-    };
 
     debug_assert_eq!(children.try_consume_any(), None);
-    Plays::new(span, role, overridden)
+    Plays::new(span, role)
 }

--- a/rust/parser/test/schema_queries.rs
+++ b/rust/parser/test/schema_queries.rs
@@ -8,24 +8,7 @@ use super::assert_valid_eq_repr;
 use crate::parse_query;
 
 #[test]
-fn test_define_query_with_owns_overrides() {
-    let query = r#"define
-entity triangle;
-triangle owns side-length;
-triangle-right-angled sub triangle;
-triangle-right-angled owns hypotenuse-length as side-length;"#;
-    let parsed = parse_query(query).unwrap();
-    // let expected = define!(
-    // type_("triangle").sub("entity"),
-    // type_("triangle").owns("side-length"),
-    // type_("triangle-right-angled").sub("triangle"),
-    // type_("triangle-right-angled").owns("hypotenuse-length".as_("side-length"))
-    // );
-    assert_valid_eq_repr!(expected, parsed, query);
-}
-
-#[test]
-fn test_define_query_with_relates_overrides() {
+fn test_define_query_with_relates_specialises() {
     let query = r#"define
 entity pokemon;
 relation evolves;
@@ -47,7 +30,17 @@ evolves-final relates from-final as from;"#;
 }
 
 #[test]
-fn test_define_query_with_plays_overrides() {
+fn test_define_query_with_owns_specialises_is_not_allowed() {
+    let query = r#"define
+entity triangle;
+triangle owns side-length;
+triangle-right-angled sub triangle;
+triangle-right-angled owns hypotenuse-length as side-length;"#;
+    assert!(parse_query(query).is_err());
+}
+
+#[test]
+fn test_define_query_with_plays_specialises_is_not_allowed() {
     let query = r#"define
 entity pokemon;
 relation evolves;
@@ -57,20 +50,7 @@ relation evolves-final sub evolves;
 evolves-final relates from-final as from;
 pokemon plays evolves-final:from-final as from;"#;
 
-    let parsed = parse_query(query).unwrap();
-    // let expected = define!(
-    // type_("pokemon").sub("entity"),
-    // type_("evolves").sub("relation"),
-    // type_("evolves").relates("from").relates("to"),
-    // type_("evolves-final").sub("evolves"),
-    // type_("evolves-final").relates("from-final".as_("from").distinct()),
-    // type_("pokemon")
-    // .plays("evolves-final:from-final".ordered())
-    // .distinct()
-    // .card(0, None)
-    // );
-
-    assert_valid_eq_repr!(expected, parsed, query);
+    assert!(parse_query(query).is_err());
 }
 
 #[test]

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -90,12 +90,12 @@ sub_constraint = { SUB_ ~ type_ref_any }
 value_type_constraint = { VALUE ~ value_type }
 label_constraint = { LABEL ~ ( label_scoped | label ) }
 owns_constraint = { OWNS ~ type_ref_list
-                  | OWNS ~ type_ref ~ ( AS ~ type_ref )?
+                  | OWNS ~ type_ref
                   }
 relates_constraint = { RELATES ~ type_ref_list
                      | RELATES ~ type_ref ~ ( AS ~ type_ref )?
                      }
-plays_constraint = { PLAYS ~ type_ref ~ ( AS ~ type_ref )? }
+plays_constraint = { PLAYS ~ type_ref }
 
 // THING STATEMENTS ============================================================
 
@@ -213,9 +213,9 @@ sub_declaration = { SUB ~ label }
 alias_declaration = { ALIAS ~ label }
 value_type_declaration = { VALUE ~ value_type }
 owns_declaration = { OWNS ~ label_list
-                   | OWNS ~ label ~ ( AS ~ label )?
+                   | OWNS ~ label
                    }
-plays_declaration = { PLAYS ~ label_scoped ~ ( AS ~ named_type )? }
+plays_declaration = { PLAYS ~ label_scoped }
 relates_declaration = { RELATES ~ label_list
                       | RELATES ~ label ~ ( AS ~ label )?
                       }
@@ -263,12 +263,12 @@ undefinable = { undefine_from | undefine_function | undefine_struct | label }
 undefine_from = { undefine_annotation_from_capability
                 | undefine_annotation_from_type
                 | undefine_capability
-                | undefine_override
+                | undefine_specialise
                 }
 undefine_annotation_from_capability = { annotation_category ~ FROM ~ label ~ type_capability_base }
 undefine_annotation_from_type = { annotation_category ~ FROM ~ label }
 undefine_capability = { type_capability_base ~ FROM ~ label }
-undefine_override = { AS ~ label ~ FROM ~ label ~ type_capability_base }
+undefine_specialise = { AS ~ label ~ FROM ~ label ~ type_capability_base }
 
 undefine_function = { FUN ~ identifier }
 undefine_struct = { STRUCT ~ identifier }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -268,7 +268,7 @@ undefine_from = { undefine_annotation_from_capability
 undefine_annotation_from_capability = { annotation_category ~ FROM ~ label ~ type_capability_base }
 undefine_annotation_from_type = { annotation_category ~ FROM ~ label }
 undefine_capability = { type_capability_base ~ FROM ~ label }
-undefine_specialise = { AS ~ label ~ FROM ~ label ~ type_capability_base }
+undefine_specialise = { AS ~ label ~ FROM ~ label ~ relates_declaration }
 
 undefine_function = { FUN ~ identifier }
 undefine_struct = { STRUCT ~ identifier }

--- a/rust/parser/undefine/mod.rs
+++ b/rust/parser/undefine/mod.rs
@@ -7,7 +7,11 @@
 use super::{IntoChildNodes, Node, Rule, RuleMatcher};
 use crate::{
     common::{error::TypeQLError, token, Spanned},
-    parser::{define::type_::visit_type_capability_base, type_::visit_label, visit_identifier},
+    parser::{
+        define::type_::{visit_relates_declaration, visit_type_capability_base},
+        type_::visit_label,
+        visit_identifier,
+    },
     query::schema::Undefine,
     schema::undefinable::{
         AnnotationCapability, AnnotationType, CapabilityType, Function, Specialise, Struct, Undefinable,
@@ -116,9 +120,9 @@ fn visit_undefine_specialise(node: Node<'_>) -> Specialise {
     let specialised = visit_label(children.consume_expected(Rule::label));
     children.skip_expected(Rule::FROM);
     let type_ = visit_label(children.consume_expected(Rule::label));
-    let capability = visit_type_capability_base(children.consume_expected(Rule::type_capability_base));
+    let relates = visit_relates_declaration(children.consume_expected(Rule::relates_declaration));
     debug_assert_eq!(children.try_consume_any(), None);
-    Specialise::new(span, specialised, type_, capability)
+    Specialise::new(span, specialised, type_, relates)
 }
 
 fn visit_undefine_struct(node: Node<'_>) -> Struct {

--- a/rust/parser/undefine/mod.rs
+++ b/rust/parser/undefine/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     parser::{define::type_::visit_type_capability_base, type_::visit_label, visit_identifier},
     query::schema::Undefine,
     schema::undefinable::{
-        AnnotationCapability, AnnotationType, CapabilityType, Function, Override, Struct, Undefinable,
+        AnnotationCapability, AnnotationType, CapabilityType, Function, Specialise, Struct, Undefinable,
     },
 };
 
@@ -50,7 +50,7 @@ fn visit_undefine_from(node: Node<'_>) -> Undefinable {
         }
         Rule::undefine_annotation_from_type => Undefinable::AnnotationType(visit_undefine_annotation_from_type(child)),
         Rule::undefine_capability => Undefinable::CapabilityType(visit_undefine_capability(child)),
-        Rule::undefine_override => Undefinable::Override(visit_undefine_override(child)),
+        Rule::undefine_specialise => Undefinable::Specialise(visit_undefine_specialise(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     }
 }
@@ -108,17 +108,17 @@ fn visit_undefine_capability(node: Node<'_>) -> CapabilityType {
     CapabilityType::new(span, capability, type_)
 }
 
-fn visit_undefine_override(node: Node<'_>) -> Override {
-    debug_assert_eq!(node.as_rule(), Rule::undefine_override);
+fn visit_undefine_specialise(node: Node<'_>) -> Specialise {
+    debug_assert_eq!(node.as_rule(), Rule::undefine_specialise);
     let span = node.span();
     let mut children = node.into_children();
     children.skip_expected(Rule::AS);
-    let overridden = visit_label(children.consume_expected(Rule::label));
+    let specialised = visit_label(children.consume_expected(Rule::label));
     children.skip_expected(Rule::FROM);
     let type_ = visit_label(children.consume_expected(Rule::label));
     let capability = visit_type_capability_base(children.consume_expected(Rule::type_capability_base));
     debug_assert_eq!(children.try_consume_any(), None);
-    Override::new(span, overridden, type_, capability)
+    Specialise::new(span, specialised, type_, capability)
 }
 
 fn visit_undefine_struct(node: Node<'_>) -> Struct {

--- a/rust/schema/definable/type_/capability.rs
+++ b/rust/schema/definable/type_/capability.rs
@@ -99,12 +99,11 @@ impl fmt::Display for ValueType {
 pub struct Owns {
     span: Option<Span>,
     pub owned: TypeRefAny,
-    pub overridden: Option<Label>,
 }
 
 impl Owns {
-    pub fn new(span: Option<Span>, owned: TypeRefAny, overridden: Option<Label>) -> Self {
-        Self { span, owned, overridden }
+    pub fn new(span: Option<Span>, owned: TypeRefAny) -> Self {
+        Self { span, owned }
     }
 }
 
@@ -119,9 +118,6 @@ impl Pretty for Owns {}
 impl fmt::Display for Owns {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", token::Keyword::Owns, self.owned)?;
-        if let Some(overridden) = &self.overridden {
-            write!(f, " {} {}", token::Keyword::As, overridden)?;
-        }
         Ok(())
     }
 }
@@ -130,12 +126,12 @@ impl fmt::Display for Owns {
 pub struct Relates {
     span: Option<Span>,
     pub related: TypeRefAny,
-    pub overridden: Option<Label>,
+    pub specialised: Option<Label>,
 }
 
 impl Relates {
-    pub fn new(span: Option<Span>, related: TypeRefAny, overridden: Option<Label>) -> Self {
-        Self { span, related, overridden }
+    pub fn new(span: Option<Span>, related: TypeRefAny, specialised: Option<Label>) -> Self {
+        Self { span, related, specialised }
     }
 }
 
@@ -148,8 +144,8 @@ impl Spanned for Relates {
 impl fmt::Display for Relates {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", token::Keyword::Relates, self.related)?;
-        if let Some(overridden) = &self.overridden {
-            write!(f, " {} {}", token::Keyword::As, overridden)?;
+        if let Some(specialised) = &self.specialised {
+            write!(f, " {} {}", token::Keyword::As, specialised)?;
         }
         Ok(())
     }
@@ -159,12 +155,11 @@ impl fmt::Display for Relates {
 pub struct Plays {
     span: Option<Span>,
     pub role: ScopedLabel,
-    pub overridden: Option<NamedType>,
 }
 
 impl Plays {
-    pub fn new(span: Option<Span>, role: ScopedLabel, overridden: Option<NamedType>) -> Self {
-        Self { span, role, overridden }
+    pub fn new(span: Option<Span>, role: ScopedLabel) -> Self {
+        Self { span, role }
     }
 }
 
@@ -177,9 +172,6 @@ impl Spanned for Plays {
 impl fmt::Display for Plays {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", token::Keyword::Plays, self.role)?;
-        if let Some(overridden) = &self.overridden {
-            write!(f, " {} {}", token::Keyword::As, overridden)?;
-        }
         Ok(())
     }
 }

--- a/rust/schema/undefinable/mod.rs
+++ b/rust/schema/undefinable/mod.rs
@@ -10,6 +10,7 @@ use super::definable::type_::CapabilityBase;
 use crate::{
     common::{identifier::Identifier, token, Span},
     pretty::Pretty,
+    schema::definable::type_::capability::Relates,
     type_::Label,
 };
 
@@ -115,12 +116,12 @@ pub struct Specialise {
     span: Option<Span>,
     pub specialised: Label,
     pub type_: Label,
-    pub capability: CapabilityBase,
+    pub capability: Relates,
 }
 
 impl Specialise {
-    pub fn new(span: Option<Span>, specialised: Label, type_: Label, capability: CapabilityBase) -> Self {
-        Self { span, specialised, type_, capability }
+    pub fn new(span: Option<Span>, specialised: Label, type_: Label, relates: Relates) -> Self {
+        Self { span, specialised, type_, capability: relates }
     }
 }
 

--- a/rust/schema/undefinable/mod.rs
+++ b/rust/schema/undefinable/mod.rs
@@ -19,7 +19,7 @@ pub enum Undefinable {
     AnnotationType(AnnotationType),             // undefine @independent from name;
     AnnotationCapability(AnnotationCapability), // undefine @card from person owns name;
     CapabilityType(CapabilityType),             // undefine owns name from person;
-    Override(Override),                         // undefine as name from person owns first-name;
+    Specialise(Specialise),                     // undefine as parent from fathership relates father;
 
     Function(Function), // undefine fun reachable;
     Struct(Struct),     // undefine struct coords;
@@ -34,7 +34,7 @@ impl fmt::Display for Undefinable {
             Self::AnnotationType(inner) => fmt::Display::fmt(inner, f),
             Self::AnnotationCapability(inner) => fmt::Display::fmt(inner, f),
             Self::CapabilityType(inner) => fmt::Display::fmt(inner, f),
-            Self::Override(inner) => fmt::Display::fmt(inner, f),
+            Self::Specialise(inner) => fmt::Display::fmt(inner, f),
             Self::Function(inner) => fmt::Display::fmt(inner, f),
             Self::Struct(inner) => fmt::Display::fmt(inner, f),
         }
@@ -111,28 +111,28 @@ impl fmt::Display for CapabilityType {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct Override {
+pub struct Specialise {
     span: Option<Span>,
-    pub overridden: Label,
+    pub specialised: Label,
     pub type_: Label,
     pub capability: CapabilityBase,
 }
 
-impl Override {
-    pub fn new(span: Option<Span>, overridden: Label, type_: Label, capability: CapabilityBase) -> Self {
-        Self { span, overridden, type_, capability }
+impl Specialise {
+    pub fn new(span: Option<Span>, specialised: Label, type_: Label, capability: CapabilityBase) -> Self {
+        Self { span, specialised, type_, capability }
     }
 }
 
-impl Pretty for Override {}
+impl Pretty for Specialise {}
 
-impl fmt::Display for Override {
+impl fmt::Display for Specialise {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} {} {} {} {}",
             token::Keyword::As,
-            self.overridden,
+            self.specialised,
             token::Keyword::From,
             self.type_,
             self.capability

--- a/rust/statement/type_.rs
+++ b/rust/statement/type_.rs
@@ -197,12 +197,11 @@ impl fmt::Display for ValueType {
 pub struct Owns {
     span: Option<Span>,
     pub owned: TypeRefAny,
-    pub overridden: Option<TypeRef>,
 }
 
 impl Owns {
-    pub fn new(span: Option<Span>, owned: TypeRefAny, overridden: Option<TypeRef>) -> Self {
-        Self { span, owned, overridden }
+    pub fn new(span: Option<Span>, owned: TypeRefAny) -> Self {
+        Self { span, owned }
     }
 }
 
@@ -211,9 +210,6 @@ impl Pretty for Owns {}
 impl fmt::Display for Owns {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", token::Keyword::Owns, self.owned)?;
-        if let Some(overridden) = &self.overridden {
-            write!(f, " {} {}", token::Keyword::As, overridden)?;
-        }
         Ok(())
     }
 }
@@ -222,12 +218,12 @@ impl fmt::Display for Owns {
 pub struct Relates {
     span: Option<Span>,
     pub related: TypeRefAny,
-    pub overridden: Option<TypeRef>,
+    pub specialised: Option<TypeRef>,
 }
 
 impl Relates {
-    pub fn new(span: Option<Span>, related: TypeRefAny, overridden: Option<TypeRef>) -> Self {
-        Self { span, related, overridden }
+    pub fn new(span: Option<Span>, related: TypeRefAny, specialised: Option<TypeRef>) -> Self {
+        Self { span, related, specialised }
     }
 }
 
@@ -236,8 +232,8 @@ impl Pretty for Relates {}
 impl fmt::Display for Relates {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", token::Keyword::Relates, self.related)?;
-        if let Some(overridden) = &self.overridden {
-            write!(f, " {} {}", token::Keyword::As, overridden)?;
+        if let Some(specialised) = &self.specialised {
+            write!(f, " {} {}", token::Keyword::As, specialised)?;
         }
         Ok(())
     }
@@ -247,12 +243,11 @@ impl fmt::Display for Relates {
 pub struct Plays {
     span: Option<Span>,
     pub role: TypeRef,
-    pub overridden: Option<TypeRef>,
 }
 
 impl Plays {
-    pub fn new(span: Option<Span>, role: TypeRef, overridden: Option<TypeRef>) -> Self {
-        Self { span, role, overridden }
+    pub fn new(span: Option<Span>, role: TypeRef) -> Self {
+        Self { span, role }
     }
 }
 
@@ -261,9 +256,6 @@ impl Pretty for Plays {}
 impl fmt::Display for Plays {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", token::Keyword::Plays, self.role)?;
-        if let Some(overridden) = &self.overridden {
-            write!(f, " {} {}", token::Keyword::As, overridden)?;
-        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Usage and product changes
Rename override to specialise. Remove specialisations for owns and plays respecting the server's changes: https://github.com/typedb/typedb/pull/7157