### PR TITLE
Add 'dec' suffix to decimal literals

### DIFF
--- a/rust/parser/literal.rs
+++ b/rust/parser/literal.rs
@@ -80,14 +80,13 @@ fn visit_signed_decimal(node: Node<'_>) -> SignedDecimalLiteral {
     debug_assert_eq!(node.as_rule(), Rule::signed_decimal);
     let mut children = node.into_children();
     let first_node = children.consume_any();
-    let (sign, decimal) = match first_node.as_rule() {
-        Rule::sign => {
-            (Some(visit_sign(first_node)), children.consume_expected(Rule::decimal_literal).as_str().to_owned())
-        }
-        Rule::decimal_literal => (None, first_node.as_str().to_owned()),
+    let (sign, decimal_with_suffix) = match first_node.as_rule() {
+        Rule::sign => (Some(visit_sign(first_node)), children.consume_expected(Rule::decimal_literal).as_str()),
+        Rule::decimal_literal => (None, first_node.as_str()),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: first_node.to_string() }),
     };
     debug_assert_eq!(children.try_consume_any(), None);
+    let decimal = decimal_with_suffix.trim_end_matches("dec").to_owned();
     SignedDecimalLiteral { sign, decimal }
 }
 

--- a/rust/parser/test/match_queries.rs
+++ b/rust/parser/test/match_queries.rs
@@ -492,9 +492,7 @@ $type relates someRole;"#;
 fn test_parsing_double_decimal_literal() {
     let query = r#"match
 let $x = -5.0 + -4.0dec;"#;
-
     let parsed = parse_query(query).unwrap();
-    // let expected = match_!(var("x").assign(5), var("a").equals(var("x")).isa("age"));
-
+    // let expected = todo!("When typeql builders exist");
     assert_valid_eq_repr!(expected, parsed, query);
 }

--- a/rust/parser/test/match_queries.rs
+++ b/rust/parser/test/match_queries.rs
@@ -489,7 +489,7 @@ $type relates someRole;"#;
 }
 
 #[test]
-fn test_parsing_doublee_decimal_literal() {
+fn test_parsing_double_decimal_literal() {
     let query = r#"match
 let $x = -5.0 + -4.0dec;"#;
 

--- a/rust/parser/test/match_queries.rs
+++ b/rust/parser/test/match_queries.rs
@@ -487,3 +487,14 @@ $type relates someRole;"#;
     // let expected = typeql_match!(var("x").isa(cvar("type")), cvar("type").relates("someRole"));
     assert_valid_eq_repr!(expected, parsed, query);
 }
+
+#[test]
+fn test_parsing_doublee_decimal_literal() {
+    let query = r#"match
+let $x = -5.0 + -4.0dec;"#;
+
+    let parsed = parse_query(query).unwrap();
+    // let expected = match_!(var("x").assign(5), var("a").equals(var("x")).isa("age"));
+
+    assert_valid_eq_repr!(expected, parsed, query);
+}

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -319,10 +319,11 @@ value_type_primitive = { BOOLEAN | INTEGER | DOUBLE | DECIMAL
                        | STRING
                        }
 value_literal = { quoted_string_literal | datetime_tz_literal | datetime_literal | date_literal
-                | duration_literal | boolean_literal | signed_decimal | signed_integer
+                | duration_literal | boolean_literal | signed_decimal | signed_double | signed_integer
                 }
 
 signed_decimal = { sign? ~ decimal_literal }
+signed_double = { sign? ~ double_literal }
 signed_integer = { sign? ~ integer_literal }
 sign = { PLUS | MINUS }
 
@@ -548,8 +549,9 @@ TRUE = @{ "true" ~ WB }
 FALSE = @{ "false" ~ WB }
 
 integer_literal = @{ ASCII_DIGIT+ }
-decimal_literal = @{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ ( ^"e" ~ sign? ~ integer_literal )? }
-numeric_literal = @{ decimal_literal | integer_literal }
+decimal_literal = @{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ "dec" }
+double_literal = @{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ ( ^"e" ~ sign? ~ integer_literal )? }
+numeric_literal = @{ double_literal | integer_literal }
 
 date_literal = ${ date_fragment ~ WB }
 datetime_literal = ${ date_fragment ~ "T" ~ time ~ WB }

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -282,7 +282,7 @@ impl fmt::Display for SignedDecimalLiteral {
         if let Some(sign) = &self.sign {
             fmt::Display::fmt(sign, f)?;
         }
-        f.write_str(self.decimal.as_str())
+        write!(f, "{}dec", self.decimal.as_str())
     }
 }
 

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Formatter};
 use crate::{
     common::{error::TypeQLError, Span, Spanned},
     pretty::Pretty,
-    Result,
+    token, Result,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -42,6 +42,12 @@ pub enum Sign {
 pub struct SignedIntegerLiteral {
     pub sign: Option<Sign>,
     pub integral: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SignedDoubleLiteral {
+    pub sign: Option<Sign>,
+    pub double: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -119,6 +125,7 @@ pub enum ValueLiteral {
     Boolean(BooleanLiteral),
     Integer(SignedIntegerLiteral),
     Decimal(SignedDecimalLiteral),
+    Double(SignedDoubleLiteral),
     Date(DateLiteral),
     DateTime(DateTimeLiteral),
     DateTimeTz(DateTimeTZLiteral),
@@ -159,6 +166,7 @@ impl fmt::Display for ValueLiteral {
             ValueLiteral::Boolean(value) => fmt::Display::fmt(value, f),
             ValueLiteral::Integer(value) => fmt::Display::fmt(value, f),
             ValueLiteral::Decimal(value) => fmt::Display::fmt(value, f),
+            ValueLiteral::Double(value) => fmt::Display::fmt(value, f),
             ValueLiteral::Date(value) => fmt::Display::fmt(value, f),
             ValueLiteral::DateTime(value) => fmt::Display::fmt(value, f),
             ValueLiteral::DateTimeTz(value) => fmt::Display::fmt(value, f),
@@ -275,6 +283,15 @@ impl fmt::Display for SignedDecimalLiteral {
             fmt::Display::fmt(sign, f)?;
         }
         f.write_str(self.decimal.as_str())
+    }
+}
+
+impl fmt::Display for SignedDoubleLiteral {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if let Some(sign) = &self.sign {
+            fmt::Display::fmt(sign, f)?;
+        }
+        f.write_str(self.double.as_str())
     }
 }
 


### PR DESCRIPTION
## Usage and product changes
Require decimal literals to be suffixed with 'dec'

## Implementation
Updates grammar & datastructures.