### PR TITLE
Make Is statement fields public

### DIFF
--- a/rust/statement/mod.rs
+++ b/rust/statement/mod.rs
@@ -26,8 +26,8 @@ pub mod type_;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Is {
     span: Option<Span>,
-    lhs: Variable,
-    rhs: Variable,
+    pub lhs: Variable,
+    pub rhs: Variable,
 }
 
 impl Is {


### PR DESCRIPTION
## Usage and product changes

We make the `lhs` and `rhs` fields of the `Is` statement struct public for use in typedb core.