### PR TITLE
Rename within to groupby

### DIFF
--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -137,7 +137,7 @@ string_enum! { Keyword
     SubX = "sub!",
     Try = "try",
     Value = "value",
-    Within = "within",
+    Groupby = "groupby",
 }
 
 string_enum! { Annotation

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -364,7 +364,7 @@ fn visit_operator_reduce(node: Node<'_>) -> Reduce {
     while let Some(child) = children.try_consume_any() {
         match child.as_rule() {
             Rule::reduce_assign => reduce_assignments.push(visit_reduce_assign(child)),
-            Rule::WITHIN => {
+            Rule::GROUPBY => {
                 debug_assert!(reduce_assignments.len() > 0);
                 group = Some(visit_vars(children.consume_expected(Rule::vars)));
                 break;

--- a/rust/parser/test/group_aggregate.rs
+++ b/rust/parser/test/group_aggregate.rs
@@ -7,12 +7,12 @@
 use crate::{parse_query, parser::test::assert_valid_eq_repr};
 
 #[test]
-fn test_reduce_within_query() {
+fn test_reduce_groupby_query() {
     let query = r#"match
 ($x, $y) isa friendship,
     has age $a;
 select $x, $y;
-reduce $max = max($a), $min = min($a) within $x, $y;"#;
+reduce $max = max($a), $min = min($a) groupby $x, $y;"#;
     let parsed = parse_query(query).unwrap();
     assert_valid_eq_repr!(expected, parsed, query);
 }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -41,7 +41,7 @@ operator_sort = { SORT ~ var_order ~ ( COMMA ~ var_order )* ~ SEMICOLON }
 operator_offset = { OFFSET ~ integer_literal ~ SEMICOLON }
 operator_limit = { LIMIT ~ integer_literal ~ SEMICOLON }
 operator_require = { REQUIRE ~ vars ~ SEMICOLON }
-operator_reduce = { REDUCE ~ reduce_assign ~ ( COMMA ~ reduce_assign )* ~ (WITHIN ~ vars )? ~ SEMICOLON }
+operator_reduce = { REDUCE ~ reduce_assign ~ ( COMMA ~ reduce_assign )* ~ (GROUPBY ~ vars )? ~ SEMICOLON }
 
 var_order = { var ~ ORDER? }
 reduce_assign = { (reduce_assignment_var ~ ASSIGN ~ reducer) }
@@ -395,7 +395,7 @@ REDUCE = @{ "reduce" ~ WB }
 CHECK = @{ "check" ~ WB }
 FIRST = @{ "first" ~ WB }
 LAST = @{ "last" ~ WB }
-WITHIN = @{ "within" ~ WB }
+GROUPBY = @{ "groupby" ~ WB }
 
 // THING KIND KEYWORDS
 

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -16,12 +16,12 @@ use crate::{
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Reduce {
     pub reduce_assignments: Vec<ReduceAssign>,
-    pub within_group: Option<Vec<Variable>>,
+    pub groupby: Option<Vec<Variable>>,
 }
 
 impl Reduce {
-    pub fn new(reduce_assignments: Vec<ReduceAssign>, within_group: Option<Vec<Variable>>) -> Self {
-        Reduce { reduce_assignments, within_group }
+    pub fn new(reduce_assignments: Vec<ReduceAssign>, groupby: Option<Vec<Variable>>) -> Self {
+        Reduce { reduce_assignments, groupby: groupby }
     }
 }
 
@@ -30,8 +30,8 @@ impl Pretty for Reduce {
         indent(indent_level, f)?;
         write!(f, "{} ", token::Operator::Reduce)?;
         write_joined!(f, ", ", self.reduce_assignments)?;
-        if let Some(group) = &self.within_group {
-            write!(f, " {} ", token::Keyword::Within)?;
+        if let Some(group) = &self.groupby {
+            write!(f, " {} ", token::Keyword::Groupby)?;
             write_joined!(f, ", ", group)?;
         }
         write!(f, ";")?;
@@ -43,8 +43,8 @@ impl fmt::Display for Reduce {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} ", token::Operator::Reduce)?;
         write_joined!(f, ", ", self.reduce_assignments)?;
-        if let Some(group) = &self.within_group {
-            write!(f, " {} (", token::Keyword::Within)?;
+        if let Some(group) = &self.groupby {
+            write!(f, " {} (", token::Keyword::Groupby)?;
             write_joined!(f, ", ", group)?;
             write!(f, ")")?;
         }


### PR DESCRIPTION
## Usage and product changes

We rename `within` to `groupby`, in better alignment with expected terminology.

## Implementation
- Rename `within` to `groupby`