### PR TITLE
Implement full fetch specification

### DIFF
--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -207,6 +207,8 @@ string_enum! { Char
     Star = "*",
     Semicolon = ";",
     Colon = ":",
+    ParenLeft = "(",
+    ParenRight = ")",
     CurlyLeft = "{",
     CurlyRight = "}",
     SquareLeft = "[",

--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -60,17 +60,16 @@ string_enum! { Clause
     Update = "update",
     Delete = "delete",
     Match = "match",
-    Within = "within",
     Fetch = "fetch",
     With = "with",
-    Reduce = "reduce",
 }
 
-string_enum! { Modifier
+string_enum! { Operator
     Select = "select",
     Sort = "sort",
     Offset = "offset",
     Limit = "limit",
+    Reduce = "reduce",
     Require = "require",
 }
 
@@ -111,6 +110,8 @@ string_enum! { Keyword
     As = "as",
     Alias = "alias",
     Assign = "=",
+    Check = "check",
+    First = "first",
     From = "from",
     Fun = "fun",
     Has = "has",
@@ -120,6 +121,7 @@ string_enum! { Keyword
     Isa = "isa",
     IsaX = "isa!",
     Label = "label",
+    Last = "last",
     Links = "links",
     Not = "not",
     Of = "of",
@@ -133,6 +135,7 @@ string_enum! { Keyword
     SubX = "sub!",
     Try = "try",
     Value = "value",
+    Within = "within",
 }
 
 string_enum! { Annotation
@@ -150,8 +153,6 @@ string_enum! { Annotation
 }
 
 string_enum! { ReduceOperator
-    Check = "check",
-    First = "first",
     Count = "count",
     Max = "max",
     Mean = "mean",

--- a/rust/parser/define/function.rs
+++ b/rust/parser/define/function.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use crate::{
     common::{error::TypeQLError, Spanned},
     parser::{
-        pipeline::{visit_clause_match, visit_operator_stream, visit_query_stage, visit_reduce},
+        pipeline::{visit_clause_match, visit_operator_stream, visit_query_stage},
         type_::visit_named_type_any,
         visit_identifier, visit_var, visit_vars, IntoChildNodes, Node, Rule, RuleMatcher,
     },
@@ -18,6 +18,8 @@ use crate::{
         Function,
     },
 };
+use crate::parser::pipeline::visit_reducer;
+use crate::schema::definable::function::{Check, ReturnReduction, ReturnSingle, SingleSelector};
 
 pub(in crate::parser) fn visit_definition_function(node: Node<'_>) -> Function {
     debug_assert_eq!(node.as_rule(), Rule::definition_function);
@@ -46,11 +48,11 @@ fn visit_return_statement(node: Node<'_>) -> ReturnStatement {
     debug_assert_eq!(node.as_rule(), Rule::return_statement);
     let mut children = node.into_children();
 
-    children.skip_expected(Rule::RETURN);
     let child = children.consume_any();
     let return_stmt = match child.as_rule() {
-        Rule::return_statement_stream => ReturnStatement::Stream(visit_return_statement_stream(child)),
-        Rule::reduce => ReturnStatement::Reduce(visit_reduce(child)),
+        Rule::return_stream => ReturnStatement::Stream(visit_return_stream(child)),
+        Rule::return_single => ReturnStatement::Single(visit_return_single(child)),
+        Rule::return_reduce => ReturnStatement::Reduce(visit_return_reduce(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     };
 
@@ -58,9 +60,56 @@ fn visit_return_statement(node: Node<'_>) -> ReturnStatement {
     return_stmt
 }
 
-fn visit_return_statement_stream(node: Node<'_>) -> ReturnStream {
-    debug_assert_eq!(node.as_rule(), Rule::return_statement_stream);
-    ReturnStream::new(node.span(), visit_vars(node.into_child()))
+fn visit_return_stream(node: Node<'_>) -> ReturnStream {
+    debug_assert_eq!(node.as_rule(), Rule::return_stream);
+    let span = node.span();
+    let mut children = node.into_children();
+    children.skip_expected(Rule::RETURN);
+    let vars = visit_vars(children.consume_any());
+    debug_assert_eq!(children.try_consume_any(), None);
+    ReturnStream::new(span, vars)
+}
+
+fn visit_return_single(node: Node<'_>) -> ReturnSingle {
+    debug_assert_eq!(node.as_rule(), Rule::return_single);
+    let span = node.span();
+    let mut children = node.into_children();
+    children.skip_expected(Rule::RETURN);
+    let selector = visit_return_single_selector(children.consume_expected(Rule::return_single_selector));
+    let vars = visit_vars(children.consume_any());
+    debug_assert_eq!(children.try_consume_any(), None);
+    ReturnSingle::new(span, selector, vars)
+}
+
+fn visit_return_single_selector(node: Node<'_>) -> SingleSelector {
+    debug_assert_eq!(node.as_rule(), Rule::return_single_selector);
+    let child = node.into_child();
+    match child.as_rule() {
+        Rule::FIRST => SingleSelector::First,
+        Rule::LAST => SingleSelector::Last,
+        _ =>  unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
+    }
+}
+
+pub(super) fn visit_return_reduce(node: Node<'_>) -> ReturnReduction {
+    debug_assert_eq!(node.as_rule(), Rule::return_reduce);
+    let mut children = node.into_children();
+    children.skip_expected(Rule::RETURN);
+    let return_reduce_reduction = visit_return_reduce_reduction(children.consume_expected(Rule::return_reduce_reduction));
+    debug_assert!(children.try_consume_any().is_none());
+    return_reduce_reduction
+}
+
+fn visit_return_reduce_reduction(node: Node<'_>) -> ReturnReduction {
+    debug_assert_eq!(node.as_rule(), Rule::return_reduce_reduction);
+    let mut children = node.into_children();
+    let reduction = match children.peek_rule().unwrap() {
+        Rule::CHECK => ReturnReduction::Check(Check::new(children.consume_expected(Rule::CHECK).span())),
+        Rule::reducer => ReturnReduction::Value(children.by_ref().map(visit_reducer).collect()),
+        _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: children.to_string() }),
+    };
+    debug_assert!(children.try_consume_any().is_none());
+    reduction
 }
 
 fn visit_function_signature(node: Node<'_>) -> Signature {

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         identifier::Identifier,
         token, LineColumn, Span, Spanned,
     },
-    parser::{pipeline::visit_query_pipeline, redefine::visit_query_redefine},
+    parser::{pipeline::visit_query_pipeline_preambled, redefine::visit_query_redefine},
     query::{Query, SchemaQuery},
     schema::definable,
     type_::Label,
@@ -160,7 +160,7 @@ fn visit_query(node: Node<'_>) -> Query {
     let child = children.consume_any();
     let query = match child.as_rule() {
         Rule::query_schema => Query::Schema(visit_query_schema(child)),
-        Rule::query_pipeline => Query::Pipeline(visit_query_pipeline(child)),
+        Rule::query_pipeline_preambled => Query::Pipeline(visit_query_pipeline_preambled(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     };
     debug_assert_eq!(children.try_consume_any(), None);

--- a/rust/parser/mod.rs
+++ b/rust/parser/mod.rs
@@ -248,3 +248,13 @@ fn visit_var_assignment(node: Node<'_>) -> Variable {
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     }
 }
+
+fn visit_reduce_assignment_var(node: Node<'_>) -> Variable {
+    debug_assert_eq!(node.as_rule(), Rule::reduce_assignment_var);
+    let child = node.into_child();
+    match child.as_rule() {
+        Rule::var => visit_var(child),
+        Rule::var_optional => visit_var_optional(child),
+        _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
+    }
+}

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -74,7 +74,7 @@ fn visit_preamble(node: Node<'_>) -> Preamble {
     Preamble::new(span, patterns)
 }
 
-fn visit_query_stage(node: Node<'_>) -> Stage {
+pub(super) fn visit_query_stage(node: Node<'_>) -> Stage {
     debug_assert_eq!(node.as_rule(), Rule::query_stage);
     let child = node.into_child();
     match child.as_rule() {
@@ -356,21 +356,21 @@ pub(super) fn visit_reduce(node: Node<'_>) -> Reduction {
     let mut children = node.into_children();
     let reduce = match children.peek_rule().unwrap() {
         Rule::CHECK => Reduction::Check(Check::new(children.consume_expected(Rule::CHECK).span())),
-        Rule::reduce_first => Reduction::First(visit_reduce_first(children.consume_expected(Rule::reduce_first))),
+        // Rule::reduce_first => Reduction::First(visit_reduce_first(children.consume_expected(Rule::reduce_first))),
         Rule::reduce_value => Reduction::Value(children.by_ref().map(visit_reduce_value).collect()),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: children.to_string() }),
     };
     debug_assert!(children.try_consume_any().is_none());
     reduce
 }
-
-fn visit_reduce_first(node: Node<'_>) -> First {
-    debug_assert_eq!(node.as_rule(), Rule::reduce_first);
-    let span = node.span();
-    let mut children = node.into_children();
-    let variables = visit_vars(children.skip_expected(Rule::FIRST).consume_expected(Rule::vars));
-    First::new(span, variables)
-}
+//
+// fn visit_reduce_first(node: Node<'_>) -> First {
+//     debug_assert_eq!(node.as_rule(), Rule::reduce_first);
+//     let span = node.span();
+//     let mut children = node.into_children();
+//     let variables = visit_vars(children.skip_expected(Rule::FIRST).consume_expected(Rule::vars));
+//     First::new(span, variables)
+// }
 
 fn visit_reduce_value(node: Node<'_>) -> ReduceValue {
     debug_assert_eq!(node.as_rule(), Rule::reduce_value);

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -397,14 +397,14 @@ pub(super) fn visit_operator_stream(node: Node<'_>) -> Operator {
 fn visit_operator_reduce(node: Node<'_>) -> Reduce {
     debug_assert_eq!(node.as_rule(), Rule::operator_reduce);
     let mut children = node.into_children();
-    let mut reducers = Vec::new();
+    let mut reduce_assignments = Vec::new();
     let mut group = None;
     children.skip_expected(Rule::REDUCE);
     while let Some(child) = children.try_consume_any() {
         match child.as_rule() {
-            Rule::reduce_assign => reducers.push(visit_reduce_assign(child)),
+            Rule::reduce_assign => reduce_assignments.push(visit_reduce_assign(child)),
             Rule::WITHIN => {
-                debug_assert!(reducers.len() > 0);
+                debug_assert!(reduce_assignments.len() > 0);
                 group = Some(visit_vars(children.consume_expected(Rule::vars)));
                 break;
             }
@@ -412,7 +412,7 @@ fn visit_operator_reduce(node: Node<'_>) -> Reduce {
         }
     }
     debug_assert_eq!(children.try_consume_any(), None);
-    Reduce::new(reducers, group)
+    Reduce::new(reduce_assignments, group)
 }
 
 

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -344,6 +344,7 @@ pub(super) fn visit_operator_stream(node: Node<'_>) -> Operator {
         Rule::operator_offset => Operator::Offset(visit_operator_offset(child)),
         Rule::operator_limit => Operator::Limit(visit_operator_limit(child)),
         Rule::operator_reduce => Operator::Reduce(visit_operator_reduce(child)),
+        Rule::operator_require => Operator::Require(visit_operator_require(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     }
 }

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -6,10 +6,18 @@
 
 use itertools::Itertools;
 
-use super::{define::function::visit_definition_function, expression::{visit_expression, visit_expression_function}, literal::{visit_integer_literal, visit_quoted_string_literal}, statement::{
-    thing::{visit_relation, visit_statement_thing},
-    visit_statement,
-}, type_::{visit_label, visit_label_list}, visit_var, visit_var_named, visit_vars, visit_vars_assignment, ChildNodes, IntoChildNodes, Node, Rule, RuleMatcher, visit_reduce_assignment_var};
+use super::{
+    define::function::visit_definition_function,
+    expression::{visit_expression, visit_expression_function},
+    literal::{visit_integer_literal, visit_quoted_string_literal},
+    statement::{
+        thing::{visit_relation, visit_statement_thing},
+        visit_statement,
+    },
+    type_::{visit_label, visit_label_list},
+    visit_reduce_assignment_var, visit_var, visit_var_named, visit_vars, visit_vars_assignment, ChildNodes,
+    IntoChildNodes, Node, Rule, RuleMatcher,
+};
 use crate::{
     common::{
         error::TypeQLError,
@@ -34,16 +42,16 @@ use crate::{
                 FetchAttribute, FetchList, FetchObject, FetchObjectBody, FetchObjectEntry, FetchSingle, FetchStream,
             },
             modifier::Require,
-            reduce::{ReduceAssign},
+            reduce::ReduceAssign,
         },
         Pipeline,
     },
+    schema::definable::function::{Check, ReturnReduction},
     statement::Statement,
     type_::NamedType,
     value::StringLiteral,
     TypeRef, TypeRefAny,
 };
-use crate::schema::definable::function::{Check, ReturnReduction};
 
 pub(super) fn visit_query_pipeline_preambled(node: Node<'_>) -> Pipeline {
     debug_assert_eq!(node.as_rule(), Rule::query_pipeline_preambled);
@@ -369,7 +377,6 @@ fn visit_operator_reduce(node: Node<'_>) -> Reduce {
     debug_assert_eq!(children.try_consume_any(), None);
     Reduce::new(reduce_assignments, group)
 }
-
 
 pub(super) fn visit_reduce_assign(node: Node<'_>) -> ReduceAssign {
     debug_assert_eq!(node.as_rule(), Rule::reduce_assign);

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -247,6 +247,52 @@ fn visit_clause_fetch(node: Node<'_>) -> Fetch {
     Fetch::new(span, fetch_object)
 }
 
+
+// insert
+// let $value = 10 + 1;
+//
+// attribute name, value string;
+//
+// struct coordinate:
+//   x-coord value long,
+//   y-coord value long;
+//
+//
+// $age 10 isa age; $age == 10;
+//
+// $age $value isa age;
+// $age 10 + 1 isa age;
+// $age ($value + $other_value / 10) isa age;
+
+// $age isa age 10;
+// $age isa age $value;
+// $age isa age 10 + 1;
+//
+// $name isa age(10 + 1);
+// $name isa age($value);
+//
+//
+// $p isa person, has age 10+1;
+//
+// $x isa person, has age $attr; $attr == $value;
+// $x isa person, has age 10;  <---> $x isa person, has $a; $a isa age; $a == 10;
+//
+// $x isa person, has $attr; $attr isa age(10+1);
+// $x isa person, has age($value);
+// $name $value isa age;
+// $name == $value;
+// $name isa age(10 + 1);
+// $name isa age($value);
+//
+// $r isa marriage(spouse: $x)
+
+
+// match
+// ...
+// let $value = 10 + 11 / 2;
+// $p isa person, has age $value;
+// $p isa person, has age $attr; $attr == $value;
+
 fn visit_fetch_some(node: Node<'_>) -> FetchEntry {
     debug_assert_eq!(node.as_rule(), Rule::fetch_some);
     let child = node.into_child();

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -240,52 +240,6 @@ fn visit_clause_fetch(node: Node<'_>) -> Fetch {
     Fetch::new(span, fetch_object)
 }
 
-
-// insert
-// let $value = 10 + 1;
-//
-// attribute name, value string;
-//
-// struct coordinate:
-//   x-coord value long,
-//   y-coord value long;
-//
-//
-// $age 10 isa age; $age == 10;
-//
-// $age $value isa age;
-// $age 10 + 1 isa age;
-// $age ($value + $other_value / 10) isa age;
-
-// $age isa age 10;
-// $age isa age $value;
-// $age isa age 10 + 1;
-//
-// $name isa age(10 + 1);
-// $name isa age($value);
-//
-//
-// $p isa person, has age 10+1;
-//
-// $x isa person, has age $attr; $attr == $value;
-// $x isa person, has age 10;  <---> $x isa person, has $a; $a isa age; $a == 10;
-//
-// $x isa person, has $attr; $attr isa age(10+1);
-// $x isa person, has age($value);
-// $name $value isa age;
-// $name == $value;
-// $name isa age(10 + 1);
-// $name isa age($value);
-//
-// $r isa marriage(spouse: $x)
-
-
-// match
-// ...
-// let $value = 10 + 11 / 2;
-// $p isa person, has age $value;
-// $p isa person, has age $attr; $attr == $value;
-
 fn visit_fetch_some(node: Node<'_>) -> FetchEntry {
     debug_assert_eq!(node.as_rule(), Rule::fetch_some);
     let child = node.into_child();

--- a/rust/parser/statement/mod.rs
+++ b/rust/parser/statement/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     statement::{comparison::Comparison, Statement},
 };
 
-mod single;
+pub(super) mod single;
 pub(super) mod thing;
 pub(super) mod type_;
 

--- a/rust/parser/test/fetch.rs
+++ b/rust/parser/test/fetch.rs
@@ -10,34 +10,44 @@ use crate::parse_query;
 #[test]
 fn test_fetch_query() {
     let query = r#"match
-$x isa movie,
-    has title "Godfather",
-    has release-date $d;
+$x isa person,
+    has $a;
+$a isa age;
+$a == 10;
 fetch {
-    "d_only": $d,
-    "d optional attr": $d.title,
-    "d many attr": [ $d.name ],
-    "d everything": { $d.* },
-    "d object": {
-        "entry single 1": $x.name,
-        "entry single 2": $d + 10,
-        "entry single 3": (
-            match
-            $x has name $n;
-            return count($n);
-        ),
-        "entry object": {
-            "all": { $x.* }
-        },
-        "entry list": [
-            match
-            ($x, $y) isa bla;
-            fetch {
-                "y values": { $y.* }
-            }
-        ]
-    }
-}"#;
+    "single attr": $a,
+    "single-card attributes": $x.age,
+    "single value expression": $a + 1,
+    "single answer block": (
+        match
+        $x has name $name;
+        return first $name;
+    ),
+    "reduce answer block": (
+        match
+        $x has name $name;
+        return count($name);
+    ),
+    "list positional return block": [
+        match
+        $x has name $n,
+            has age $a;
+        return { $n, $a };
+    ],
+    "list pipeline": [
+        match
+        $x has name $n,
+            has age $a;
+        fetch {
+            "name": $n
+        };
+    ],
+    "list higher-card attributes": [ $x.name ],
+    "list attributes": $x.name[],
+    "all attributes": { $x.* }
+};"#;
+    // TODO: Include list expression function
+    // # "list expression function": [ all_names($x) ],
     let parsed = parse_query(query).unwrap();
     // let projections: Vec<Projection> = vec![
     // var("d").into(),

--- a/rust/parser/test/fetch.rs
+++ b/rust/parser/test/fetch.rs
@@ -21,10 +21,11 @@ fetch {
     "d object": {
         "entry single 1": $x.name,
         "entry single 2": $d + 10,
-        "entry single 3":
+        "entry single 3": (
             match
             $x has name $n;
-            reduce $c = count($n);,
+            return count($n);
+        ),
         "entry object": {
             "all": { $x.* }
         },

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -22,7 +22,7 @@ preamble = { WITH ~ definition_function }
 
 query_stage = { clause_match | clause_insert | clause_put | clause_update | clause_delete | operator_stream }
 
-query_stage_terminal = { clause_fetch }
+query_stage_terminal = { clause_fetch ~ SEMICOLON }
 
 clause_match = { MATCH ~ patterns }
 

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -25,7 +25,7 @@ query_stage_terminal = { clause_fetch }
 
 clause_match = { MATCH ~ patterns }
 
-clause_insert = { INSERT ~ ( statement_thing ~ SEMICOLON )+ }
+clause_insert = { INSERT ~ ( statement_thing ~ SEMICOLON | statement_assignment ~ SEMICOLON )+ }
 clause_put = { PUT ~ ( statement_thing ~ SEMICOLON )+ }
 clause_update = { UPDATE ~ ( statement_thing ~ SEMICOLON )+ }
 
@@ -48,11 +48,8 @@ reduce_assign = { (var ~ ASSIGN ~ reduce_value) }
 
 // REDUCE ======================================================================
 reduce = { CHECK
-         | reduce_first
          | reduce_value ~ ( COMMA ~ reduce_value )* ~ COMMA?
          }
-
-reduce_first = { FIRST ~ PAREN_OPEN ~ vars ~ PAREN_CLOSE }
 
 reduce_value = { COUNT ~ ( PAREN_OPEN ~ var ~ PAREN_CLOSE )?
                | MAX ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
@@ -185,9 +182,10 @@ fetch_key = { quoted_string_literal }
 
 fetch_list = { SQ_BRACKET_OPEN ~ fetch_stream ~ SQ_BRACKET_CLOSE }
 
-fetch_stream = { expression_function | query_pipeline | fetch_attribute }
+fetch_stream = { expression_function | function_block | fetch_subfetch | fetch_attribute }
+fetch_subfetch = { query_stage+ ~ clause_fetch }
 
-fetch_single = { fetch_attribute | expression | query_pipeline }
+fetch_single = { PAREN_OPEN? ~ fetch_attribute | expression | function_block ~ PAREN_CLOSE? }
 
 fetch_attribute = { var_named ~ DOT ~ ( label_list | label ) }
 fetch_attributes_all = { var_named ~ DOT ~ STAR }
@@ -224,12 +222,14 @@ relates_declaration = { RELATES ~ label_list
 
 // FUNCTION DEFINITION =========================================================
 
-definition_function = { FUN ~ function_signature ~ COLON ~ clause_match ~ operator_stream* ~ return_statement }
+definition_function = { FUN ~ function_signature ~ COLON ~ function_block }
 
 function_signature = { identifier ~ PAREN_OPEN ~ function_arguments ~ PAREN_CLOSE ~ ARROW ~ function_output }
 
 function_arguments = { ( function_argument ~ ( COMMA ~ function_argument )* ~ COMMA? )? }
 function_argument = { var ~ COLON ~ named_type_any }
+
+function_block = { query_stage+ ~ return_statement }
 
 function_output = { function_output_stream | function_output_single }
 function_output_stream = { CURLY_OPEN ~ named_type_any ~ ( COMMA ~ named_type_any )* ~ COMMA? ~ CURLY_CLOSE }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -15,7 +15,8 @@ query = { query_schema | query_pipeline }
 
 // QUERY PIPELINES =============================================================
 
-query_pipeline = { preamble* ~ query_stage+ ~ query_stage_terminal? }
+query_pipeline = { preamble* ~ query_stages }
+query_stages = { query_stage+ ~ query_stage_terminal? }
 
 preamble = { WITH ~ definition_function }
 
@@ -182,10 +183,9 @@ fetch_key = { quoted_string_literal }
 
 fetch_list = { SQ_BRACKET_OPEN ~ fetch_stream ~ SQ_BRACKET_CLOSE }
 
-fetch_stream = { expression_function | function_block | fetch_subfetch | fetch_attribute }
-fetch_subfetch = { query_stage+ ~ clause_fetch }
+fetch_stream = { expression_function | function_block | query_stages | fetch_attribute }
 
-fetch_single = { PAREN_OPEN? ~ fetch_attribute | expression | function_block ~ PAREN_CLOSE? }
+fetch_single = { PAREN_OPEN? ~ ( fetch_attribute | expression | function_block ) ~ PAREN_CLOSE? }
 
 fetch_attribute = { var_named ~ DOT ~ ( label_list | label ) }
 fetch_attributes_all = { var_named ~ DOT ~ STAR }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -11,12 +11,12 @@ eof_definition_struct = { SOI ~ definition_struct ~ EOI }
 
 // TYPEQL QUERY LANGUAGE =======================================================
 
-query = { query_schema | query_pipeline }
+query = { query_schema | query_pipeline_preambled }
 
 // QUERY PIPELINES =============================================================
 
-query_pipeline = { preamble* ~ query_stages }
-query_stages = { query_stage+ ~ query_stage_terminal? }
+query_pipeline_preambled = { preamble* ~ query_pipeline }
+query_pipeline = { query_stage+ ~ query_stage_terminal? }
 
 preamble = { WITH ~ definition_function }
 
@@ -185,7 +185,7 @@ fetch_key = { quoted_string_literal }
 
 fetch_list = { SQ_BRACKET_OPEN ~ fetch_stream ~ SQ_BRACKET_CLOSE }
 
-fetch_stream = { expression_function | function_block | query_stages | fetch_attribute }
+fetch_stream = { expression_function | function_block | query_pipeline | fetch_attribute }
 
 fetch_single = { PAREN_OPEN? ~ ( fetch_attribute | expression | function_block ) ~ PAREN_CLOSE? }
 

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -20,7 +20,7 @@ query_pipeline = { query_stage+ ~ query_stage_terminal? }
 
 preamble = { WITH ~ definition_function }
 
-query_stage = { clause_match | clause_insert | clause_put | clause_update | clause_delete | operator_stream | operator_reduce }
+query_stage = { clause_match | clause_insert | clause_put | clause_update | clause_delete | operator_stream }
 
 query_stage_terminal = { clause_fetch }
 
@@ -32,35 +32,30 @@ clause_update = { UPDATE ~ ( statement_thing ~ SEMICOLON )+ }
 
 clause_delete = { DELETE ~ ( statement_deletable ~ SEMICOLON )+ }
 
-operator_reduce = { REDUCE ~ reduce_assign ~ ( COMMA ~ reduce_assign )* ~ (WITHIN ~ vars )? ~ SEMICOLON }
+// STREAM OPERATORS  ===========================================================
 
-// QUERY MODIFIERS =============================================================
-
-operator_stream = { operator_select | operator_sort | operator_offset | operator_limit | operator_require }
+operator_stream = { operator_select | operator_sort | operator_offset | operator_limit | operator_reduce }
 
 operator_select = { SELECT ~ vars ~ SEMICOLON }
 operator_sort = { SORT ~ var_order ~ ( COMMA ~ var_order )* ~ SEMICOLON }
 operator_offset = { OFFSET ~ integer_literal ~ SEMICOLON }
 operator_limit = { LIMIT ~ integer_literal ~ SEMICOLON }
 operator_require = { REQUIRE ~ vars ~ SEMICOLON }
+operator_reduce = { REDUCE ~ reduce_assign ~ ( COMMA ~ reduce_assign )* ~ (WITHIN ~ vars )? ~ SEMICOLON }
 
 var_order = { var ~ ORDER? }
-reduce_assign = { (var ~ ASSIGN ~ reduce_value) }
+reduce_assign = { (reduce_assignment_var ~ ASSIGN ~ reducer) }
 
-// REDUCE ======================================================================
-reduce = { CHECK
-         | reduce_value ~ ( COMMA ~ reduce_value )* ~ COMMA?
-         }
-
-reduce_value = { COUNT ~ ( PAREN_OPEN ~ var ~ PAREN_CLOSE )?
-               | MAX ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
-               | MIN ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
-               | MEAN ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
-               | MEDIAN ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
-               | STD ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
-               | SUM ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
-               | LIST ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
-               }
+reduce_assignment_var = { var_optional | var }
+reducer = { COUNT ~ ( PAREN_OPEN ~ var ~ PAREN_CLOSE )?
+          | MAX ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
+          | MIN ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
+          | MEAN ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
+          | MEDIAN ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
+          | STD ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
+          | SUM ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
+          | LIST ~ PAREN_OPEN ~ var ~ PAREN_CLOSE
+          }
 
 // QUERY PATTERNS ==============================================================
 
@@ -237,8 +232,15 @@ function_output = { function_output_stream | function_output_single }
 function_output_stream = { CURLY_OPEN ~ named_type_any ~ ( COMMA ~ named_type_any )* ~ COMMA? ~ CURLY_CLOSE }
 function_output_single = { named_type_any ~ ( COMMA ~ named_type_any )* ~ COMMA? }
 
-return_statement = { RETURN ~ ( return_statement_stream | reduce ) ~ SEMICOLON }
-return_statement_stream = { CURLY_OPEN ~ vars ~ CURLY_CLOSE }
+return_statement = { ( return_stream | return_single | return_reduce ) ~ SEMICOLON }
+// return_statement = { RETURN ~ ( return_statement_stream | reduce ) ~ SEMICOLON }
+return_stream = { RETURN ~ CURLY_OPEN ~ vars ~ CURLY_CLOSE }
+return_single = { RETURN ~ return_single_selector ~ vars }
+return_single_selector = { FIRST | LAST }
+return_reduce = { RETURN ~ return_reduce_reduction }
+return_reduce_reduction = { CHECK
+                          | reducer ~ ( COMMA ~ reducer )* ~ COMMA?
+                          }
 
 // STRUCT DEFINITION ===========================================================
 
@@ -397,6 +399,7 @@ DELETE = @{ "delete" ~ WB }
 REDUCE = @{ "reduce" ~ WB }
 CHECK = @{ "check" ~ WB }
 FIRST = @{ "first" ~ WB }
+LAST = @{ "last" ~ WB }
 WITHIN = @{ "within" ~ WB }
 
 // THING KIND KEYWORDS

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -104,6 +104,8 @@ statement_relation_anonymous = { relation ~ thing_constraint? ~ ( COMMA ~ thing_
 
 statement_thing_var = { var ~ COMMA? ~ thing_constraint ~ ( COMMA ~ thing_constraint )* ~ COMMA?
                       | var ~ ( value_literal | expression_struct ) ~ isa_constraint
+                      // TODO: need to allow $x $name_value isa name;
+                      // option: $x isa name($value), extend to literals as well
                       | var ~ comparison ~ isa_constraint
                       }
 

--- a/rust/query/pipeline/stage/fetch.rs
+++ b/rust/query/pipeline/stage/fetch.rs
@@ -10,7 +10,7 @@ use crate::{
     common::{token, Span},
     expression::{Expression, FunctionCall},
     pretty::{indent, Pretty},
-    query::{stage::Stage, Pipeline},
+    query::{stage::Stage},
     schema::definable::function::FunctionBlock,
     value::StringLiteral,
     TypeRefAny, Variable,
@@ -32,7 +32,8 @@ impl Pretty for Fetch {
     fn fmt(&self, indent_level: usize, f: &mut Formatter<'_>) -> fmt::Result {
         indent(indent_level, f)?;
         write!(f, "{} ", token::Clause::Fetch)?;
-        Pretty::fmt(&self.object, indent_level, f)
+        Pretty::fmt(&self.object, indent_level, f)?;
+        write!(f, "{}", token::Char::Semicolon)
     }
 }
 
@@ -40,7 +41,7 @@ impl fmt::Display for Fetch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} ", token::Clause::Fetch)?;
         fmt::Display::fmt(&self.object, f)?;
-        Ok(())
+        write!(f, "{}", token::Char::Semicolon)
     }
 }
 

--- a/rust/query/pipeline/stage/fetch.rs
+++ b/rust/query/pipeline/stage/fetch.rs
@@ -10,7 +10,7 @@ use crate::{
     common::{token, Span},
     expression::{Expression, FunctionCall},
     pretty::{indent, Pretty},
-    query::{stage::Stage},
+    query::stage::Stage,
     schema::definable::function::FunctionBlock,
     value::StringLiteral,
     TypeRefAny, Variable,

--- a/rust/query/pipeline/stage/fetch.rs
+++ b/rust/query/pipeline/stage/fetch.rs
@@ -10,12 +10,11 @@ use crate::{
     common::{token, Span},
     expression::{Expression, FunctionCall},
     pretty::{indent, Pretty},
-    query::Pipeline,
+    query::{stage::Stage, Pipeline},
+    schema::definable::function::FunctionBlock,
     value::StringLiteral,
     TypeRefAny, Variable,
 };
-use crate::query::stage::Stage;
-use crate::schema::definable::function::FunctionBlock;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Fetch {
@@ -63,9 +62,7 @@ impl Pretty for FetchEntry {
                 write!(f, " ")?;
                 Pretty::fmt(entry, indent_level, f)
             }
-            FetchEntry::Single(entry) => {
-                Pretty::fmt(entry, indent_level, f)
-            },
+            FetchEntry::Single(entry) => Pretty::fmt(entry, indent_level, f),
         }
     }
 }
@@ -244,7 +241,7 @@ impl fmt::Display for FetchSingle {
                 write!(f, "{} ", token::Char::ParenLeft)?;
                 fmt::Display::fmt(single, f)?;
                 write!(f, " {}", token::Char::ParenRight)
-            },
+            }
         }
     }
 }
@@ -304,7 +301,7 @@ impl fmt::Display for FetchStream {
                     fmt::Display::fmt(stage, f)?;
                 }
                 Ok(())
-            },
+            }
             FetchStream::SubQueryFunctionBlock(block) => fmt::Display::fmt(block, f),
         }?;
         write!(f, "{}", token::Char::SquareRight)

--- a/rust/query/pipeline/stage/mod.rs
+++ b/rust/query/pipeline/stage/mod.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 
 pub use self::{
-    delete::Delete, fetch::Fetch, insert::Insert, match_::Match, modifier::Modifier, put::Put, reduce::Reduce,
+    delete::Delete, fetch::Fetch, insert::Insert, match_::Match, modifier::Operator, put::Put, reduce::Reduce,
     update::Update,
 };
 use crate::{pretty::Pretty, util::enum_getter};
@@ -29,8 +29,7 @@ pub enum Stage {
     Update(Update),
     Fetch(Fetch),
     Delete(Delete),
-    Reduce(Reduce),
-    Modifier(Modifier),
+    Operator(Operator),
 }
 
 enum_getter! { Stage
@@ -40,8 +39,7 @@ enum_getter! { Stage
     into_update(Update) => Update,
     into_fetch(Fetch) => Fetch,
     into_delete(Delete) => Delete,
-    into_reduce(Reduce) => Reduce,
-    into_modifier(Modifier) => Modifier,
+    into_modifier(Operator) => Operator,
 }
 
 impl Pretty for Stage {
@@ -53,8 +51,7 @@ impl Pretty for Stage {
             Self::Update(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Fetch(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Delete(inner) => Pretty::fmt(inner, indent_level, f),
-            Self::Reduce(inner) => Pretty::fmt(inner, indent_level, f),
-            Self::Modifier(inner) => Pretty::fmt(inner, indent_level, f),
+            Self::Operator(inner) => Pretty::fmt(inner, indent_level, f),
         }
     }
 }
@@ -68,8 +65,7 @@ impl fmt::Display for Stage {
             Self::Update(inner) => fmt::Display::fmt(inner, f),
             Self::Fetch(inner) => fmt::Display::fmt(inner, f),
             Self::Delete(inner) => fmt::Display::fmt(inner, f),
-            Self::Reduce(inner) => fmt::Display::fmt(inner, f),
-            Self::Modifier(inner) => fmt::Display::fmt(inner, f),
+            Self::Operator(inner) => fmt::Display::fmt(inner, f),
         }
     }
 }

--- a/rust/query/pipeline/stage/modifier.rs
+++ b/rust/query/pipeline/stage/modifier.rs
@@ -16,6 +16,7 @@ use crate::{
     value::IntegerLiteral,
     variable::Variable,
 };
+use crate::query::stage::Reduce;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct OrderedVariable {
@@ -58,7 +59,7 @@ impl Pretty for Sort {}
 
 impl fmt::Display for Sort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} ", token::Modifier::Sort)?;
+        write!(f, "{} ", token::Operator::Sort)?;
         write_joined!(f, ", ", self.ordered_variables)?;
         f.write_char(';')?;
         Ok(())
@@ -81,7 +82,7 @@ impl Pretty for Select {}
 
 impl fmt::Display for Select {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} ", token::Modifier::Select)?;
+        write!(f, "{} ", token::Operator::Select)?;
         write_joined!(f, ", ", self.variables)?;
         f.write_char(';')?;
         Ok(())
@@ -104,7 +105,7 @@ impl Pretty for Offset {}
 
 impl fmt::Display for Offset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {};", token::Modifier::Offset, self.offset)
+        write!(f, "{} {};", token::Operator::Offset, self.offset)
     }
 }
 
@@ -124,7 +125,7 @@ impl Pretty for Limit {}
 
 impl fmt::Display for Limit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {};", token::Modifier::Limit, self.limit)
+        write!(f, "{} {};", token::Operator::Limit, self.limit)
     }
 }
 
@@ -152,33 +153,36 @@ impl fmt::Display for Require {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Modifier {
+pub enum Operator {
     Select(Select),
     Sort(Sort),
     Offset(Offset),
     Limit(Limit),
+    Reduce(Reduce),
     Require(Require),
 }
 
-impl Pretty for Modifier {
+impl Pretty for Operator {
     fn fmt(&self, indent_level: usize, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Select(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Sort(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Offset(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Limit(inner) => Pretty::fmt(inner, indent_level, f),
+            Self::Reduce(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Require(inner) => Pretty::fmt(inner, indent_level, f),
         }
     }
 }
 
-impl fmt::Display for Modifier {
+impl fmt::Display for Operator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Select(inner) => fmt::Display::fmt(inner, f),
             Self::Sort(inner) => fmt::Display::fmt(inner, f),
             Self::Offset(inner) => fmt::Display::fmt(inner, f),
             Self::Limit(inner) => fmt::Display::fmt(inner, f),
+            Self::Reduce(inner) => fmt::Display::fmt(inner, f),
             Self::Require(inner) => fmt::Display::fmt(inner, f),
         }
     }

--- a/rust/query/pipeline/stage/modifier.rs
+++ b/rust/query/pipeline/stage/modifier.rs
@@ -12,11 +12,11 @@ use crate::{
         Span,
     },
     pretty::Pretty,
+    query::stage::Reduce,
     util::write_joined,
     value::IntegerLiteral,
     variable::Variable,
 };
-use crate::query::stage::Reduce;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct OrderedVariable {

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -28,10 +28,10 @@ impl Reduce {
 impl Pretty for Reduce {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         indent(indent_level, f)?;
-        write!(f, "{} ", token::Clause::Reduce)?;
+        write!(f, "{} ", token::Operator::Reduce)?;
         write_joined!(f, ", ", self.reductions)?;
         if let Some(group) = &self.within_group {
-            write!(f, " {} ", token::Clause::Within)?;
+            write!(f, " {} ", token::Keyword::Within)?;
             write_joined!(f, ", ", group)?;
         }
         write!(f, ";")?;
@@ -41,10 +41,10 @@ impl Pretty for Reduce {
 
 impl fmt::Display for Reduce {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} ", token::Clause::Reduce)?;
+        write!(f, "{} ", token::Operator::Reduce)?;
         write_joined!(f, ", ", self.reductions)?;
         if let Some(group) = &self.within_group {
-            write!(f, " {} (", token::Clause::Within)?;
+            write!(f, " {} (", token::Keyword::Within)?;
             write_joined!(f, ", ", group)?;
             write!(f, ")")?;
         }
@@ -55,98 +55,30 @@ impl fmt::Display for Reduce {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ReduceAssign {
-    pub assign_to: Variable,
-    pub reduce_value: ReduceValue,
+    pub variable: Variable,
+    pub reducer: Reducer,
 }
 
 impl Pretty for ReduceAssign {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         indent(indent_level, f)?;
-        write!(f, "{} = {}", self.assign_to, self.reduce_value)
+        write!(f, "{} = {}", self.variable, self.reducer)
     }
 }
 
 impl fmt::Display for ReduceAssign {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} = {}", self.assign_to, self.reduce_value)
+        write!(f, "{} = {}", self.variable, self.reducer)
     }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Reduction {
-    Check(Check),
-    First(First),
-    Value(Vec<ReduceValue>),
-}
-
-impl Pretty for Reduction {
-    fn fmt(&self, _indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl fmt::Display for Reduction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Check(inner) => fmt::Display::fmt(inner, f),
-            Self::First(inner) => fmt::Display::fmt(inner, f),
-            Self::Value(inner) => {
-                write_joined!(f, ", ", inner)?;
-                Ok(())
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Check {
-    span: Option<Span>,
-}
-
-impl Check {
-    pub fn new(span: Option<Span>) -> Self {
-        Self { span }
-    }
-}
-
-impl Pretty for Check {}
-
-impl fmt::Display for Check {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{};", token::ReduceOperator::Check)
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct First {
-    span: Option<Span>,
-    pub variables: Vec<Variable>,
-}
-
-impl First {
-    pub fn new(span: Option<Span>, variables: Vec<Variable>) -> Self {
-        Self { span, variables }
-    }
-}
-
-impl Pretty for First {}
-
-impl fmt::Display for First {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}(", token::ReduceOperator::First)?;
-        write_joined!(f, ", ", self.variables)?;
-        f.write_str(");")?;
-        Ok(())
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum ReduceValue {
+pub enum Reducer {
     Count(Count),
     Stat(Stat),
 }
 
-impl Pretty for ReduceValue {
+impl Pretty for Reducer {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Count(inner) => Pretty::fmt(inner, indent_level, f),
@@ -155,7 +87,7 @@ impl Pretty for ReduceValue {
     }
 }
 
-impl fmt::Display for ReduceValue {
+impl fmt::Display for Reducer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Count(inner) => fmt::Display::fmt(inner, f),

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -15,13 +15,13 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Reduce {
-    pub reductions: Vec<ReduceAssign>,
+    pub reduce_assignments: Vec<ReduceAssign>,
     pub within_group: Option<Vec<Variable>>,
 }
 
 impl Reduce {
-    pub fn new(reductions: Vec<ReduceAssign>, within_group: Option<Vec<Variable>>) -> Self {
-        Reduce { reductions, within_group }
+    pub fn new(reduce_assignments: Vec<ReduceAssign>, within_group: Option<Vec<Variable>>) -> Self {
+        Reduce { reduce_assignments, within_group }
     }
 }
 
@@ -29,7 +29,7 @@ impl Pretty for Reduce {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         indent(indent_level, f)?;
         write!(f, "{} ", token::Operator::Reduce)?;
-        write_joined!(f, ", ", self.reductions)?;
+        write_joined!(f, ", ", self.reduce_assignments)?;
         if let Some(group) = &self.within_group {
             write!(f, " {} ", token::Keyword::Within)?;
             write_joined!(f, ", ", group)?;
@@ -42,7 +42,7 @@ impl Pretty for Reduce {
 impl fmt::Display for Reduce {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} ", token::Operator::Reduce)?;
-        write_joined!(f, ", ", self.reductions)?;
+        write_joined!(f, ", ", self.reduce_assignments)?;
         if let Some(group) = &self.within_group {
             write!(f, " {} (", token::Keyword::Within)?;
             write_joined!(f, ", ", group)?;

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -217,6 +217,7 @@ impl Pretty for FunctionBlock {
         for stage in &self.stages {
             Pretty::fmt(stage, indent_level, f)?;
         }
+        write!(f, "\n")?;
         Pretty::fmt(&self.return_stmt, indent_level, f)
     }
 }
@@ -247,10 +248,10 @@ impl fmt::Display for ReturnStatement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ReturnStatement::Stream(return_stream) => {
-                write!(f, "{} {}", token::Keyword::Return, return_stream)
+                write!(f, "{} {};", token::Keyword::Return, return_stream)
             }
             ReturnStatement::Reduce(reduction) => {
-                write!(f, "{} {}", token::Keyword::Return, reduction)
+                write!(f, "{} {};", token::Keyword::Return, reduction)
             }
         }
     }

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -16,25 +16,23 @@ use crate::{
     type_::TypeRefAny,
     variable::Variable,
 };
+use crate::query::Pipeline;
+use crate::query::stage::Stage;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
     span: Option<Span>,
     pub signature: Signature,
-    pub body: Match,
-    pub modifiers: Vec<Modifier>,
-    pub return_stmt: ReturnStatement,
+    pub block: FunctionBlock,
 }
 
 impl Function {
     pub fn new(
         span: Option<Span>,
         signature: Signature,
-        body: Match,
-        modifiers: Vec<Modifier>,
-        return_stmt: ReturnStatement,
+        block: FunctionBlock
     ) -> Self {
-        Self { span, signature, body, modifiers, return_stmt }
+        Self { span, signature, block }
     }
 }
 
@@ -44,16 +42,17 @@ impl Pretty for Function {
         write!(f, "{} ", token::Keyword::Fun)?;
         Pretty::fmt(&self.signature, indent_level, f)?;
         f.write_char(':')?;
+        f.write_str("\n")?;
+        Pretty::fmt(&self.block, indent_level + 1, f)?;
         Ok(())
     }
 }
 
 impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            return Pretty::fmt(self, 0, f);
-        }
-
+        // if f.alternate() {
+        //     return Pretty::fmt(self, 0, f);
+        // }
         todo!()
     }
 }
@@ -198,6 +197,36 @@ impl Pretty for Single {
 impl fmt::Display for Single {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         todo!()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FunctionBlock {
+    pub stages: Vec<Stage>,
+    pub return_stmt: ReturnStatement,
+}
+
+impl FunctionBlock {
+    pub fn new(stages: Vec<Stage>, return_stmt: ReturnStatement) -> Self {
+        Self { stages, return_stmt }
+    }
+}
+
+impl Pretty for FunctionBlock {
+    fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for stage in &self.stages {
+            Pretty::fmt(stage, indent_level, f)?;
+        }
+        Pretty::fmt(&self.return_stmt, indent_level, f)
+    }
+}
+
+impl fmt::Display for FunctionBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for stage in &self.stages {
+            fmt::Display::fmt(stage, f)?;
+        }
+        fmt::Display::fmt(&self.return_stmt, f)
     }
 }
 

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -273,11 +273,11 @@ impl ReturnStream {
 impl fmt::Display for ReturnStream {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         assert!(!self.vars.is_empty());
-        write!(f, "{}", self.vars[0])?;
+        write!(f, "{} {}", token::Char::CurlyLeft , self.vars[0])?;
         for var in &self.vars[1..] {
             write!(f, ", {}", var)?;
         }
-        Ok(())
+        write!(f, " {}", token::Char::CurlyRight)
     }
 }
 
@@ -297,7 +297,7 @@ impl ReturnSingle {
 impl fmt::Display for ReturnSingle {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         assert!(!self.vars.is_empty());
-        write!(f, "{}", self.selector)?;
+        write!(f, "{} ", self.selector)?;
         write!(f, "{}", self.vars[0])?;
         for var in &self.vars[1..] {
             write!(f, ", {}", var)?;

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -11,13 +11,12 @@ use crate::{
     pretty::{indent, Pretty},
     query::{
         pipeline::stage::{Match, Modifier},
-        stage::reduce::Reduction,
+        stage::{reduce::Reduction, Stage},
+        Pipeline,
     },
     type_::TypeRefAny,
     variable::Variable,
 };
-use crate::query::Pipeline;
-use crate::query::stage::Stage;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
@@ -27,11 +26,7 @@ pub struct Function {
 }
 
 impl Function {
-    pub fn new(
-        span: Option<Span>,
-        signature: Signature,
-        block: FunctionBlock
-    ) -> Self {
+    pub fn new(span: Option<Span>, signature: Signature, block: FunctionBlock) -> Self {
         Self { span, signature, block }
     }
 }

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -11,14 +11,13 @@ use crate::{
     pretty::{indent, Pretty},
     query::{
         pipeline::stage::{Match, Operator},
-        stage::{Stage},
+        stage::{reduce::Reducer, Stage},
         Pipeline,
     },
     type_::TypeRefAny,
+    util::write_joined,
     variable::Variable,
 };
-use crate::query::stage::reduce::Reducer;
-use crate::util::write_joined;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
@@ -273,7 +272,7 @@ impl ReturnStream {
 impl fmt::Display for ReturnStream {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         assert!(!self.vars.is_empty());
-        write!(f, "{} {}", token::Char::CurlyLeft , self.vars[0])?;
+        write!(f, "{} {}", token::Char::CurlyLeft, self.vars[0])?;
         for var in &self.vars[1..] {
             write!(f, ", {}", var)?;
         }
@@ -363,4 +362,3 @@ impl fmt::Display for Check {
         write!(f, "{};", token::Keyword::Check)
     }
 }
-


### PR DESCRIPTION
## Usage and product changes

We refactor Fetch and Function behaviour, to allow any of the following Fetching patterns:
```
match
...
fetch {
    // fetch a matched attribute, value, or type. Represented as a attribute/value/type or null (if the variable is optional).
    "single variable": $a,   

    // attribute 'age' of $x. Must be `@card(0..1)` or `@card(1..1)`. Represented as an attribute or null.
    "single-card attributes": $x.age,

    // all attributes 'name' of $x. Can be any cardinality.
    "list higher-card attributes": [ $x.name ], 

    // inline-computed expression value. Represented as a value.
    "single value expression": $a + 1,  

    // an inline query with a 'return' block to select a *single* answer. Represented identically to a single variable or null.
    "single answer block": (  
        match
        $x has name $name;
        return first $name;
    ),

    // an inline query with a 'return' block to reduce to a *single* answer. Represented as a value or null
    "reduce answer block": ( 
        match
        $x has name $name;
        return count($name);
    ),

    // an inline query that returns a stream of lists/tuples. Represented as list of lists.
    "list positional return block": [  
        match
        $x has name $n,
            has age $a;
        return { $n, $a };
    ],

    // an inline query that returns stream of sub-documents. Represented as a list of objects.
    "list pipeline": [ 
        match
        $x has name $n,
            has age $a;
        fetch {
            "name": $n
        };
    ],

    // special syntax to fetch all attributes of a concept. Represented as an object, where keys are attribute type names and values are either lists (for >card(1)) or nullable values (for card(0..1) or card(1..1))
    "all attributes": { $x.* }
}
```

## Implementation
