### PR TITLE
Update syntax for reduce stages in pipelines

### DIFF
--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -60,7 +60,7 @@ string_enum! { Clause
     Update = "update",
     Delete = "delete",
     Match = "match",
-    Group = "group",
+    Within = "within",
     Fetch = "fetch",
     With = "with",
     Reduce = "reduce",

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -377,10 +377,7 @@ fn visit_reduce_value(node: Node<'_>) -> ReduceValue {
     let mut children = node.into_children();
     let keyword = children.consume_any();
     match keyword.as_rule() {
-        Rule::COUNT => ReduceValue::Count(Count::new(
-            span,
-            children.try_consume_expected(Rule::vars).map(visit_vars).unwrap_or_default(),
-        )),
+        Rule::COUNT => ReduceValue::Count(Count::new(span, children.try_consume_expected(Rule::var).map(visit_var))),
         Rule::MAX => {
             ReduceValue::Stat(Stat::new(span, ReduceOperator::Max, visit_var(children.consume_expected(Rule::var))))
         }

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -47,6 +47,7 @@ use crate::{
     value::StringLiteral,
     TypeRef, TypeRefAny,
 };
+use crate::query::stage::reduce::ReduceAssign;
 
 pub(super) fn visit_query_pipeline(node: Node<'_>) -> Pipeline {
     debug_assert_eq!(node.as_rule(), Rule::query_pipeline);
@@ -83,6 +84,7 @@ fn visit_query_stage(node: Node<'_>) -> Stage {
         Rule::clause_update => Stage::Update(visit_clause_update(child)),
         Rule::clause_delete => Stage::Delete(visit_clause_delete(child)),
         Rule::operator_stream => Stage::Modifier(visit_operator_stream(child)),
+        Rule::operator_reduce => Stage::Reduce(visit_operator_reduce(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     }
 }
@@ -92,7 +94,6 @@ fn visit_query_stage_terminal(node: Node<'_>) -> Stage {
     let child = node.into_child();
     match child.as_rule() {
         Rule::clause_fetch => Stage::Fetch(visit_clause_fetch(child)),
-        Rule::operator_reduce => Stage::Reduce(visit_operator_reduce(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     }
 }
@@ -323,8 +324,33 @@ fn visit_fetch_stream(node: Node<'_>) -> FetchStream {
 fn visit_operator_reduce(node: Node<'_>) -> Reduce {
     debug_assert_eq!(node.as_rule(), Rule::operator_reduce);
     let mut children = node.into_children();
+    let mut reducers = Vec::new();
+    let mut group = None;
     children.skip_expected(Rule::REDUCE);
-    Reduce::new(visit_reduce(children.consume_any()))
+    while let Some(child) = children.try_consume_any() {
+        match child.as_rule() {
+            Rule::reduce_assign => {
+                reducers.push(visit_reduce_assign(child))
+            },
+            Rule::WITHIN => {
+                debug_assert!(reducers.len() > 0);
+                group = Some(visit_vars(children.consume_expected(Rule::vars)));
+                break;
+            }
+            _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
+        }
+    }
+    debug_assert_eq!(children.try_consume_any(), None);
+    Reduce::new(reducers, group)
+}
+
+pub(super) fn visit_reduce_assign(node: Node<'_>) -> ReduceAssign {
+    debug_assert_eq!(node.as_rule(), Rule::reduce_assign);
+    let mut children = node.into_children();
+    let assign_to = visit_var(children.consume_expected(Rule::var));
+    children.consume_expected(Rule::ASSIGN);
+    let reduce_value = visit_reduce_value(children.consume_expected(Rule::reduce_value));
+    ReduceAssign { assign_to, reduce_value }
 }
 
 pub(super) fn visit_reduce(node: Node<'_>) -> Reduction {

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -39,7 +39,7 @@ use crate::{
             fetch::{
                 FetchAttribute, FetchList, FetchObject, FetchObjectBody, FetchObjectEntry, FetchSingle, FetchStream,
             },
-            reduce::Reduction,
+            reduce::{ReduceAssign, Reduction},
         },
         Pipeline,
     },
@@ -47,7 +47,6 @@ use crate::{
     value::StringLiteral,
     TypeRef, TypeRefAny,
 };
-use crate::query::stage::reduce::ReduceAssign;
 
 pub(super) fn visit_query_pipeline(node: Node<'_>) -> Pipeline {
     debug_assert_eq!(node.as_rule(), Rule::query_pipeline);
@@ -329,9 +328,7 @@ fn visit_operator_reduce(node: Node<'_>) -> Reduce {
     children.skip_expected(Rule::REDUCE);
     while let Some(child) = children.try_consume_any() {
         match child.as_rule() {
-            Rule::reduce_assign => {
-                reducers.push(visit_reduce_assign(child))
-            },
+            Rule::reduce_assign => reducers.push(visit_reduce_assign(child)),
             Rule::WITHIN => {
                 debug_assert!(reducers.len() > 0);
                 group = Some(visit_vars(children.consume_expected(Rule::vars)));

--- a/rust/parser/test/aggregate.rs
+++ b/rust/parser/test/aggregate.rs
@@ -11,7 +11,7 @@ use crate::parse_query;
 fn test_parsing_aggregate_std() {
     let query = r#"match
 $x isa movie;
-reduce std($x);"#;
+reduce $std = std($x);"#;
     let parsed = parse_query(query).unwrap();
     // let expected = typeql_match!(var("x").isa("movie")).std(cvar("x"));
     assert_valid_eq_repr!(expected, parsed, query);
@@ -41,7 +41,7 @@ fn test_aggregate_count_query() {
     let query = r#"match
 ($x, $y) isa friendship;
 select $x, $y;
-reduce count($x);"#;
+reduce $count = count($x);"#;
     let parsed = parse_query(query).unwrap();
     //     let expected = typeql_match!(rel("x").links("y").isa("friendship")).get_fixed([var("x"), cvar("y")]).count();
     assert_valid_eq_repr!(expected, parsed, query);
@@ -52,7 +52,7 @@ fn when_comparing_count_query_using_typeql_and_rust_typeql_they_are_equivalent()
     let query = r#"match
 $x isa movie,
     has title "Godfather";
-reduce count($x);"#;
+reduce $count = count($x);"#;
     let parsed = parse_query(query).unwrap();
     //     let expected = typeql_match!(var("x").isa("movie").has(("title", "Godfather"))).count();
     assert_valid_eq_repr!(expected, parsed, query);

--- a/rust/parser/test/fetch.rs
+++ b/rust/parser/test/fetch.rs
@@ -24,7 +24,7 @@ fetch {
         "entry single 3":
             match
             $x has name $n;
-            reduce count($n);,
+            reduce $c = count($n);,
         "entry object": {
             "all": { $x.* }
         },

--- a/rust/parser/test/group_aggregate.rs
+++ b/rust/parser/test/group_aggregate.rs
@@ -4,17 +4,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-// #[test]
-// fn test_aggregate_group_count_query() {
-//     let query = r#"match
-// ($x, $y) isa friendship;
-// get $x, $y;
-// group $x; count;"#;
-//     let parsed = parse_query(query).unwrap().into_get_group_aggregate();
-//     let expected =
-//         typeql_match!(rel("x").links("y").isa("friendship")).get_fixed([var("x"), cvar("y")]).group(cvar("x")).count();
-//     assert_valid_eq_repr!(expected, parsed, query);
-// }
+use crate::parse_query;
+use crate::parser::test::assert_valid_eq_repr;
+
+#[test]
+fn test_aggregate_group_count_query() {
+    let query = r#"match
+($x, $y) isa friendship;
+select $x, $y;
+reduce $c = count($y) within ($x);"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}
 
 // #[test]
 // fn test_single_line_group_aggregate_max_query() {

--- a/rust/parser/test/group_aggregate.rs
+++ b/rust/parser/test/group_aggregate.rs
@@ -12,7 +12,16 @@ fn test_reduce_within_query() {
 ($x, $y) isa friendship,
     has age $a;
 select $x, $y;
-reduce $max = max($a), $min = min($a) within ($x, $y);"#;
+reduce $max = max($a), $min = min($a) within $x, $y;"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}
+
+#[test]
+fn test_count_without_parentheses() {
+    let query = r#"match
+$x isa friendship;
+reduce $count = count;"#;
     let parsed = parse_query(query).unwrap();
     assert_valid_eq_repr!(expected, parsed, query);
 }

--- a/rust/parser/test/group_aggregate.rs
+++ b/rust/parser/test/group_aggregate.rs
@@ -4,8 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::parse_query;
-use crate::parser::test::assert_valid_eq_repr;
+use crate::{parse_query, parser::test::assert_valid_eq_repr};
 
 #[test]
 fn test_reduce_within_query() {

--- a/rust/parser/test/group_aggregate.rs
+++ b/rust/parser/test/group_aggregate.rs
@@ -8,11 +8,12 @@ use crate::parse_query;
 use crate::parser::test::assert_valid_eq_repr;
 
 #[test]
-fn test_aggregate_group_count_query() {
+fn test_reduce_within_query() {
     let query = r#"match
-($x, $y) isa friendship;
+($x, $y) isa friendship,
+    has age $a;
 select $x, $y;
-reduce $c = count($y) within ($x);"#;
+reduce $max = max($a), $min = min($a) within ($x, $y);"#;
     let parsed = parse_query(query).unwrap();
     assert_valid_eq_repr!(expected, parsed, query);
 }

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -167,10 +167,10 @@ fn when_parsing_query_with_comments_they_are_ignored() {
     let query = r#"match
 # there's a comment here
 $x isa###WOW HERES ANOTHER###
-movie; reduce count($x);"#;
+movie; reduce $c1 = count($x);"#;
     let uncommented = r#"match
 $x isa movie;
-reduce count($x);"#;
+reduce $c1 = count($x);"#;
     let parsed = parse_query(query).unwrap();
     // let expected = typeql_match!(var("x").isa("movie")).count();
     assert_valid_eq_repr!(expected, parsed, uncommented);

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -19,9 +19,9 @@ query_pipeline = { preamble* ~ query_stage+ ~ query_stage_terminal? }
 
 preamble = { WITH ~ definition_function }
 
-query_stage = { clause_match | clause_insert | clause_put | clause_update | clause_delete | operator_stream }
+query_stage = { clause_match | clause_insert | clause_put | clause_update | clause_delete | operator_stream | operator_reduce }
 
-query_stage_terminal = { clause_fetch | operator_reduce }
+query_stage_terminal = { clause_fetch }
 
 clause_match = { MATCH ~ patterns }
 
@@ -30,6 +30,8 @@ clause_put = { PUT ~ ( statement_thing ~ SEMICOLON )+ }
 clause_update = { UPDATE ~ ( statement_thing ~ SEMICOLON )+ }
 
 clause_delete = { DELETE ~ ( statement_deletable ~ SEMICOLON )+ }
+
+operator_reduce = { REDUCE ~ reduce_assign+ ~ (WITHIN ~  PAREN_OPEN ~ vars ~ PAREN_CLOSE )? ~ SEMICOLON }
 
 // QUERY MODIFIERS =============================================================
 
@@ -41,10 +43,9 @@ operator_offset = { OFFSET ~ integer_literal ~ SEMICOLON }
 operator_limit = { LIMIT ~ integer_literal ~ SEMICOLON }
 
 var_order = { var ~ ORDER? }
+reduce_assign = { (var ~ ASSIGN ~ reduce_value) }
 
 // REDUCE ======================================================================
-
-operator_reduce = { REDUCE ~ reduce ~ SEMICOLON }
 reduce = { CHECK
          | reduce_first
          | reduce_value ~ ( COMMA ~ reduce_value )* ~ COMMA?
@@ -393,6 +394,7 @@ DELETE = @{ "delete" ~ WB }
 REDUCE = @{ "reduce" ~ WB }
 CHECK = @{ "check" ~ WB }
 FIRST = @{ "first" ~ WB }
+WITHIN = @{ "within" ~ WB }
 
 // THING KIND KEYWORDS
 

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -31,7 +31,7 @@ clause_update = { UPDATE ~ ( statement_thing ~ SEMICOLON )+ }
 
 clause_delete = { DELETE ~ ( statement_deletable ~ SEMICOLON )+ }
 
-operator_reduce = { REDUCE ~ reduce_assign ~ ( COMMA ~ reduce_assign )* ~ (WITHIN ~  PAREN_OPEN ~ vars ~ PAREN_CLOSE )? ~ SEMICOLON }
+operator_reduce = { REDUCE ~ reduce_assign ~ ( COMMA ~ reduce_assign )* ~ (WITHIN ~ vars )? ~ SEMICOLON }
 
 // QUERY MODIFIERS =============================================================
 
@@ -53,7 +53,7 @@ reduce = { CHECK
 
 reduce_first = { FIRST ~ PAREN_OPEN ~ vars ~ PAREN_CLOSE }
 
-reduce_value = { COUNT ~ ( PAREN_OPEN ~ vars ~ PAREN_CLOSE )?
+reduce_value = { COUNT ~ ( PAREN_OPEN ~ var ~ PAREN_CLOSE )?
                | MAX ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
                | MIN ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
                | MEAN ~ PAREN_OPEN ~ var ~ PAREN_CLOSE

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -31,7 +31,7 @@ clause_update = { UPDATE ~ ( statement_thing ~ SEMICOLON )+ }
 
 clause_delete = { DELETE ~ ( statement_deletable ~ SEMICOLON )+ }
 
-operator_reduce = { REDUCE ~ reduce_assign+ ~ (WITHIN ~  PAREN_OPEN ~ vars ~ PAREN_CLOSE )? ~ SEMICOLON }
+operator_reduce = { REDUCE ~ reduce_assign ~ ( COMMA ~ reduce_assign )* ~ (WITHIN ~  PAREN_OPEN ~ vars ~ PAREN_CLOSE )? ~ SEMICOLON }
 
 // QUERY MODIFIERS =============================================================
 

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -31,9 +31,8 @@ impl Pretty for Reduce {
         write!(f, "{} ", token::Clause::Reduce)?;
         write_joined!(f, ", ", self.reductions)?;
         if let Some(group) = &self.within_group {
-            write!(f, " {} (", token::Clause::Within)?;
+            write!(f, " {} ", token::Clause::Within)?;
             write_joined!(f, ", ", group)?;
-            write!(f, ")")?;
         }
         write!(f, ";")?;
         Ok(())
@@ -168,12 +167,12 @@ impl fmt::Display for ReduceValue {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Count {
     span: Option<Span>,
-    pub variables: Vec<Variable>,
+    pub variable: Option<Variable>,
 }
 
 impl Count {
-    pub fn new(span: Option<Span>, variables: Vec<Variable>) -> Self {
-        Self { span, variables }
+    pub fn new(span: Option<Span>, variable: Option<Variable>) -> Self {
+        Self { span, variable }
     }
 }
 
@@ -181,9 +180,10 @@ impl Pretty for Count {}
 
 impl fmt::Display for Count {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}(", token::ReduceOperator::Count)?;
-        write_joined!(f, ", ", self.variables)?;
-        f.write_str(")")?;
+        write!(f, "{}", token::ReduceOperator::Count)?;
+        if let Some(variable) = &self.variable {
+            write!(f, "({})", variable)?;
+        }
         Ok(())
     }
 }

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -15,25 +15,61 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Reduce {
-    reduction: Reduction,
+    pub reductions: Vec<ReduceAssign>,
+    pub within_group: Option<Vec<Variable>>,
 }
 
 impl Reduce {
-    pub fn new(reduction: Reduction) -> Self {
-        Reduce { reduction }
+    pub fn new(reductions: Vec<ReduceAssign>, within_group: Option<Vec<Variable>>) -> Self {
+        Reduce { reductions, within_group }
     }
 }
 
 impl Pretty for Reduce {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         indent(indent_level, f)?;
-        write!(f, "{} {};", token::Clause::Reduce, self.reduction)
+        write!(f, "{} ", token::Clause::Reduce)?;
+        write_joined!(f, ", ", self.reductions)?;
+        if let Some(group) = &self.within_group {
+            write!(f, " {} (", token::Clause::Within)?;
+            write_joined!(f, ", ", group)?;
+            write!(f, ")")?;
+        }
+        write!(f, ";")?;
+        Ok(())
     }
 }
 
 impl fmt::Display for Reduce {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {};", token::Clause::Reduce, self.reduction)
+        write!(f, "{} ", token::Clause::Reduce)?;
+        write_joined!(f, ", ", self.reductions)?;
+        if let Some(group) = &self.within_group {
+            write!(f, " {} (", token::Clause::Within)?;
+            write_joined!(f, ", ", group)?;
+            write!(f, ")")?;
+        }
+        write!(f, ";")?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ReduceAssign {
+    pub assign_to: Variable,
+    pub reduce_value: ReduceValue,
+}
+
+impl Pretty for ReduceAssign {
+    fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        indent(indent_level, f)?;
+        write!(f, "{} = {}", self.assign_to, self.reduce_value)
+    }
+}
+
+impl fmt::Display for ReduceAssign {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} = {}", self.assign_to, self.reduce_value)
     }
 }
 


### PR DESCRIPTION
## Usage and product changes
Update syntax for reduce stages in pipelines. Example: `reduce $max = max($of1), $sum = sum($of2) within ($group, $variables)`

## Implementation
Update syntax for reduce stages in pipelines
