### PR TITLE
Allow loader options when loading YAML

### DIFF
--- a/common/java/yaml/YAML.java
+++ b/common/java/yaml/YAML.java
@@ -23,9 +23,18 @@ public abstract class YAML {
         return wrap(new org.yaml.snakeyaml.Yaml().load(yaml));
     }
 
+    public static YAML load(java.lang.String yaml, org.yaml.snakeyaml.LoaderOptions options) {
+        return wrap(new org.yaml.snakeyaml.Yaml(options).load(yaml));
+    }
+
     public static YAML load(Path filePath) throws FileNotFoundException {
         FileInputStream inputStream = new FileInputStream(filePath.toFile());
         return wrap(new org.yaml.snakeyaml.Yaml().load(inputStream));
+    }
+
+    public static YAML load(Path filePath, org.yaml.snakeyaml.LoaderOptions options) throws FileNotFoundException {
+        FileInputStream inputStream = new FileInputStream(filePath.toFile());
+        return wrap(new org.yaml.snakeyaml.Yaml(options).load(inputStream));
     }
 
     private static YAML wrap(Object yaml) {


### PR DESCRIPTION
## Usage and product changes

Allow setting `snakeyaml.LoaderOptions` when loading YAML

## Implementation

We add alternative implementations of `load` that take a `snakeyaml.LoaderOptions` and use it when constructing the `snakeyaml.Yaml` object.