### PR TITLE
Make `identifier` and `common` mods public to reuse in typedb

### DIFF
--- a/rust/common/mod.rs
+++ b/rust/common/mod.rs
@@ -10,7 +10,7 @@ pub use error::Error;
 
 pub mod date_time;
 pub mod error;
-pub(crate) mod identifier;
+pub mod identifier;
 pub mod string;
 pub mod token;
 

--- a/rust/typeql.rs
+++ b/rust/typeql.rs
@@ -30,7 +30,7 @@ use crate::{
 
 pub mod annotation;
 pub mod builder;
-mod common;
+pub mod common;
 pub mod expression;
 pub mod parser;
 pub mod pattern;


### PR DESCRIPTION
## Usage and product changes
We make `identifier` and `common` `mod`s public to reuse their symbols in [typedb](https://github.com/typedb/typedb/pull/7208).