### PR TITLE
Implement require operator

### DIFF
--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -71,6 +71,7 @@ string_enum! { Modifier
     Sort = "sort",
     Offset = "offset",
     Limit = "limit",
+    Require = "require",
 }
 
 string_enum! { LogicOperator

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -39,6 +39,7 @@ use crate::{
             fetch::{
                 FetchAttribute, FetchList, FetchObject, FetchObjectBody, FetchObjectEntry, FetchSingle, FetchStream,
             },
+            modifier::Require,
             reduce::{ReduceAssign, Reduction},
         },
         Pipeline,
@@ -412,6 +413,7 @@ pub(super) fn visit_operator_stream(node: Node<'_>) -> Modifier {
         Rule::operator_sort => Modifier::Sort(visit_operator_sort(child)),
         Rule::operator_offset => Modifier::Offset(visit_operator_offset(child)),
         Rule::operator_limit => Modifier::Limit(visit_operator_limit(child)),
+        Rule::operator_require => Modifier::Require(visit_operator_require(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     }
 }
@@ -468,4 +470,13 @@ fn visit_operator_limit(node: Node<'_>) -> Limit {
     let limit = visit_integer_literal(children.skip_expected(Rule::LIMIT).consume_expected(Rule::integer_literal));
     debug_assert_eq!(children.try_consume_any(), None);
     Limit::new(span, limit)
+}
+
+fn visit_operator_require(node: Node<'_>) -> Require {
+    debug_assert_eq!(node.as_rule(), Rule::operator_require);
+    let span = node.span();
+    let mut children = node.into_children();
+    let variables = visit_vars(children.skip_expected(Rule::REQUIRE).consume_expected(Rule::vars));
+    debug_assert_eq!(children.try_consume_any(), None);
+    Require::new(span, variables)
 }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -35,12 +35,13 @@ operator_reduce = { REDUCE ~ reduce_assign ~ ( COMMA ~ reduce_assign )* ~ (WITHI
 
 // QUERY MODIFIERS =============================================================
 
-operator_stream = { operator_select | operator_sort | operator_offset | operator_limit }
+operator_stream = { operator_select | operator_sort | operator_offset | operator_limit | operator_require }
 
 operator_select = { SELECT ~ vars ~ SEMICOLON }
 operator_sort = { SORT ~ var_order ~ ( COMMA ~ var_order )* ~ SEMICOLON }
 operator_offset = { OFFSET ~ integer_literal ~ SEMICOLON }
 operator_limit = { LIMIT ~ integer_literal ~ SEMICOLON }
+operator_require = { REQUIRE ~ vars ~ SEMICOLON }
 
 var_order = { var ~ ORDER? }
 reduce_assign = { (var ~ ASSIGN ~ reduce_value) }
@@ -410,6 +411,7 @@ SELECT = @{ "select" ~ WB }
 LIMIT = @{ "limit" ~ WB }
 OFFSET = @{ "offset" ~ WB }
 SORT = @{ "sort" ~ WB }
+REQUIRE = @{ "require" ~ WB }
 
 ORDER = ${ ASC | DESC }
 ASC = @{ "asc" ~ WB }

--- a/rust/query/pipeline/stage/modifier.rs
+++ b/rust/query/pipeline/stage/modifier.rs
@@ -129,11 +129,35 @@ impl fmt::Display for Limit {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Require {
+    span: Option<Span>,
+    pub variables: Vec<Variable>,
+}
+
+impl Require {
+    pub fn new(span: Option<Span>, variables: Vec<Variable>) -> Self {
+        Self { span, variables }
+    }
+}
+
+impl Pretty for Require {}
+
+impl fmt::Display for Require {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ", token::Modifier::Require)?;
+        write_joined!(f, ", ", self.variables)?;
+        f.write_char(';')?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Modifier {
     Select(Select),
     Sort(Sort),
     Offset(Offset),
     Limit(Limit),
+    Require(Require),
 }
 
 impl Pretty for Modifier {
@@ -143,6 +167,7 @@ impl Pretty for Modifier {
             Self::Sort(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Offset(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Limit(inner) => Pretty::fmt(inner, indent_level, f),
+            Self::Require(inner) => Pretty::fmt(inner, indent_level, f),
         }
     }
 }
@@ -154,6 +179,7 @@ impl fmt::Display for Modifier {
             Self::Sort(inner) => fmt::Display::fmt(inner, f),
             Self::Offset(inner) => fmt::Display::fmt(inner, f),
             Self::Limit(inner) => fmt::Display::fmt(inner, f),
+            Self::Require(inner) => fmt::Display::fmt(inner, f),
         }
     }
 }


### PR DESCRIPTION
## Usage and product changes

Implement the 'require' clause:
```
match
...
require $x, $y, $z;
```
Will filter the match output stream to ensure that the variable `$x, $y, $z` are all non-empty variables (if they are optional).
