### PR TITLE
Add function redefine, other small changes for functions

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -43,11 +43,15 @@ build:
         bazel test //java/query/... --test_output=errors
         bazel test //java/test/deployment/... --test_output=errors
         bazel test //java/test/behaviour/... --test_output=errors
-    test-rust:
+    test-rust-unit:
       image: typedb-ubuntu-22.04
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel test //rust:typeql_unit_tests --test_output=errors
+    test-rust-behaviour:
+      image: typedb-ubuntu-22.04
+      command: |
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel test //rust/tests/behaviour:test_behaviour --test_output=errors
     deploy-crate-snapshot:
       filter:

--- a/rust/parser/define/function.rs
+++ b/rust/parser/define/function.rs
@@ -25,13 +25,13 @@ use crate::{
 pub(in crate::parser) fn visit_definition_function(node: Node<'_>) -> Function {
     debug_assert_eq!(node.as_rule(), Rule::definition_function);
     let span = node.span();
+    let unparsed = node.as_span().as_str().to_owned();
     let mut children = node.into_children();
-
     children.skip_expected(Rule::FUN);
     let signature = visit_function_signature(children.consume_expected(Rule::function_signature));
     let block = visit_function_block(children.consume_expected(Rule::function_block));
     debug_assert_eq!(children.try_consume_any(), None);
-    Function::new(span, signature, block)
+    Function::new(span, signature, block, unparsed)
 }
 
 pub fn visit_function_block(node: Node<'_>) -> FunctionBlock {

--- a/rust/parser/test/functions.rs
+++ b/rust/parser/test/functions.rs
@@ -1,0 +1,52 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use super::assert_valid_eq_repr;
+use crate::parse_query;
+
+#[test]
+fn test_function_stream() {
+    let query = r#"define
+    fun my_function() -> { return-type }:
+        match
+        $v isa var-type;
+        return { $v };"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}
+
+#[test]
+fn test_function_single() {
+    let query = r#"define
+    fun my_function() -> return-type:
+        match
+        $v isa var-type;
+        return first $v;"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}
+
+#[test]
+fn test_function_reduce() {
+    let query = r#"define
+    fun my_function() -> return-type:
+        match
+        $v isa var-type;
+        return count($v), sum($v);"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}
+
+#[test]
+fn test_function_args() {
+    let query = r#"define
+    fun my_function($arg1: type1, $arg2: type2) -> { return-type }:
+        match
+        $v isa var-type;
+        return { $v };"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -13,6 +13,7 @@ mod builtin_functions;
 mod disjunctions;
 mod error;
 mod fetch;
+mod functions;
 mod group;
 mod group_aggregate;
 mod list;

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -255,8 +255,9 @@ struct_destructor_value = { var | struct_destructor }
 
 // REDEFINE QUERY ==============================================================
 
-query_redefine = { REDEFINE ~ ( redefinable ~ SEMICOLON )+ }
-redefinable = { kind? ~ label ~ ( annotations | type_capability ) }
+query_redefine = { REDEFINE ~ ( redefinable )+ }
+redefinable = { redefinable_type | definition_function }
+redefinable_type = { kind? ~ label ~ ( annotations | type_capability ) ~ SEMICOLON }
 // TODO: add `redefine <person> label <new_person_label>
 
 // UNDEFINE QUERY ==============================================================

--- a/rust/query/schema/define.rs
+++ b/rust/query/schema/define.rs
@@ -41,7 +41,7 @@ impl Pretty for Define {
         for definable in &self.definables {
             writeln!(f)?;
             Pretty::fmt(definable, indent_level + 1, f)?;
-            f.write_char(';')?;
+            // f.write_char(';')?;
         }
         Ok(())
     }

--- a/rust/query/schema/define.rs
+++ b/rust/query/schema/define.rs
@@ -41,7 +41,6 @@ impl Pretty for Define {
         for definable in &self.definables {
             writeln!(f)?;
             Pretty::fmt(definable, indent_level + 1, f)?;
-            // f.write_char(';')?;
         }
         Ok(())
     }

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -258,13 +258,13 @@ impl fmt::Display for ReturnStatement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ReturnStatement::Stream(return_stream) => {
-                write!(f, "{} {}", token::Keyword::Return, return_stream)
+                write!(f, "{} {};", token::Keyword::Return, return_stream)
             }
             ReturnStatement::Single(return_single) => {
-                write!(f, "{} {}", token::Keyword::Return, return_single)
+                write!(f, "{} {};", token::Keyword::Return, return_single)
             }
             ReturnStatement::Reduce(reduction) => {
-                write!(f, "{} {}", token::Keyword::Return, reduction)
+                write!(f, "{} {};", token::Keyword::Return, reduction)
             }
         }
     }

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -20,11 +20,12 @@ pub struct Function {
     span: Option<Span>,
     pub signature: Signature,
     pub block: FunctionBlock,
+    pub unparsed: String,
 }
 
 impl Function {
-    pub fn new(span: Option<Span>, signature: Signature, block: FunctionBlock) -> Self {
-        Self { span, signature, block }
+    pub fn new(span: Option<Span>, signature: Signature, block: FunctionBlock, unparsed: String) -> Self {
+        Self { span, signature, block, unparsed }
     }
 }
 

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -49,8 +49,8 @@ impl fmt::Display for Function {
         if f.alternate() {
             return Pretty::fmt(self, 0, f);
         } else {
-            self.signature.fmt(f)?;
-            self.block.fmt(f)
+            std::fmt::Display::fmt(&self.signature, f)?;
+            std::fmt::Display::fmt(&self.block, f)
         }
     }
 }
@@ -74,7 +74,10 @@ impl Pretty for Signature {
         write!(f, "{}(", self.ident)?;
         if self.args.len() > 0 {
             Pretty::fmt(&self.args[0], indent_level, f)?;
-            self.args[1..self.args.len()].iter().try_for_each(|arg| write!(f, ", {}: {}", arg.var, arg.type_))?;
+            self.args[1..self.args.len()].iter().try_for_each(|arg| {
+                f.write_str(", ")?;
+                Pretty::fmt(arg, indent_level, f)
+            })?;
         }
         write!(f, ") -> ")?;
         Pretty::fmt(&self.output, indent_level, f)?;
@@ -89,8 +92,8 @@ impl fmt::Display for Signature {
         } else {
             write!(f, "{}(", self.ident)?;
             if self.args.len() > 0 {
-                write!(f, ", {}: {}", self.args[0].var, self.args[0].type_)?;
-                self.args[1..self.args.len()].iter().try_for_each(|arg| write!(f, ", {}: {}", arg.var, arg.type_))?;
+                write!(f, "{}", self.args[0])?;
+                self.args[1..self.args.len()].iter().try_for_each(|arg| write!(f, ", {arg}"))?;
             }
             write!(f, ") -> {}", self.output)?;
             Ok(())
@@ -108,6 +111,13 @@ pub struct Argument {
 impl Argument {
     pub fn new(span: Option<Span>, var: Variable, type_: TypeRefAny) -> Self {
         Self { span, var, type_ }
+    }
+}
+
+impl Pretty for Argument {}
+impl fmt::Display for Argument {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.var, self.type_)
     }
 }
 
@@ -248,13 +258,13 @@ impl fmt::Display for ReturnStatement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ReturnStatement::Stream(return_stream) => {
-                write!(f, "{} {};", token::Keyword::Return, return_stream)
+                write!(f, "{} {}", token::Keyword::Return, return_stream)
             }
             ReturnStatement::Single(return_single) => {
-                write!(f, "{} {};", token::Keyword::Return, return_single)
+                write!(f, "{} {}", token::Keyword::Return, return_single)
             }
             ReturnStatement::Reduce(reduction) => {
-                write!(f, "{} {};", token::Keyword::Return, reduction)
+                write!(f, "{} {}", token::Keyword::Return, reduction)
             }
         }
     }

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -5,7 +5,7 @@
  */
 
 use std::{
-    fmt::{self, Formatter, Write},
+    fmt::{self, Debug, Formatter, Write},
     ptr::write,
 };
 
@@ -46,10 +46,12 @@ impl Pretty for Function {
 
 impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // if f.alternate() {
-        //     return Pretty::fmt(self, 0, f);
-        // }
-        todo!()
+        if f.alternate() {
+            return Pretty::fmt(self, 0, f);
+        } else {
+            self.signature.fmt(f)?;
+            self.block.fmt(f)
+        }
     }
 }
 
@@ -70,7 +72,10 @@ impl Signature {
 impl Pretty for Signature {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}(", self.ident)?;
-        self.args.iter().try_for_each(|arg| write!(f, "{}: {}", arg.var, arg.type_))?;
+        if self.args.len() > 0 {
+            Pretty::fmt(&self.args[0], indent_level, f)?;
+            self.args[1..self.args.len()].iter().try_for_each(|arg| write!(f, ", {}: {}", arg.var, arg.type_))?;
+        }
         write!(f, ") -> ")?;
         Pretty::fmt(&self.output, indent_level, f)?;
         Ok(())
@@ -83,7 +88,10 @@ impl fmt::Display for Signature {
             Pretty::fmt(self, 0, f)
         } else {
             write!(f, "{}(", self.ident)?;
-            self.args.iter().try_for_each(|arg| write!(f, "{}: {}", arg.var, arg.type_))?;
+            if self.args.len() > 0 {
+                write!(f, ", {}: {}", self.args[0].var, self.args[0].type_)?;
+                self.args[1..self.args.len()].iter().try_for_each(|arg| write!(f, ", {}: {}", arg.var, arg.type_))?;
+            }
             write!(f, ") -> {}", self.output)?;
             Ok(())
         }
@@ -154,11 +162,7 @@ impl Spanned for Stream {
     }
 }
 
-impl Pretty for Stream {
-    fn fmt(&self, _indent_level: usize, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
-    }
-}
+impl Pretty for Stream {}
 
 impl fmt::Display for Stream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -186,11 +190,7 @@ impl Spanned for Single {
     }
 }
 
-impl Pretty for Single {
-    fn fmt(&self, _indent_level: usize, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
-    }
-}
+impl Pretty for Single {}
 
 impl fmt::Display for Single {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -5,6 +5,7 @@
  */
 
 use std::fmt::{self, Formatter, Write};
+use std::ptr::write;
 
 use crate::{
     common::{identifier::Identifier, token, Span, Spanned},
@@ -67,7 +68,7 @@ impl Signature {
 impl Pretty for Signature {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}(", self.ident)?;
-        todo!("write args");
+        self.args.iter().try_for_each(|arg| write!(f, "{}: {}", arg.var, arg.type_))?;
         write!(f, ") -> ")?;
         Pretty::fmt(&self.output, indent_level, f)?;
         Ok(())
@@ -80,7 +81,7 @@ impl fmt::Display for Signature {
             Pretty::fmt(self, 0, f)
         } else {
             write!(f, "{}(", self.ident)?;
-            todo!("write args");
+            self.args.iter().try_for_each(|arg| write!(f, "{}: {}", arg.var, arg.type_))?;
             write!(f, ") -> {}", self.output)?;
             Ok(())
         }
@@ -158,8 +159,10 @@ impl Pretty for Stream {
 }
 
 impl fmt::Display for Stream {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{ ")?;
+        write_joined!(f, ", ", self.types)?;
+        write!(f, " }}")
     }
 }
 
@@ -188,8 +191,8 @@ impl Pretty for Single {
 }
 
 impl fmt::Display for Single {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_joined!(f, ", ", self.types)
     }
 }
 

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -4,8 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::{self, Formatter, Write};
-use std::ptr::write;
+use std::{
+    fmt::{self, Formatter, Write},
+    ptr::write,
+};
 
 use crate::{
     common::{identifier::Identifier, token, Span, Spanned},

--- a/rust/schema/definable/type_/mod.rs
+++ b/rust/schema/definable/type_/mod.rs
@@ -72,6 +72,7 @@ impl Pretty for Type {
             indent(indent_level, f)?;
             write!(f, "{}", cap)?;
         }
+        f.write_char(';')?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Usage and product changes
Adds function redefine syntax, and some small changes.

## Implementation
* Add function redefine
* Makes some fields public
* Functions keep their unparsed string representation so the function manager can store it.

