### PR TITLE
Enhance error printing and query source span availability

### DIFF
--- a/rust/annotation.rs
+++ b/rust/annotation.rs
@@ -65,7 +65,7 @@ impl fmt::Display for Annotation {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Abstract {
-    span: Option<Span>,
+    pub span: Option<Span>,
 }
 
 impl Abstract {
@@ -88,7 +88,7 @@ impl fmt::Display for Abstract {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Cardinality {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub range: CardinalityRange,
 }
 
@@ -128,7 +128,7 @@ impl fmt::Display for CardinalityRange {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Cascade {
-    span: Option<Span>,
+    pub span: Option<Span>,
 }
 
 impl Cascade {
@@ -151,7 +151,7 @@ impl fmt::Display for Cascade {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Distinct {
-    span: Option<Span>,
+    pub span: Option<Span>,
 }
 
 impl Distinct {
@@ -174,7 +174,7 @@ impl fmt::Display for Distinct {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Independent {
-    span: Option<Span>,
+    pub span: Option<Span>,
 }
 
 impl Independent {
@@ -197,7 +197,7 @@ impl fmt::Display for Independent {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Key {
-    span: Option<Span>,
+    pub span: Option<Span>,
 }
 
 impl Key {
@@ -220,7 +220,7 @@ impl fmt::Display for Key {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Range {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub min: Option<Literal>,
     pub max: Option<Literal>,
 }
@@ -254,7 +254,7 @@ impl fmt::Display for Range {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Regex {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub regex: StringLiteral,
 }
 
@@ -278,7 +278,7 @@ impl fmt::Display for Regex {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Subkey {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub ident: Identifier,
 }
 
@@ -302,7 +302,7 @@ impl fmt::Display for Subkey {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Unique {
-    span: Option<Span>,
+    pub span: Option<Span>,
 }
 
 impl Unique {
@@ -325,7 +325,7 @@ impl fmt::Display for Unique {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Values {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub values: Vec<Literal>,
 }
 

--- a/rust/annotation.rs
+++ b/rust/annotation.rs
@@ -7,10 +7,11 @@
 use std::fmt::{self, Write};
 
 use crate::{
-    common::{identifier::Identifier, token, Span},
+    common::{identifier::Identifier, Span, token},
     util::write_joined,
     value::{IntegerLiteral, Literal, StringLiteral},
 };
+use crate::common::Spanned;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Annotation {
@@ -25,6 +26,24 @@ pub enum Annotation {
     Subkey(Subkey),
     Unique(Unique),
     Values(Values),
+}
+
+impl Spanned for Annotation {
+    fn span(&self) -> Option<Span> {
+        match self {
+            Annotation::Abstract(annotation) => annotation.span(),
+            Annotation::Cardinality(annotation) => annotation.span(),
+            Annotation::Cascade(annotation) => annotation.span(),
+            Annotation::Distinct(annotation) => annotation.span(),
+            Annotation::Independent(annotation) => annotation.span(),
+            Annotation::Key(annotation) => annotation.span(),
+            Annotation::Range(annotation) => annotation.span(),
+            Annotation::Regex(annotation) => annotation.span(),
+            Annotation::Subkey(annotation) => annotation.span(),
+            Annotation::Unique(annotation) => annotation.span(),
+            Annotation::Values(annotation) => annotation.span(),
+        }
+    }
 }
 
 impl fmt::Display for Annotation {
@@ -56,6 +75,12 @@ impl Abstract {
     }
 }
 
+impl Spanned for Abstract {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl fmt::Display for Abstract {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "@{}", token::Annotation::Abstract)
@@ -71,6 +96,12 @@ pub struct Cardinality {
 impl Cardinality {
     pub fn new(span: Option<Span>, range: CardinalityRange) -> Self {
         Self { span, range }
+    }
+}
+
+impl Spanned for Cardinality {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -107,6 +138,12 @@ impl Cascade {
     }
 }
 
+impl Spanned for Cascade {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl fmt::Display for Cascade {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "@{}", token::Annotation::Cascade)
@@ -121,6 +158,12 @@ pub struct Distinct {
 impl Distinct {
     pub fn new(span: Option<Span>) -> Self {
         Self { span }
+    }
+}
+
+impl Spanned for Distinct {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -141,6 +184,12 @@ impl Independent {
     }
 }
 
+impl Spanned for Independent {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl fmt::Display for Independent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "@{}", token::Annotation::Independent)
@@ -155,6 +204,12 @@ pub struct Key {
 impl Key {
     pub fn new(span: Option<Span>) -> Self {
         Self { span }
+    }
+}
+
+impl Spanned for Key {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -174,6 +229,12 @@ pub struct Range {
 impl Range {
     pub fn new(span: Option<Span>, min: Option<Literal>, max: Option<Literal>) -> Self {
         Self { span, min, max }
+    }
+}
+
+impl Spanned for Range {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -204,6 +265,12 @@ impl Regex {
     }
 }
 
+impl Spanned for Regex {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl fmt::Display for Regex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "@{}({})", token::Annotation::Regex, self.regex.value)
@@ -219,6 +286,12 @@ pub struct Subkey {
 impl Subkey {
     pub fn new(span: Option<Span>, ident: Identifier) -> Self {
         Self { span, ident }
+    }
+}
+
+impl Spanned for Subkey {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -239,6 +312,12 @@ impl Unique {
     }
 }
 
+impl Spanned for Unique {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl fmt::Display for Unique {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "@{}", token::Annotation::Unique)
@@ -254,6 +333,12 @@ pub struct Values {
 impl Values {
     pub fn new(span: Option<Span>, values: Vec<Literal>) -> Self {
         Self { span, values }
+    }
+}
+
+impl Spanned for Values {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/annotation.rs
+++ b/rust/annotation.rs
@@ -7,11 +7,10 @@
 use std::fmt::{self, Write};
 
 use crate::{
-    common::{identifier::Identifier, Span, token},
+    common::{identifier::Identifier, token, Span, Spanned},
     util::write_joined,
     value::{IntegerLiteral, Literal, StringLiteral},
 };
-use crate::common::Spanned;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Annotation {

--- a/rust/common/error/mod.rs
+++ b/rust/common/error/mod.rs
@@ -39,13 +39,14 @@ impl From<Vec<TypeQLError>> for Error {
 }
 
 pub(crate) fn syntax_error<T: pest::RuleType>(query: &str, error: PestError<T>) -> TypeQLError {
-    let (error_line_nr, error_col) = match error.line_col {
+    let (error_line_nr, error_col_nr) = match error.line_col {
         LineColLocation::Pos((line, col)) => (line, col),
         LineColLocation::Span((line, col), _) => (line, col),
     };
-    // error_line_nr is 1-indexed, we operate on 0-offset
+    // error_line_nr and error_col_nr is 1-indexed, we operate on 0-offset
     let error_line = error_line_nr - 1;
-    let formatted_error = query.extract_annotated_line_col((error_line, error_col), usize::MAX, usize::MAX).unwrap();
+    let error_col = error_col_nr - 1;
+    let formatted_error = query.extract_annotated_line_col(error_line, error_col, usize::MAX, usize::MAX).unwrap();
     TypeQLError::SyntaxErrorDetailed { error_line_nr, error_col, formatted_error }
 }
 

--- a/rust/common/error/mod.rs
+++ b/rust/common/error/mod.rs
@@ -46,7 +46,9 @@ pub(crate) fn syntax_error<T: pest::RuleType>(query: &str, error: PestError<T>) 
     // error_line_nr and error_col_nr is 1-indexed, we operate on 0-offset
     let error_line = error_line_nr - 1;
     let error_col = error_col_nr - 1;
-    let formatted_error = query.extract_annotated_line_col(error_line, error_col, usize::MAX, usize::MAX).unwrap();
+    let formatted_error = query
+        .extract_annotated_line_col(error_line, error_col, usize::MAX, usize::MAX)
+        .unwrap_or_else(|| String::new());
     TypeQLError::SyntaxErrorDetailed { error_line_nr, error_col, formatted_error }
 }
 

--- a/rust/common/error/mod.rs
+++ b/rust/common/error/mod.rs
@@ -10,12 +10,14 @@ use itertools::Itertools;
 use pest::error::{Error as PestError, LineColLocation};
 
 use crate::{error_messages, util::write_joined, Identifier};
+use crate::common::Spannable;
 
 #[macro_use]
 mod macros;
 
-const SYNTAX_ERROR_INDENT: usize = 4;
-const SYNTAX_ERROR_INDICATOR: &str = "--> ";
+pub(crate) const SYNTAX_ANNOTATED_INDENT: usize = 4;
+pub(crate) const SYNTAX_ANNOTATED_INDICATOR_LINE: &str = "--> ";
+pub(crate) const SYNTAX_ANNOTATED_INDICATOR_COL: &str = "^";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Error {
@@ -45,16 +47,8 @@ pub(crate) fn syntax_error<T: pest::RuleType>(query: &str, error: PestError<T>) 
     // error_line_nr is 1-indexed, we operate on 0-offset
     let error_line = error_line_nr - 1;
     let formatted_error = query
-        .lines()
-        .enumerate()
-        .map(|(i, line)| {
-            if i == error_line {
-                format!("{SYNTAX_ERROR_INDICATOR}{line}")
-            } else {
-                format!("{}{line}", " ".repeat(SYNTAX_ERROR_INDENT))
-            }
-        })
-        .join("\n");
+        .extract_annotated_line_col((error_line, error_col), usize::MAX, usize::MAX)
+        .unwrap();
     TypeQLError::SyntaxErrorDetailed { error_line_nr, error_col, formatted_error }
 }
 
@@ -76,7 +70,7 @@ pub fn collect_err(i: impl IntoIterator<Item = Result<(), Error>>) -> Result<(),
 error_messages! { TypeQLError
     code: "TQL", type: "TypeQL Error",
     SyntaxErrorDetailed { error_line_nr: usize, error_col: usize, formatted_error: String } =
-        3: "There is a syntax error at {error_line_nr}:{error_col}:\n{formatted_error}",
+        3: "There is a syntax error near {error_line_nr}:{error_col}:\n{formatted_error}",
     InvalidCasting { enum_name: &'static str, variant: &'static str, expected_variant: &'static str, typename: &'static str } =
         4: "Enum '{enum_name}::{variant}' does not match '{expected_variant}', and cannot be unwrapped into '{typename}'.",
     InvalidLiteral { variant: &'static str, expected_variant: &'static str } =

--- a/rust/common/error/mod.rs
+++ b/rust/common/error/mod.rs
@@ -9,8 +9,7 @@ use std::{error::Error as StdError, fmt};
 use itertools::Itertools;
 use pest::error::{Error as PestError, LineColLocation};
 
-use crate::{error_messages, util::write_joined, Identifier};
-use crate::common::Spannable;
+use crate::{common::Spannable, error_messages, util::write_joined, Identifier};
 
 #[macro_use]
 mod macros;
@@ -46,9 +45,7 @@ pub(crate) fn syntax_error<T: pest::RuleType>(query: &str, error: PestError<T>) 
     };
     // error_line_nr is 1-indexed, we operate on 0-offset
     let error_line = error_line_nr - 1;
-    let formatted_error = query
-        .extract_annotated_line_col((error_line, error_col), usize::MAX, usize::MAX)
-        .unwrap();
+    let formatted_error = query.extract_annotated_line_col((error_line, error_col), usize::MAX, usize::MAX).unwrap();
     TypeQLError::SyntaxErrorDetailed { error_line_nr, error_col, formatted_error }
 }
 

--- a/rust/common/identifier.rs
+++ b/rust/common/identifier.rs
@@ -16,7 +16,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Identifier {
-    span: Option<Span>,
+    pub span: Option<Span>,
     ident: String,
 }
 

--- a/rust/common/mod.rs
+++ b/rust/common/mod.rs
@@ -91,7 +91,10 @@ impl Spannable for &str {
             .collect();
         if annotated {
             let lines_start = line.checked_sub(lines_before).unwrap_or(0);
-            let lines_end = min(lines.len(), line.checked_add(lines_after.checked_add(1).unwrap_or(usize::MAX)).unwrap_or(usize::MAX));
+            let lines_end = min(
+                lines.len(),
+                line.checked_add(lines_after.checked_add(1).unwrap_or(usize::MAX)).unwrap_or(usize::MAX),
+            );
             Some(lines[lines_start..lines_end].join("\n"))
         } else {
             None

--- a/rust/common/mod.rs
+++ b/rust/common/mod.rs
@@ -4,11 +4,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::cmp::min;
-use std::fmt::{Display, Formatter};
-use itertools::Itertools;
+use std::{
+    cmp::min,
+    fmt::{Display, Formatter},
+};
 
 pub use error::Error;
+use itertools::Itertools;
+
 use crate::common::error::{SYNTAX_ANNOTATED_INDENT, SYNTAX_ANNOTATED_INDICATOR_COL, SYNTAX_ANNOTATED_INDICATOR_LINE};
 
 pub mod date_time;
@@ -40,7 +43,12 @@ pub trait Spannable {
 
     fn line_col(&self, span: Span) -> Option<(LineColumn, LineColumn)>;
 
-    fn extract_annotated_line_col(&self, line_col: (usize, usize), lines_before: usize, lines_after: usize) -> Option<String>;
+    fn extract_annotated_line_col(
+        &self,
+        line_col: (usize, usize),
+        lines_before: usize,
+        lines_after: usize,
+    ) -> Option<String>;
 }
 
 impl Spannable for &str {
@@ -57,7 +65,12 @@ impl Spannable for &str {
         ))
     }
 
-    fn extract_annotated_line_col(&self, line_col: (usize, usize), lines_before: usize, lines_after: usize) -> Option<String> {
+    fn extract_annotated_line_col(
+        &self,
+        line_col: (usize, usize),
+        lines_before: usize,
+        lines_after: usize,
+    ) -> Option<String> {
         let (line, col) = line_col;
         let mut annotated = false;
         let lines: Vec<_> = self
@@ -68,7 +81,8 @@ impl Spannable for &str {
                     annotated = true;
                     format!(
                         "{SYNTAX_ANNOTATED_INDICATOR_LINE}{line_string}\n{}{SYNTAX_ANNOTATED_INDICATOR_COL}",
-                        " ".repeat(SYNTAX_ANNOTATED_INDENT + col))
+                        " ".repeat(SYNTAX_ANNOTATED_INDENT + col)
+                    )
                 } else {
                     format!("{}{line_string}", " ".repeat(SYNTAX_ANNOTATED_INDENT))
                 }

--- a/rust/common/mod.rs
+++ b/rust/common/mod.rs
@@ -45,7 +45,8 @@ pub trait Spannable {
 
     fn extract_annotated_line_col(
         &self,
-        line_col: (usize, usize),
+        line: usize,
+        col: usize,
         lines_before: usize,
         lines_after: usize,
     ) -> Option<String>;
@@ -67,11 +68,11 @@ impl Spannable for &str {
 
     fn extract_annotated_line_col(
         &self,
-        line_col: (usize, usize),
+        line: usize,
+        col: usize,
         lines_before: usize,
         lines_after: usize,
     ) -> Option<String> {
-        let (line, col) = line_col;
         let mut annotated = false;
         let lines: Vec<_> = self
             .lines()
@@ -90,7 +91,7 @@ impl Spannable for &str {
             .collect();
         if annotated {
             let lines_start = line.checked_sub(lines_before).unwrap_or(0);
-            let lines_end = min(lines.len(), line.checked_add(lines_after).unwrap_or(usize::MAX));
+            let lines_end = min(lines.len(), line.checked_add(lines_after.checked_add(1).unwrap_or(usize::MAX)).unwrap_or(usize::MAX));
             Some(lines[lines_start..lines_end].join("\n"))
         } else {
             None

--- a/rust/expression/mod.rs
+++ b/rust/expression/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct BuiltinFunctionName {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub token: token::Function,
 }
 
@@ -72,7 +72,7 @@ impl fmt::Display for FunctionName {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FunctionCall {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub name: FunctionName,
     pub args: Vec<Expression>,
 }
@@ -133,7 +133,7 @@ impl fmt::Display for Operation {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Paren {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub inner: Expression,
 }
 
@@ -159,7 +159,7 @@ impl fmt::Display for Paren {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ListIndex {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub variable: Variable,
     pub index: Expression,
 }
@@ -186,7 +186,7 @@ impl fmt::Display for ListIndex {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct List {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub items: Vec<Expression>,
 }
 
@@ -215,7 +215,7 @@ impl fmt::Display for List {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ListIndexRange {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub var: Variable,
     pub from: Expression,
     pub to: Expression,

--- a/rust/expression/mod.rs
+++ b/rust/expression/mod.rs
@@ -30,6 +30,12 @@ impl BuiltinFunctionName {
     }
 }
 
+impl Spanned for BuiltinFunctionName {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for BuiltinFunctionName {}
 
 impl fmt::Display for BuiltinFunctionName {
@@ -45,6 +51,15 @@ pub enum FunctionName {
 }
 
 impl Pretty for FunctionName {}
+
+impl Spanned for FunctionName {
+    fn span(&self) -> Option<Span> {
+        match self {
+            Self::Builtin(inner) => inner.span(),
+            Self::Identifier(inner) => inner.span(),
+        }
+    }
+}
 
 impl fmt::Display for FunctionName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/rust/parser/define/function.rs
+++ b/rust/parser/define/function.rs
@@ -104,10 +104,11 @@ pub(super) fn visit_return_reduce(node: Node<'_>) -> ReturnReduction {
 
 fn visit_return_reduce_reduction(node: Node<'_>) -> ReturnReduction {
     debug_assert_eq!(node.as_rule(), Rule::return_reduce_reduction);
+    let span = node.span();
     let mut children = node.into_children();
     let reduction = match children.peek_rule().unwrap() {
         Rule::CHECK => ReturnReduction::Check(Check::new(children.consume_expected(Rule::CHECK).span())),
-        Rule::reducer => ReturnReduction::Value(children.by_ref().map(visit_reducer).collect()),
+        Rule::reducer => ReturnReduction::Value(children.by_ref().map(visit_reducer).collect(), span),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: children.to_string() }),
     };
     debug_assert!(children.try_consume_any().is_none());

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -357,6 +357,7 @@ pub(super) fn visit_operator_stream(node: Node<'_>) -> Operator {
 
 fn visit_operator_reduce(node: Node<'_>) -> Reduce {
     debug_assert_eq!(node.as_rule(), Rule::operator_reduce);
+    let span = node.span();
     let mut children = node.into_children();
     let mut reduce_assignments = Vec::new();
     let mut group = None;
@@ -373,7 +374,7 @@ fn visit_operator_reduce(node: Node<'_>) -> Reduce {
         }
     }
     debug_assert_eq!(children.try_consume_any(), None);
-    Reduce::new(reduce_assignments, group)
+    Reduce::new(span, reduce_assignments, group)
 }
 
 pub(super) fn visit_reduce_assign(node: Node<'_>) -> ReduceAssign {

--- a/rust/parser/redefine.rs
+++ b/rust/parser/redefine.rs
@@ -9,10 +9,7 @@ use super::{
 };
 use crate::{
     common::{error::TypeQLError, Spanned},
-    parser::{
-        annotation::visit_annotations,
-        define::{function::visit_definition_function, struct_::visit_definition_struct},
-    },
+    parser::{annotation::visit_annotations, define::function::visit_definition_function},
     query::schema::Redefine,
     schema::definable::{Definable, Type},
 };

--- a/rust/parser/test/error.rs
+++ b/rust/parser/test/error.rs
@@ -88,7 +88,7 @@ fn test_syntax_error_pointer() {
     let parsed = parse_query("match\n$x of");
     assert!(parsed.is_err());
     let report = parsed.unwrap_err().to_string();
-    assert!(report.contains("at 2:4"), "{report}");
+    assert!(report.contains("near 2:3"), "{report}");
     assert!(report.contains("$x of"), "{report}");
 }
 
@@ -97,7 +97,7 @@ fn when_parsing_incorrect_syntax_trailing_query_whitespace_is_ignored() {
     let parsed = parse_query("match\n$x isa \n");
     assert!(parsed.is_err());
     let report = parsed.unwrap_err().to_string();
-    assert!(report.contains("at 2:7"), "{report}");
+    assert!(report.contains("near 2:6"), "{report}");
     assert!(report.contains("$x isa"), "{report}");
 }
 
@@ -114,6 +114,6 @@ fn when_parsing_incorrect_syntax_throw_typeql_syntax_exception_with_helpful_erro
     let parsed = parse_query("match\n$x isa");
     assert!(parsed.is_err());
     let report = parsed.unwrap_err().to_string();
-    assert!(report.contains("at 2:7"), "{report}");
+    assert!(report.contains("near 2:6"), "{report}");
     assert!(report.contains("$x isa"), "{report}");
 }

--- a/rust/parser/test/fetch.rs
+++ b/rust/parser/test/fetch.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::process::exit;
+
 use super::assert_valid_eq_repr;
 use crate::parse_query;
 
@@ -48,7 +50,14 @@ fetch {
 };"#;
     // TODO: Include list expression function
     // # "list expression function": [ all_names($x) ],
-    let parsed = parse_query(query).unwrap();
+    let parsed = parse_query(query);
+    let parsed = match parsed {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            println!("{}", err);
+            exit(1)
+        }
+    };
     // let projections: Vec<Projection> = vec![
     // var("d").into(),
     // var("d").label("date").into(),

--- a/rust/parser/test/match_queries.rs
+++ b/rust/parser/test/match_queries.rs
@@ -359,7 +359,7 @@ $x has release-date 1000-11-12T13:14:15.0001234567;"#;
 
     let parsed = parse_query(query);
     assert!(parsed.is_err());
-    assert!(parsed.unwrap_err().to_string().contains(" at 2:50"));
+    assert!(parsed.unwrap_err().to_string().contains(" near 2:49"));
 }
 
 #[test]

--- a/rust/pattern/mod.rs
+++ b/rust/pattern/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Conjunction {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub patterns: Vec<Pattern>,
 }
 
@@ -43,7 +43,7 @@ impl fmt::Display for Conjunction {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Negation {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub patterns: Vec<Pattern>,
 }
 
@@ -74,7 +74,7 @@ impl fmt::Display for Negation {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Optional {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub patterns: Vec<Pattern>,
 }
 
@@ -105,7 +105,7 @@ impl fmt::Display for Optional {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Disjunction {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub branches: Vec<Vec<Pattern>>,
 }
 

--- a/rust/query/pipeline/mod.rs
+++ b/rust/query/pipeline/mod.rs
@@ -18,7 +18,7 @@ pub mod stage;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Preamble {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub function: definable::Function,
 }
 
@@ -45,7 +45,7 @@ impl fmt::Display for Preamble {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Pipeline {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub preambles: Vec<Preamble>,
     pub stages: Vec<Stage>,
 }

--- a/rust/query/pipeline/stage/delete.rs
+++ b/rust/query/pipeline/stage/delete.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Delete {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub deletables: Vec<Deletable>,
 }
 
@@ -60,7 +60,7 @@ impl fmt::Display for Delete {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Deletable {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub kind: DeletableKind,
 }
 

--- a/rust/query/pipeline/stage/delete.rs
+++ b/rust/query/pipeline/stage/delete.rs
@@ -25,6 +25,12 @@ impl Delete {
     }
 }
 
+impl Spanned for Delete {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Delete {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", token::Clause::Delete)?;

--- a/rust/query/pipeline/stage/delete.rs
+++ b/rust/query/pipeline/stage/delete.rs
@@ -7,7 +7,7 @@
 use std::fmt::{self, Write};
 
 use crate::{
-    common::{token, Span},
+    common::{token, Span, Spanned},
     pretty::{indent, Pretty},
     statement::thing::Relation,
     variable::Variable,
@@ -61,6 +61,12 @@ pub struct Deletable {
 impl Deletable {
     pub fn new(span: Option<Span>, kind: DeletableKind) -> Self {
         Self { span, kind }
+    }
+}
+
+impl Spanned for Deletable {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/query/pipeline/stage/fetch.rs
+++ b/rust/query/pipeline/stage/fetch.rs
@@ -7,7 +7,7 @@
 use std::{fmt, fmt::Formatter};
 
 use crate::{
-    common::{token, Span},
+    common::{token, Span, Spanned},
     expression::{Expression, FunctionCall},
     pretty::{indent, Pretty},
     query::stage::Stage,
@@ -25,6 +25,12 @@ pub struct Fetch {
 impl Fetch {
     pub fn new(span: Option<Span>, object: FetchObject) -> Self {
         Self { span, object }
+    }
+}
+
+impl Spanned for Fetch {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -87,6 +93,12 @@ pub struct FetchObject {
 impl FetchObject {
     pub fn new(span: Option<Span>, body: FetchObjectBody) -> Self {
         Self { span, body }
+    }
+}
+
+impl Spanned for FetchObject {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -166,6 +178,12 @@ impl FetchObjectEntry {
     }
 }
 
+impl Spanned for FetchObjectEntry {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for FetchObjectEntry {
     fn fmt(&self, indent_level: usize, f: &mut Formatter<'_>) -> fmt::Result {
         indent(indent_level, f)?;
@@ -189,6 +207,12 @@ pub struct FetchList {
 impl FetchList {
     pub fn new(span: Option<Span>, stream: FetchStream) -> Self {
         Self { span, stream }
+    }
+}
+
+impl Spanned for FetchList {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -324,6 +348,12 @@ impl FetchAttribute {
 
     pub fn is_list(&self) -> bool {
         matches!(self.attribute, TypeRefAny::List(_))
+    }
+}
+
+impl Spanned for FetchAttribute {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/query/pipeline/stage/insert.rs
+++ b/rust/query/pipeline/stage/insert.rs
@@ -7,7 +7,7 @@
 use std::fmt::{self, Write};
 
 use crate::{
-    common::{token, Span},
+    common::{token, Span, Spanned},
     pretty::{indent, Pretty},
     statement::Statement,
 };
@@ -21,6 +21,12 @@ pub struct Insert {
 impl Insert {
     pub(crate) fn new(span: Option<Span>, statements: Vec<Statement>) -> Self {
         Self { span, statements }
+    }
+}
+
+impl Spanned for Insert {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/query/pipeline/stage/insert.rs
+++ b/rust/query/pipeline/stage/insert.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Insert {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub statements: Vec<Statement>,
 }
 

--- a/rust/query/pipeline/stage/match_.rs
+++ b/rust/query/pipeline/stage/match_.rs
@@ -7,7 +7,7 @@
 use std::fmt::{self, Write};
 
 use crate::{
-    common::{token, Span},
+    common::{token, Span, Spanned},
     pattern::Pattern,
     pretty::{indent, Pretty},
 };
@@ -30,6 +30,12 @@ impl Match {
     pub fn and(mut self, pattern: Pattern) -> Self {
         self.patterns.push(pattern);
         self
+    }
+}
+
+impl Spanned for Match {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/query/pipeline/stage/match_.rs
+++ b/rust/query/pipeline/stage/match_.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Match {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub patterns: Vec<Pattern>,
 }
 

--- a/rust/query/pipeline/stage/mod.rs
+++ b/rust/query/pipeline/stage/mod.rs
@@ -10,7 +10,11 @@ pub use self::{
     delete::Delete, fetch::Fetch, insert::Insert, match_::Match, modifier::Operator, put::Put, reduce::Reduce,
     update::Update,
 };
-use crate::{pretty::Pretty, util::enum_getter};
+use crate::{
+    common::{Span, Spanned},
+    pretty::Pretty,
+    util::enum_getter,
+};
 
 pub mod delete;
 pub mod fetch;
@@ -40,6 +44,20 @@ enum_getter! { Stage
     into_fetch(Fetch) => Fetch,
     into_delete(Delete) => Delete,
     into_modifier(Operator) => Operator,
+}
+
+impl Spanned for Stage {
+    fn span(&self) -> Option<Span> {
+        match self {
+            Self::Match(inner) => inner.span(),
+            Self::Insert(inner) => inner.span(),
+            Self::Put(inner) => inner.span(),
+            Self::Update(inner) => inner.span(),
+            Self::Fetch(inner) => inner.span(),
+            Self::Delete(inner) => inner.span(),
+            Self::Operator(inner) => inner.span(),
+        }
+    }
 }
 
 impl Pretty for Stage {

--- a/rust/query/pipeline/stage/modifier.rs
+++ b/rust/query/pipeline/stage/modifier.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Write};
 use crate::{
     common::{
         token::{self, Order},
-        Span,
+        Span, Spanned,
     },
     pretty::Pretty,
     query::stage::Reduce,
@@ -28,6 +28,12 @@ pub struct OrderedVariable {
 impl OrderedVariable {
     pub fn new(span: Option<Span>, variable: Variable, ordering: Option<Order>) -> Self {
         Self { span, variable, ordering }
+    }
+}
+
+impl Spanned for OrderedVariable {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -55,6 +61,12 @@ impl Sort {
     }
 }
 
+impl Spanned for Sort {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Sort {}
 
 impl fmt::Display for Sort {
@@ -75,6 +87,12 @@ pub struct Select {
 impl Select {
     pub fn new(span: Option<Span>, variables: Vec<Variable>) -> Self {
         Self { span, variables }
+    }
+}
+
+impl Spanned for Select {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -101,6 +119,12 @@ impl Offset {
     }
 }
 
+impl Spanned for Offset {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Offset {}
 
 impl fmt::Display for Offset {
@@ -121,6 +145,12 @@ impl Limit {
     }
 }
 
+impl Spanned for Limit {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Limit {}
 
 impl fmt::Display for Limit {
@@ -138,6 +168,12 @@ pub struct Require {
 impl Require {
     pub fn new(span: Option<Span>, variables: Vec<Variable>) -> Self {
         Self { span, variables }
+    }
+}
+
+impl Spanned for Require {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/query/pipeline/stage/modifier.rs
+++ b/rust/query/pipeline/stage/modifier.rs
@@ -20,7 +20,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct OrderedVariable {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub variable: Variable,
     pub ordering: Option<Order>,
 }
@@ -51,7 +51,7 @@ impl fmt::Display for OrderedVariable {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Sort {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub ordered_variables: Vec<OrderedVariable>,
 }
 
@@ -80,7 +80,7 @@ impl fmt::Display for Sort {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Select {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub variables: Vec<Variable>,
 }
 
@@ -109,7 +109,7 @@ impl fmt::Display for Select {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Offset {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub offset: IntegerLiteral,
 }
 
@@ -135,7 +135,7 @@ impl fmt::Display for Offset {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Limit {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub limit: IntegerLiteral,
 }
 
@@ -161,7 +161,7 @@ impl fmt::Display for Limit {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Require {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub variables: Vec<Variable>,
 }
 

--- a/rust/query/pipeline/stage/modifier.rs
+++ b/rust/query/pipeline/stage/modifier.rs
@@ -198,6 +198,19 @@ pub enum Operator {
     Require(Require),
 }
 
+impl Spanned for Operator {
+    fn span(&self) -> Option<Span> {
+        match self {
+            Self::Select(inner) => inner.span(),
+            Self::Sort(inner) => inner.span(),
+            Self::Offset(inner) => inner.span(),
+            Self::Limit(inner) => inner.span(),
+            Self::Reduce(inner) => inner.span(),
+            Self::Require(inner) => inner.span(),
+        }
+    }
+}
+
 impl Pretty for Operator {
     fn fmt(&self, indent_level: usize, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/rust/query/pipeline/stage/put.rs
+++ b/rust/query/pipeline/stage/put.rs
@@ -7,7 +7,7 @@
 use std::fmt::{self, Write};
 
 use crate::{
-    common::{token, Span},
+    common::{token, Span, Spanned},
     pretty::{indent, Pretty},
     statement::Statement,
 };
@@ -21,6 +21,12 @@ pub struct Put {
 impl Put {
     pub(crate) fn new(span: Option<Span>, statements: Vec<Statement>) -> Self {
         Self { span, statements }
+    }
+}
+
+impl Spanned for Put {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/query/pipeline/stage/put.rs
+++ b/rust/query/pipeline/stage/put.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Put {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub statements: Vec<Statement>,
 }
 

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Reduce {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub reduce_assignments: Vec<ReduceAssign>,
     pub groupby: Option<Vec<Variable>>,
 }
@@ -105,7 +105,7 @@ impl fmt::Display for Reducer {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Count {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub variable: Option<Variable>,
 }
 
@@ -135,7 +135,7 @@ impl fmt::Display for Count {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Stat {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub reduce_operator: token::ReduceOperator,
     pub variable: Variable,
 }

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -7,8 +7,9 @@
 use std::fmt;
 
 use crate::{
-    common::{token, Span},
+    common::{token, Span, Spanned},
     pretty::{indent, Pretty},
+    query::stage::modifier::Require,
     util::write_joined,
     variable::Variable,
 };
@@ -108,6 +109,12 @@ impl Count {
     }
 }
 
+impl Spanned for Count {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Count {}
 
 impl fmt::Display for Count {
@@ -130,6 +137,12 @@ pub struct Stat {
 impl Stat {
     pub fn new(span: Option<Span>, aggregate: token::ReduceOperator, variable: Variable) -> Self {
         Self { span, reduce_operator: aggregate, variable }
+    }
+}
+
+impl Spanned for Stat {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/query/pipeline/stage/reduce.rs
+++ b/rust/query/pipeline/stage/reduce.rs
@@ -9,20 +9,26 @@ use std::fmt;
 use crate::{
     common::{token, Span, Spanned},
     pretty::{indent, Pretty},
-    query::stage::modifier::Require,
     util::write_joined,
     variable::Variable,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Reduce {
+    span: Option<Span>,
     pub reduce_assignments: Vec<ReduceAssign>,
     pub groupby: Option<Vec<Variable>>,
 }
 
 impl Reduce {
-    pub fn new(reduce_assignments: Vec<ReduceAssign>, groupby: Option<Vec<Variable>>) -> Self {
-        Reduce { reduce_assignments, groupby: groupby }
+    pub fn new(span: Option<Span>, reduce_assignments: Vec<ReduceAssign>, groupby: Option<Vec<Variable>>) -> Self {
+        Reduce { span, reduce_assignments, groupby: groupby }
+    }
+}
+
+impl Spanned for Reduce {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/query/pipeline/stage/update.rs
+++ b/rust/query/pipeline/stage/update.rs
@@ -7,7 +7,7 @@
 use std::fmt::{self, Write};
 
 use crate::{
-    common::{token, Span},
+    common::{token, Span, Spanned},
     pretty::{indent, Pretty},
     statement::Statement,
 };
@@ -21,6 +21,12 @@ pub struct Update {
 impl Update {
     pub(crate) fn new(span: Option<Span>, statements: Vec<Statement>) -> Self {
         Self { span, statements }
+    }
+}
+
+impl Spanned for Update {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/query/pipeline/stage/update.rs
+++ b/rust/query/pipeline/stage/update.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Update {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub statements: Vec<Statement>,
 }
 

--- a/rust/query/schema/define.rs
+++ b/rust/query/schema/define.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Define {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub definables: Vec<Definable>,
 }
 

--- a/rust/query/schema/redefine.rs
+++ b/rust/query/schema/redefine.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Redefine {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub definables: Vec<Definable>,
 }
 

--- a/rust/query/schema/undefine.rs
+++ b/rust/query/schema/undefine.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Undefine {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub undefinables: Vec<Undefinable>,
 }
 

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -4,10 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    fmt::{self, Debug, Formatter, Write},
-    ptr::write,
-};
+use std::fmt::{self, Debug, Formatter, Write};
 
 use crate::{
     common::{identifier::Identifier, token, Span, Spanned},

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -283,7 +283,6 @@ impl ReturnStream {
     pub fn new(span: Option<Span>, vars: Vec<Variable>) -> Self {
         Self { span, vars }
     }
-
 }
 
 impl Spanned for ReturnStream {

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -283,7 +283,16 @@ impl ReturnStream {
     pub fn new(span: Option<Span>, vars: Vec<Variable>) -> Self {
         Self { span, vars }
     }
+
 }
+
+impl Spanned for ReturnStream {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
+impl Pretty for ReturnStream {}
 
 impl fmt::Display for ReturnStream {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -308,6 +317,14 @@ impl ReturnSingle {
         Self { span, selector, vars }
     }
 }
+
+impl Spanned for ReturnSingle {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
+impl Pretty for ReturnSingle {}
 
 impl fmt::Display for ReturnSingle {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -339,7 +356,16 @@ impl fmt::Display for SingleSelector {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ReturnReduction {
     Check(Check),
-    Value(Vec<Reducer>),
+    Value(Vec<Reducer>, Option<Span>),
+}
+
+impl Spanned for ReturnReduction {
+    fn span(&self) -> Option<Span> {
+        match self {
+            ReturnReduction::Check(check) => check.span(),
+            ReturnReduction::Value(_, span) => *span,
+        }
+    }
 }
 
 impl Pretty for ReturnReduction {
@@ -352,7 +378,7 @@ impl fmt::Display for ReturnReduction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Check(inner) => fmt::Display::fmt(inner, f),
-            Self::Value(inner) => {
+            Self::Value(inner, _) => {
                 write_joined!(f, ", ", inner)?;
                 Ok(())
             }
@@ -368,6 +394,12 @@ pub struct Check {
 impl Check {
     pub fn new(span: Option<Span>) -> Self {
         Self { span }
+    }
+}
+
+impl Spanned for Check {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -17,7 +17,7 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub signature: Signature,
     pub block: FunctionBlock,
     pub unparsed: String,
@@ -60,7 +60,7 @@ impl fmt::Display for Function {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Signature {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub ident: Identifier,
     pub args: Vec<Argument>,
     pub output: Output,
@@ -106,7 +106,7 @@ impl fmt::Display for Signature {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Argument {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub var: Variable,
     pub type_: TypeRefAny,
 }
@@ -159,7 +159,7 @@ impl fmt::Display for Output {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Stream {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub types: Vec<TypeRefAny>,
 }
 
@@ -187,7 +187,7 @@ impl fmt::Display for Stream {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Single {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub types: Vec<TypeRefAny>,
 }
 
@@ -275,7 +275,7 @@ impl fmt::Display for ReturnStatement {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReturnStream {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub vars: Vec<Variable>,
 }
 
@@ -298,7 +298,7 @@ impl fmt::Display for ReturnStream {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReturnSingle {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub selector: SingleSelector,
     pub vars: Vec<Variable>,
 }
@@ -362,7 +362,7 @@ impl fmt::Display for ReturnReduction {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Check {
-    span: Option<Span>,
+    pub span: Option<Span>,
 }
 
 impl Check {

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -32,6 +32,12 @@ impl Function {
     }
 }
 
+impl Spanned for Function {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Function {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         indent(indent_level, f)?;

--- a/rust/schema/definable/struct_.rs
+++ b/rust/schema/definable/struct_.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Struct {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub ident: Identifier,
     pub fields: Vec<Field>,
 }
@@ -62,7 +62,7 @@ impl fmt::Display for Struct {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Field {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub key: Identifier,
     pub type_: TypeRefAny,
 }

--- a/rust/schema/definable/struct_.rs
+++ b/rust/schema/definable/struct_.rs
@@ -12,6 +12,7 @@ use crate::{
     token,
     type_::TypeRefAny,
 };
+use crate::common::Spanned;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Struct {
@@ -23,6 +24,12 @@ pub struct Struct {
 impl Struct {
     pub fn new(span: Option<Span>, ident: Identifier, fields: Vec<Field>) -> Self {
         Self { span, ident, fields }
+    }
+}
+
+impl Spanned for Struct {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -64,6 +71,12 @@ pub struct Field {
 impl Field {
     pub fn new(span: Option<Span>, key: Identifier, type_: TypeRefAny) -> Self {
         Self { span, key, type_ }
+    }
+}
+
+impl Spanned for Field {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/schema/definable/struct_.rs
+++ b/rust/schema/definable/struct_.rs
@@ -7,12 +7,11 @@
 use std::{fmt, fmt::Formatter};
 
 use crate::{
-    common::{identifier::Identifier, Span},
+    common::{identifier::Identifier, Span, Spanned},
     pretty::{indent, Pretty},
     token,
     type_::TypeRefAny,
 };
-use crate::common::Spanned;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Struct {

--- a/rust/schema/definable/type_/capability.rs
+++ b/rust/schema/definable/type_/capability.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Alias {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub aliases: Vec<Label>,
 }
 
@@ -41,7 +41,7 @@ impl fmt::Display for Alias {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Sub {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub supertype_label: Label,
 }
 
@@ -71,7 +71,7 @@ impl fmt::Display for Sub {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ValueType {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub value_type: NamedType,
 }
 
@@ -97,7 +97,7 @@ impl fmt::Display for ValueType {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Owns {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub owned: TypeRefAny,
 }
 
@@ -124,7 +124,7 @@ impl fmt::Display for Owns {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Relates {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub related: TypeRefAny,
     pub specialised: Option<Label>,
 }
@@ -153,7 +153,7 @@ impl fmt::Display for Relates {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Plays {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub role: ScopedLabel,
 }
 

--- a/rust/schema/definable/type_/mod.rs
+++ b/rust/schema/definable/type_/mod.rs
@@ -19,7 +19,7 @@ pub mod capability;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Type {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub kind: Option<token::Kind>,
     pub label: Label,
     pub annotations: Vec<Annotation>,
@@ -88,7 +88,7 @@ impl fmt::Display for Type {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Capability {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub base: CapabilityBase,
     pub annotations: Vec<Annotation>,
 }

--- a/rust/schema/undefinable/mod.rs
+++ b/rust/schema/undefinable/mod.rs
@@ -8,12 +8,11 @@ use std::fmt;
 
 use super::definable::type_::CapabilityBase;
 use crate::{
-    common::{identifier::Identifier, token, Span},
+    common::{identifier::Identifier, token, Span, Spanned},
     pretty::Pretty,
     schema::definable::type_::capability::Relates,
     type_::Label,
 };
-use crate::common::Spanned;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Undefinable {

--- a/rust/schema/undefinable/mod.rs
+++ b/rust/schema/undefinable/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     schema::definable::type_::capability::Relates,
     type_::Label,
 };
+use crate::common::Spanned;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Undefinable {
@@ -55,6 +56,12 @@ impl AnnotationType {
     }
 }
 
+impl Spanned for AnnotationType {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for AnnotationType {}
 
 impl fmt::Display for AnnotationType {
@@ -82,6 +89,12 @@ impl AnnotationCapability {
     }
 }
 
+impl Spanned for AnnotationCapability {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for AnnotationCapability {}
 
 impl fmt::Display for AnnotationCapability {
@@ -100,6 +113,12 @@ pub struct CapabilityType {
 impl CapabilityType {
     pub fn new(span: Option<Span>, capability: CapabilityBase, type_: Label) -> Self {
         Self { span, capability, type_ }
+    }
+}
+
+impl Spanned for CapabilityType {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -122,6 +141,12 @@ pub struct Specialise {
 impl Specialise {
     pub fn new(span: Option<Span>, specialised: Label, type_: Label, relates: Relates) -> Self {
         Self { span, specialised, type_, capability: relates }
+    }
+}
+
+impl Spanned for Specialise {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -153,6 +178,12 @@ impl Function {
     }
 }
 
+impl Spanned for Function {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Function {}
 
 impl fmt::Display for Function {
@@ -170,6 +201,12 @@ pub struct Struct {
 impl Struct {
     pub fn new(span: Option<Span>, ident: Identifier) -> Self {
         Self { span, ident }
+    }
+}
+
+impl Spanned for Struct {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/schema/undefinable/mod.rs
+++ b/rust/schema/undefinable/mod.rs
@@ -44,7 +44,7 @@ impl fmt::Display for Undefinable {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AnnotationType {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub annotation_category: token::Annotation,
     pub type_: Label,
 }
@@ -71,7 +71,7 @@ impl fmt::Display for AnnotationType {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AnnotationCapability {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub annotation_category: token::Annotation,
     pub type_: Label,
     pub capability: CapabilityBase,
@@ -104,7 +104,7 @@ impl fmt::Display for AnnotationCapability {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CapabilityType {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub capability: CapabilityBase,
     pub type_: Label,
 }
@@ -131,7 +131,7 @@ impl fmt::Display for CapabilityType {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Specialise {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub specialised: Label,
     pub type_: Label,
     pub capability: Relates,
@@ -167,7 +167,7 @@ impl fmt::Display for Specialise {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub ident: Identifier,
 }
 
@@ -193,7 +193,7 @@ impl fmt::Display for Function {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Struct {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub ident: Identifier,
 }
 

--- a/rust/statement/comparison.rs
+++ b/rust/statement/comparison.rs
@@ -11,6 +11,7 @@ use crate::{
     expression::Expression,
     pretty::Pretty,
 };
+use crate::common::Spanned;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ComparisonStatement {
@@ -43,6 +44,12 @@ pub struct Comparison {
 impl Comparison {
     pub(crate) fn new(span: Option<Span>, comparator: token::Comparator, rhs: Expression) -> Self {
         Self { span, comparator, rhs }
+    }
+}
+
+impl Spanned for Comparison {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/statement/comparison.rs
+++ b/rust/statement/comparison.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ComparisonStatement {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub lhs: Expression,
     pub comparison: Comparison,
 }
@@ -41,7 +41,7 @@ impl fmt::Display for ComparisonStatement {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Comparison {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub comparator: token::Comparator,
     pub rhs: Expression,
 }

--- a/rust/statement/comparison.rs
+++ b/rust/statement/comparison.rs
@@ -7,11 +7,10 @@
 use std::fmt;
 
 use crate::{
-    common::{token, Span},
+    common::{token, Span, Spanned},
     expression::Expression,
     pretty::Pretty,
 };
-use crate::common::Spanned;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ComparisonStatement {

--- a/rust/statement/comparison.rs
+++ b/rust/statement/comparison.rs
@@ -25,6 +25,12 @@ impl ComparisonStatement {
     }
 }
 
+impl Spanned for ComparisonStatement {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for ComparisonStatement {}
 
 impl fmt::Display for ComparisonStatement {

--- a/rust/statement/mod.rs
+++ b/rust/statement/mod.rs
@@ -22,7 +22,7 @@ pub mod type_;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Is {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub lhs: Variable,
     pub rhs: Variable,
 }
@@ -49,7 +49,7 @@ impl fmt::Display for Is {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct InIterable {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub lhs: Vec<Variable>,
     pub rhs: Expression,
 }
@@ -102,7 +102,7 @@ impl fmt::Display for DeconstructField {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct StructDeconstruct {
-    span: Option<Span>,
+    pub span: Option<Span>,
     field_map: HashMap<Identifier, DeconstructField>,
 }
 
@@ -154,7 +154,7 @@ impl fmt::Display for AssignmentPattern {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Assignment {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub lhs: AssignmentPattern,
     pub rhs: Expression,
 }

--- a/rust/statement/mod.rs
+++ b/rust/statement/mod.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, fmt};
 use self::comparison::ComparisonStatement;
 pub use self::{thing::Thing, type_::Type};
 use crate::{
-    common::{identifier::Identifier, token, Span},
+    common::{identifier::Identifier, token, Span, Spanned},
     expression::Expression,
     pretty::{indent, Pretty},
     util::write_joined,
@@ -33,6 +33,12 @@ impl Is {
     }
 }
 
+impl Spanned for Is {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Is {}
 
 impl fmt::Display for Is {
@@ -51,6 +57,12 @@ pub struct InIterable {
 impl InIterable {
     pub(crate) fn new(span: Option<Span>, lhs: Vec<Variable>, rhs: Expression) -> Self {
         Self { span, lhs, rhs }
+    }
+}
+
+impl Spanned for InIterable {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -100,6 +112,12 @@ impl StructDeconstruct {
     }
 }
 
+impl Spanned for StructDeconstruct {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for StructDeconstruct {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         indent(indent_level, f)?;
@@ -144,6 +162,12 @@ pub struct Assignment {
 impl Assignment {
     pub fn new(span: Option<Span>, lhs: AssignmentPattern, rhs: Expression) -> Self {
         Self { span, lhs, rhs }
+    }
+}
+
+impl Spanned for Assignment {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/statement/mod.rs
+++ b/rust/statement/mod.rs
@@ -189,6 +189,19 @@ pub enum Statement {
     Type(Type),
 }
 
+impl Spanned for Statement {
+    fn span(&self) -> Option<Span> {
+        match self {
+            Statement::Is(inner) => inner.span(),
+            Statement::InIterable(inner) => inner.span(),
+            Statement::Comparison(inner) => inner.span(),
+            Statement::Assignment(inner) => inner.span(),
+            Statement::Thing(inner) => inner.span(),
+            Statement::Type(inner) => inner.span(),
+        }
+    }
+}
+
 impl Pretty for Statement {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/rust/statement/thing/isa.rs
+++ b/rust/statement/thing/isa.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 
 use crate::{
-    common::{token, Span},
+    common::{token, Span, Spanned},
     pretty::Pretty,
     statement::{comparison::Comparison, thing::Relation},
     type_::TypeRef,
@@ -26,6 +26,12 @@ pub struct Isa {
 impl Isa {
     pub fn new(span: Option<Span>, kind: IsaKind, type_: TypeRef, constraint: Option<IsaInstanceConstraint>) -> Self {
         Self { span, kind, type_, constraint }
+    }
+}
+
+impl Spanned for Isa {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/statement/thing/isa.rs
+++ b/rust/statement/thing/isa.rs
@@ -11,7 +11,6 @@ use crate::{
     pretty::Pretty,
     statement::{comparison::Comparison, thing::Relation},
     type_::TypeRef,
-    value::ValueLiteral,
     Expression, Literal,
 };
 

--- a/rust/statement/thing/isa.rs
+++ b/rust/statement/thing/isa.rs
@@ -16,7 +16,7 @@ use crate::{
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Isa {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub kind: IsaKind,
     pub type_: TypeRef,
     pub constraint: Option<IsaInstanceConstraint>,

--- a/rust/statement/thing/mod.rs
+++ b/rust/statement/thing/mod.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Write};
 use self::isa::Isa;
 use super::{comparison, Statement};
 use crate::{
-    common::{token, Span},
+    common::{token, Span, Spanned},
     expression::Expression,
     pretty::{indent, Pretty},
     type_::TypeRefAny,
@@ -37,6 +37,12 @@ impl Thing {
 impl From<Thing> for Statement {
     fn from(val: Thing) -> Self {
         Statement::Thing(val)
+    }
+}
+
+impl Spanned for Thing {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -104,6 +110,12 @@ pub struct Relation {
 impl Relation {
     pub(crate) fn new(span: Option<Span>, role_players: Vec<RolePlayer>) -> Self {
         Self { span, role_players }
+    }
+}
+
+impl Spanned for Relation {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -177,6 +189,12 @@ impl Iid {
     }
 }
 
+impl Spanned for Iid {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Iid {}
 
 impl fmt::Display for Iid {
@@ -195,6 +213,12 @@ pub struct Has {
 impl Has {
     pub fn new(span: Option<Span>, type_: Option<TypeRefAny>, value: HasValue) -> Self {
         Self { span, type_, value }
+    }
+}
+
+impl Spanned for Has {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -247,6 +271,12 @@ pub struct Links {
 impl Links {
     pub fn new(span: Option<Span>, relation: Relation) -> Self {
         Self { span, relation }
+    }
+}
+
+impl Spanned for Links {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/statement/thing/mod.rs
+++ b/rust/statement/thing/mod.rs
@@ -14,7 +14,6 @@ use crate::{
     pretty::{indent, Pretty},
     type_::TypeRefAny,
     util::write_joined,
-    value::Literal,
     variable::Variable,
     TypeRef,
 };

--- a/rust/statement/thing/mod.rs
+++ b/rust/statement/thing/mod.rs
@@ -22,7 +22,7 @@ pub mod isa;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Thing {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub head: Head,
     pub constraints: Vec<Constraint>,
 }
@@ -102,7 +102,7 @@ impl fmt::Display for Head {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Relation {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub role_players: Vec<RolePlayer>,
 }
 
@@ -178,7 +178,7 @@ impl fmt::Display for Constraint {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Iid {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub iid: String,
 }
 
@@ -204,7 +204,7 @@ impl fmt::Display for Iid {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Has {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub type_: Option<TypeRefAny>,
     pub value: HasValue,
 }
@@ -263,7 +263,7 @@ impl fmt::Display for HasValue {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Links {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub relation: Relation,
 }
 

--- a/rust/statement/type_.rs
+++ b/rust/statement/type_.rs
@@ -8,7 +8,7 @@ use std::fmt::{self, Write};
 
 use crate::{
     annotation::Annotation,
-    common::{token, Span},
+    common::{token, Span, Spanned},
     pretty::{indent, Pretty},
     type_::{Label, NamedType, ScopedLabel, TypeRef, TypeRefAny},
 };
@@ -24,6 +24,12 @@ pub struct Type {
 impl Type {
     pub fn new(span: Option<Span>, kind: Option<token::Kind>, type_: TypeRefAny, constraints: Vec<Constraint>) -> Self {
         Self { span, kind, type_, constraints }
+    }
+}
+
+impl Spanned for Type {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -66,6 +72,12 @@ pub struct Constraint {
 impl Constraint {
     pub fn new(span: Option<Span>, base: ConstraintBase, annotations: Vec<Annotation>) -> Self {
         Self { span, base, annotations }
+    }
+}
+
+impl Spanned for Constraint {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -165,6 +177,12 @@ impl Sub {
     }
 }
 
+impl Spanned for Sub {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Sub {}
 
 impl fmt::Display for Sub {
@@ -185,6 +203,12 @@ impl ValueType {
     }
 }
 
+impl Spanned for ValueType {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for ValueType {}
 
 impl fmt::Display for ValueType {
@@ -202,6 +226,12 @@ pub struct Owns {
 impl Owns {
     pub fn new(span: Option<Span>, owned: TypeRefAny) -> Self {
         Self { span, owned }
+    }
+}
+
+impl Spanned for Owns {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 
@@ -227,6 +257,12 @@ impl Relates {
     }
 }
 
+impl Spanned for Relates {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
 impl Pretty for Relates {}
 
 impl fmt::Display for Relates {
@@ -248,6 +284,12 @@ pub struct Plays {
 impl Plays {
     pub fn new(span: Option<Span>, role: TypeRef) -> Self {
         Self { span, role }
+    }
+}
+
+impl Spanned for Plays {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/statement/type_.rs
+++ b/rust/statement/type_.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Type {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub kind: Option<token::Kind>,
     pub type_: TypeRefAny,
     pub constraints: Vec<Constraint>,
@@ -64,7 +64,7 @@ impl fmt::Display for Type {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Constraint {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub base: ConstraintBase,
     pub annotations: Vec<Annotation>,
 }
@@ -166,7 +166,7 @@ impl fmt::Display for SubKind {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Sub {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub kind: SubKind,
     pub supertype: TypeRefAny,
 }
@@ -193,7 +193,7 @@ impl fmt::Display for Sub {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ValueType {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub value_type: NamedType,
 }
 
@@ -219,7 +219,7 @@ impl fmt::Display for ValueType {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Owns {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub owned: TypeRefAny,
 }
 
@@ -246,7 +246,7 @@ impl fmt::Display for Owns {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Relates {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub related: TypeRefAny,
     pub specialised: Option<TypeRef>,
 }
@@ -277,7 +277,7 @@ impl fmt::Display for Relates {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Plays {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub role: TypeRef,
 }
 

--- a/rust/type_.rs
+++ b/rust/type_.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct BuiltinValueType {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub token: token::ValueType,
 }
 
@@ -40,7 +40,7 @@ impl fmt::Display for BuiltinValueType {
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Label {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub ident: Identifier,
 }
 
@@ -66,7 +66,7 @@ impl fmt::Display for Label {
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ScopedLabel {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub scope: Label,
     pub name: Label,
 }
@@ -174,7 +174,7 @@ impl fmt::Display for TypeRefAny {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Optional {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub inner: TypeRef,
 }
 
@@ -199,7 +199,7 @@ impl fmt::Display for Optional {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct List {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub inner: TypeRef,
 }
 

--- a/rust/type_.rs
+++ b/rust/type_.rs
@@ -124,6 +124,15 @@ pub enum TypeRef {
     Variable(Variable), // $t
 }
 
+impl Spanned for TypeRef {
+    fn span(&self) -> Option<Span> {
+        match self {
+            Self::Named(named) => named.span(),
+            Self::Variable(var) => var.span(),
+        }
+    }
+}
+
 impl Pretty for TypeRef {}
 
 impl fmt::Display for TypeRef {
@@ -143,6 +152,15 @@ pub enum TypeRefAny {
 }
 
 impl Pretty for TypeRefAny {}
+impl Spanned for TypeRefAny {
+    fn span(&self) -> Option<Span> {
+        match self {
+            Self::Type(inner) => inner.span(),
+            Self::Optional(inner) => inner.span(),
+            Self::List(inner) => inner.span(),
+        }
+    }
+}
 
 impl fmt::Display for TypeRefAny {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -165,6 +183,11 @@ impl Optional {
         Self { span, inner }
     }
 }
+impl Spanned for Optional {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
 
 impl Pretty for Optional {}
 
@@ -183,6 +206,12 @@ pub struct List {
 impl List {
     pub fn new(span: Option<Span>, inner: TypeRef) -> Self {
         Self { span, inner }
+    }
+}
+
+impl Spanned for List {
+    fn span(&self) -> Option<Span> {
+        self.span
     }
 }
 

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Formatter};
 use crate::{
     common::{error::TypeQLError, Span, Spanned},
     pretty::Pretty,
-    token, Result,
+    Result,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -136,7 +136,7 @@ pub enum ValueLiteral {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Literal {
-    span: Option<Span>,
+    pub span: Option<Span>,
     pub inner: ValueLiteral,
 }
 


### PR DESCRIPTION
## Usage and product changes

We improve the error messages to show a `^` column indicator along with `-->` line indicator:
```
        define
        attribute name value string;
-->     entity person owns name @range(0..10);
                                ^
```

We also expose more information about where in the original query spans which sourced various internal data structures.


## Implementation

* Improve error message printing
* Include further information about `Span`s throughout TypeQL data structures