### PR TITLE
Implement duration literal parsing

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,12 +53,12 @@ rust_analyzer_dependencies()
 load("@rules_rust//rust:defs.bzl", "rust_common")
 rust_register_toolchains(
     edition = "2021",
-    versions = ["1.76.0"],
+    versions = ["1.81.0"],
 )
 
 rust_analyzer_toolchain_tools_repository(
     name = "rust_analyzer_toolchain_tools",
-    version = "1.76.0",
+    version = "1.81.0",
 )
 
 load("@vaticle_dependencies//library/crates:crates.bzl", "fetch_crates")

--- a/rust/parser/literal.rs
+++ b/rust/parser/literal.rs
@@ -212,4 +212,3 @@ fn visit_duration_seconds(node: Node<'_>) -> NumericLiteral {
     debug_assert_eq!(node.as_rule(), Rule::duration_seconds);
     visit_numeric_literal(node.into_child())
 }
-

--- a/rust/parser/literal.rs
+++ b/rust/parser/literal.rs
@@ -8,8 +8,9 @@ use crate::{
     common::{error::TypeQLError, Spanned},
     parser::{IntoChildNodes, Node, Rule, RuleMatcher},
     value::{
-        BooleanLiteral, DateFragment, DateLiteral, DateTimeLiteral, DateTimeTZLiteral, IntegerLiteral, Literal, Sign,
-        SignedDecimalLiteral, SignedIntegerLiteral, StringLiteral, TimeFragment, TimeZone, ValueLiteral,
+        BooleanLiteral, DateFragment, DateLiteral, DateTimeLiteral, DateTimeTZLiteral, DurationDate, DurationLiteral,
+        DurationTime, IntegerLiteral, Literal, NumericLiteral, Sign, SignedDecimalLiteral, SignedIntegerLiteral,
+        StringLiteral, TimeFragment, TimeZone, ValueLiteral,
     },
 };
 
@@ -26,6 +27,7 @@ pub(super) fn visit_value_literal(node: Node<'_>) -> Literal {
         Rule::datetime_tz_literal => ValueLiteral::DateTimeTz(visit_datetime_tz_literal(child)),
         Rule::datetime_literal => ValueLiteral::DateTime(visit_datetime_literal(child)),
         Rule::date_literal => ValueLiteral::Date(visit_date_literal(child)),
+        Rule::duration_literal => ValueLiteral::Duration(visit_duration_literal(child)),
 
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     };
@@ -45,6 +47,11 @@ fn visit_sign(node: Node<'_>) -> Sign {
 pub(super) fn visit_integer_literal(node: Node<'_>) -> IntegerLiteral {
     debug_assert_eq!(node.as_rule(), Rule::integer_literal);
     IntegerLiteral { value: node.as_str().to_owned() }
+}
+
+pub(super) fn visit_numeric_literal(node: Node<'_>) -> NumericLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::numeric_literal);
+    NumericLiteral { value: node.as_str().to_owned() }
 }
 
 pub(super) fn visit_quoted_string_literal(node: Node<'_>) -> StringLiteral {
@@ -133,3 +140,76 @@ fn visit_time(node: Node<'_>) -> TimeFragment {
     debug_assert_eq!(children.try_consume_any(), None);
     TimeFragment { hour, minute, second, second_fraction }
 }
+
+fn visit_duration_literal(node: Node<'_>) -> DurationLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::duration_literal);
+    let mut children = node.into_children();
+    let child = children.consume_any();
+    let duration = match child.as_rule() {
+        Rule::duration_weeks => DurationLiteral::Weeks(visit_duration_weeks(child)),
+        Rule::duration_date => {
+            let date = visit_duration_date(child);
+            let time = children.try_consume_expected(Rule::duration_time).map(visit_duration_time);
+            DurationLiteral::DateAndTime(date, time)
+        }
+        _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
+    };
+    debug_assert_eq!(children.try_consume_any(), None);
+    duration
+}
+
+fn visit_duration_weeks(node: Node<'_>) -> IntegerLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::duration_weeks);
+    visit_integer_literal(node.into_child())
+}
+
+fn visit_duration_date(node: Node<'_>) -> DurationDate {
+    debug_assert_eq!(node.as_rule(), Rule::duration_date);
+    let mut children = node.into_children();
+    let years = children.try_consume_expected(Rule::duration_years).map(visit_duration_years);
+    let months = children.try_consume_expected(Rule::duration_months).map(visit_duration_months);
+    let days = children.try_consume_expected(Rule::duration_days).map(visit_duration_days);
+    debug_assert_eq!(children.try_consume_any(), None);
+    DurationDate { years, months, days }
+}
+
+fn visit_duration_years(node: Node<'_>) -> IntegerLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::duration_years);
+    visit_integer_literal(node.into_child())
+}
+
+fn visit_duration_months(node: Node<'_>) -> IntegerLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::duration_months);
+    visit_integer_literal(node.into_child())
+}
+
+fn visit_duration_days(node: Node<'_>) -> IntegerLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::duration_days);
+    visit_integer_literal(node.into_child())
+}
+
+fn visit_duration_time(node: Node<'_>) -> DurationTime {
+    debug_assert_eq!(node.as_rule(), Rule::duration_time);
+    let mut children = node.into_children();
+    let hours = children.try_consume_expected(Rule::duration_hours).map(visit_duration_hours);
+    let minutes = children.try_consume_expected(Rule::duration_minutes).map(visit_duration_minutes);
+    let seconds = children.try_consume_expected(Rule::duration_seconds).map(visit_duration_seconds);
+    debug_assert_eq!(children.try_consume_any(), None);
+    DurationTime { hours, minutes, seconds }
+}
+
+fn visit_duration_hours(node: Node<'_>) -> IntegerLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::duration_hours);
+    visit_integer_literal(node.into_child())
+}
+
+fn visit_duration_minutes(node: Node<'_>) -> IntegerLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::duration_minutes);
+    visit_integer_literal(node.into_child())
+}
+
+fn visit_duration_seconds(node: Node<'_>) -> NumericLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::duration_seconds);
+    visit_numeric_literal(node.into_child())
+}
+

--- a/rust/parser/statement/thing.rs
+++ b/rust/parser/statement/thing.rs
@@ -22,7 +22,7 @@ use crate::{
         },
         Statement,
     },
-    type_::{TypeRef, TypeRefAny},
+    type_::TypeRefAny,
 };
 
 pub(in crate::parser) fn visit_statement_thing(node: Node<'_>) -> Statement {

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -318,7 +318,7 @@ value_type_primitive = { BOOLEAN | LONG | DOUBLE | DECIMAL
                        | STRING
                        }
 value_literal = { quoted_string_literal | datetime_tz_literal | datetime_literal | date_literal
-                | boolean_literal | signed_decimal | signed_integer
+                | duration_literal | boolean_literal | signed_decimal | signed_integer
                 }
 
 signed_decimal = { sign? ~ decimal_literal }

--- a/rust/query/pipeline/stage/fetch.rs
+++ b/rust/query/pipeline/stage/fetch.rs
@@ -113,13 +113,13 @@ impl Pretty for FetchObjectBody {
         match self {
             FetchObjectBody::Entries(entries) => {
                 if !entries.is_empty() {
-                    writeln!(f, "")?; // entries always go on new line
+                    writeln!(f)?; // entries always go on new line
                     Pretty::fmt(&entries[0], indent_level + 1, f)?;
                     for field in &entries[1..] {
                         writeln!(f, ",")?;
                         Pretty::fmt(field, indent_level + 1, f)?;
                     }
-                    writeln!(f, "")?;
+                    writeln!(f)?;
                 }
                 indent(indent_level, f)?;
                 write!(f, "{}", token::Char::CurlyRight)
@@ -221,7 +221,7 @@ impl Pretty for FetchSingle {
                 Pretty::fmt(single, indent_level, f)
             }
             FetchSingle::Subquery(single) => {
-                writeln!(f, "")?;
+                writeln!(f)?;
                 Pretty::fmt(single, indent_level + 1, f)
             }
         }
@@ -262,7 +262,7 @@ impl Pretty for FetchStream {
             FetchStream::Subquery(stream) => {
                 writeln!(f, "{}", token::Char::SquareLeft)?;
                 Pretty::fmt(stream, indent_level + 1, f)?;
-                writeln!(f, "")?;
+                writeln!(f)?;
                 indent(indent_level, f)?;
                 write!(f, "{}", token::Char::SquareRight)
             }

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -45,7 +45,7 @@ pub enum Reduction {
 }
 
 impl Pretty for Reduction {
-    fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, _indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::{self, Write};
+use std::fmt;
 
 use crate::{
     common::{token, Span},

--- a/rust/schema/definable/struct_.rs
+++ b/rust/schema/definable/struct_.rs
@@ -29,13 +29,13 @@ impl Struct {
 impl Pretty for Struct {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         indent(indent_level, f)?;
-        write!(f, "{} {}{}\n", token::Keyword::Struct, self.ident, token::Char::Colon)?;
+        writeln!(f, "{} {}{}", token::Keyword::Struct, self.ident, token::Char::Colon)?;
         if !self.fields.is_empty() {
             Pretty::fmt(&self.fields[0], indent_level + 1, f)?;
             for field in &self.fields[1..] {
                 Pretty::fmt(field, indent_level + 1, f)?;
             }
-            writeln!(f, "")?;
+            writeln!(f)?;
         }
         writeln!(f, "{}", token::Char::Semicolon)
     }

--- a/rust/statement/mod.rs
+++ b/rust/statement/mod.rs
@@ -4,11 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::HashMap,
-    fmt,
-    fmt::{Display, Formatter},
-};
+use std::{collections::HashMap, fmt};
 
 use self::{
     comparison::ComparisonStatement,
@@ -78,7 +74,7 @@ pub enum DeconstructField {
 }
 
 impl Pretty for DeconstructField {
-    fn fmt(&self, indent_level: usize, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DeconstructField::Variable(var) => Pretty::fmt(var, indent_level, f),
             DeconstructField::Deconstruct(struct_deconstruct) => Pretty::fmt(struct_deconstruct, indent_level, f),
@@ -87,7 +83,7 @@ impl Pretty for DeconstructField {
 }
 
 impl fmt::Display for DeconstructField {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DeconstructField::Variable(var) => fmt::Display::fmt(var, f),
             DeconstructField::Deconstruct(struct_deconstruct) => fmt::Display::fmt(struct_deconstruct, f),
@@ -108,14 +104,14 @@ impl StructDeconstruct {
 }
 
 impl Pretty for StructDeconstruct {
-    fn fmt(&self, indent_level: usize, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         indent(indent_level, f)?;
         fmt::Display::fmt(self, f)
     }
 }
 
 impl fmt::Display for StructDeconstruct {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", token::Char::CurlyLeft)?;
         for (identifier, field_deconstruct) in &self.field_map {
             write!(f, "{}{} {},", identifier, token::Char::Colon, field_deconstruct)?;

--- a/rust/statement/thing/mod.rs
+++ b/rust/statement/thing/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     common::{token, Span},
     expression::Expression,
     pretty::{indent, Pretty},
-    type_::{TypeRef, TypeRefAny},
+    type_::TypeRefAny,
     util::write_joined,
     value::Literal,
     variable::Variable,

--- a/rust/typeql.rs
+++ b/rust/typeql.rs
@@ -9,7 +9,6 @@
 #![deny(rust_2024_compatibility)]
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unused_must_use)]
-
 #![allow(edition_2024_expr_fragment_specifier)]
 
 pub use crate::{

--- a/rust/typeql.rs
+++ b/rust/typeql.rs
@@ -10,6 +10,8 @@
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unused_must_use)]
 
+#![allow(edition_2024_expr_fragment_specifier)]
+
 pub use crate::{
     annotation::Annotation,
     common::{error::Error, identifier::Identifier, token, Result},

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -27,6 +27,11 @@ pub struct IntegerLiteral {
     pub value: String,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct NumericLiteral {
+    pub value: String,
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Sign {
     Plus,
@@ -86,7 +91,7 @@ pub enum TimeZone {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DurationLiteral {
-    Weeks(String),
+    Weeks(IntegerLiteral),
     DateAndTime(DurationDate, Option<DurationTime>),
 }
 
@@ -97,16 +102,16 @@ pub struct StructLiteral {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DurationDate {
-    pub years: Option<String>,
-    pub months: Option<String>,
-    pub days: Option<String>,
+    pub years: Option<IntegerLiteral>,
+    pub months: Option<IntegerLiteral>,
+    pub days: Option<IntegerLiteral>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DurationTime {
-    pub hours: Option<String>,
-    pub minutes: Option<String>,
-    pub seconds: Option<String>,
+    pub hours: Option<IntegerLiteral>,
+    pub minutes: Option<IntegerLiteral>,
+    pub seconds: Option<NumericLiteral>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -165,6 +170,12 @@ impl fmt::Display for ValueLiteral {
 }
 
 impl fmt::Display for IntegerLiteral {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.value.as_str())
+    }
+}
+
+impl fmt::Display for NumericLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(self.value.as_str())
     }
@@ -292,10 +303,7 @@ impl fmt::Display for DurationLiteral {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("P")?;
         match self {
-            DurationLiteral::Weeks(weeks) => {
-                f.write_str(weeks)?;
-                f.write_str("W")?;
-            }
+            DurationLiteral::Weeks(weeks) => write!(f, "{weeks}W")?,
             DurationLiteral::DateAndTime(date, time) => {
                 fmt::Display::fmt(date, f)?;
                 match time {


### PR DESCRIPTION
# Release notes: product changes

We now accept the ISO 8601 duration literal format (`P3Y6M4DT12H30M5.346S`) in TypeQL queries.