### PR TITLE
Restrict by grammar refactoring type_ref and named_type

### DIFF
--- a/rust/parser/define/struct_.rs
+++ b/rust/parser/define/struct_.rs
@@ -11,7 +11,7 @@ use crate::{
         visit_identifier, IntoChildNodes, Node, Rule, RuleMatcher,
     },
     schema::definable::{struct_::Field, Struct},
-    type_::TypeRefAny,
+    type_::{NamedType, NamedTypeAny, TypeRefAny},
     TypeRef,
 };
 
@@ -42,12 +42,12 @@ fn visit_definition_struct_field(node: Node<'_>) -> Field {
     Field::new(span, key, type_)
 }
 
-fn visit_struct_field_value_type(node: Node<'_>) -> TypeRefAny {
+fn visit_struct_field_value_type(node: Node<'_>) -> NamedTypeAny {
     debug_assert_eq!(node.as_rule(), Rule::struct_field_value_type);
     let child = node.into_child();
     match child.as_rule() {
-        Rule::value_type => TypeRefAny::Type(TypeRef::Named(visit_value_type(child))),
-        Rule::value_type_optional => TypeRefAny::Optional(visit_value_type_optional(child)),
+        Rule::value_type => NamedTypeAny::Simple(visit_value_type(child)),
+        Rule::value_type_optional => NamedTypeAny::Optional(visit_value_type_optional(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     }
 }

--- a/rust/parser/define/type_.rs
+++ b/rust/parser/define/type_.rs
@@ -89,7 +89,7 @@ fn visit_owns_declaration(node: Node<'_>) -> Owns {
     let owned_label = children.consume_any();
     let owned = match owned_label.as_rule() {
         Rule::label_list => TypeRefAny::List(visit_label_list(owned_label)),
-        Rule::label => TypeRefAny::Type(TypeRef::Named(NamedType::Label(visit_label(owned_label)))),
+        Rule::label => TypeRefAny::Type(TypeRef::Label(visit_label(owned_label))),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: owned_label.to_string() }),
     };
 
@@ -106,7 +106,7 @@ pub(in crate::parser) fn visit_relates_declaration(node: Node<'_>) -> Relates {
     let related_label = children.consume_any();
     let related = match related_label.as_rule() {
         Rule::label_list => TypeRefAny::List(visit_label_list(related_label)),
-        Rule::label => TypeRefAny::Type(TypeRef::Named(NamedType::Label(visit_label(related_label)))),
+        Rule::label => TypeRefAny::Type(TypeRef::Label(visit_label(related_label))),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: related_label.to_string() }),
     };
     let specialised = if children.try_consume_expected(Rule::AS).is_some() {

--- a/rust/parser/pipeline.rs
+++ b/rust/parser/pipeline.rs
@@ -275,7 +275,7 @@ fn visit_fetch_attribute(node: Node<'_>) -> FetchAttribute {
     let child = children.consume_any();
     let attribute = match child.as_rule() {
         Rule::label_list => TypeRefAny::List(visit_label_list(child)),
-        Rule::label => TypeRefAny::Type(TypeRef::Named(NamedType::Label(visit_label(child)))),
+        Rule::label => TypeRefAny::Type(TypeRef::Label(visit_label(child))),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.to_string() }),
     };
     debug_assert_eq!(children.try_consume_any(), None);

--- a/rust/parser/statement/type_.rs
+++ b/rust/parser/statement/type_.rs
@@ -8,9 +8,7 @@ use crate::{
     common::{error::TypeQLError, Spanned},
     parser::{
         annotation::visit_annotations,
-        type_::{
-            visit_label, visit_label_scoped, visit_type_ref, visit_type_ref_any, visit_type_ref_list, visit_value_type,
-        },
+        type_::{visit_label, visit_label_scoped, visit_type_ref, visit_type_ref_list, visit_value_type},
         visit_kind, IntoChildNodes, Node, Rule, RuleMatcher,
     },
     statement::{
@@ -25,7 +23,7 @@ pub(super) fn visit_statement_type(node: Node<'_>) -> Statement {
     let span = node.span();
     let mut children = node.into_children();
     let kind = children.try_consume_expected(Rule::kind).map(visit_kind);
-    let type_ = visit_type_ref_any(children.consume_expected(Rule::type_ref_any));
+    let type_ = visit_type_ref(children.consume_expected(Rule::type_ref));
     let constraints = children.map(visit_type_constraint).collect();
     Statement::Type(Type::new(span, kind, type_, constraints))
 }
@@ -59,7 +57,7 @@ fn visit_sub_constraint(node: Node<'_>) -> Sub {
     let span = node.span();
     let mut children = node.into_children();
     let kind = visit_sub_token(children.consume_expected(Rule::SUB_));
-    let supertype = visit_type_ref_any(children.consume_expected(Rule::type_ref_any));
+    let supertype = visit_type_ref(children.consume_expected(Rule::type_ref));
     debug_assert_eq!(children.try_consume_any(), None);
     Sub::new(span, kind, supertype)
 }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -75,7 +75,7 @@ statement = { statement_single | statement_type | statement_thing }
 // TYPE STATEMENTS =============================================================
 
 statement_type = { kind ~ type_ref ~ ( type_constraint ~ ( COMMA ~ type_constraint )* ~ COMMA? )?
-                 | type_ref~ type_constraint ~ ( COMMA ~ type_constraint )* ~ COMMA?
+                 | type_ref ~ type_constraint ~ ( COMMA ~ type_constraint )* ~ COMMA?
                  }
 type_constraint = { type_constraint_base ~ annotations? }
 type_constraint_base = { sub_constraint | value_type_constraint | label_constraint

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -74,15 +74,15 @@ statement = { statement_single | statement_type | statement_thing }
 
 // TYPE STATEMENTS =============================================================
 
-statement_type = { kind ~ type_ref_any ~ ( type_constraint ~ ( COMMA ~ type_constraint )* ~ COMMA? )?
-                 | type_ref_any ~ type_constraint ~ ( COMMA ~ type_constraint )* ~ COMMA?
+statement_type = { kind ~ type_ref ~ ( type_constraint ~ ( COMMA ~ type_constraint )* ~ COMMA? )?
+                 | type_ref~ type_constraint ~ ( COMMA ~ type_constraint )* ~ COMMA?
                  }
 type_constraint = { type_constraint_base ~ annotations? }
 type_constraint_base = { sub_constraint | value_type_constraint | label_constraint
                        | owns_constraint | relates_constraint | plays_constraint
                        }
 
-sub_constraint = { SUB_ ~ type_ref_any }
+sub_constraint = { SUB_ ~ type_ref }
 value_type_constraint = { VALUE ~ value_type }
 label_constraint = { LABEL ~ ( label_scoped | label ) }
 owns_constraint = { OWNS ~ type_ref_list
@@ -277,12 +277,10 @@ undefine_struct = { STRUCT ~ identifier }
 
 // TYPE, LABEL AND IDENTIFIER CONSTRUCTS =======================================
 
-type_ref = { named_type | var }
-type_ref_optional = { type_ref ~ QUESTION }
+type_ref = { label_scoped | label | var }
 type_ref_list = { type_ref ~ SQ_BRACKET_OPEN ~ SQ_BRACKET_CLOSE }
-type_ref_any = { type_ref_optional | type_ref_list | type_ref }
 
-named_type = { value_type_primitive | label_scoped | label }
+named_type = { value_type_primitive | label }
 named_type_optional = { named_type ~ QUESTION }
 named_type_list = { named_type ~ SQ_BRACKET_OPEN ~ SQ_BRACKET_CLOSE }
 named_type_any = { named_type_optional | named_type_list | named_type }

--- a/rust/schema/definable/function.rs
+++ b/rust/schema/definable/function.rs
@@ -10,7 +10,7 @@ use crate::{
     common::{identifier::Identifier, token, Span, Spanned},
     pretty::{indent, Pretty},
     query::stage::{reduce::Reducer, Stage},
-    type_::TypeRefAny,
+    type_::{NamedTypeAny, TypeRefAny},
     util::write_joined,
     variable::Variable,
 };
@@ -108,11 +108,11 @@ impl fmt::Display for Signature {
 pub struct Argument {
     pub span: Option<Span>,
     pub var: Variable,
-    pub type_: TypeRefAny,
+    pub type_: NamedTypeAny,
 }
 
 impl Argument {
-    pub fn new(span: Option<Span>, var: Variable, type_: TypeRefAny) -> Self {
+    pub fn new(span: Option<Span>, var: Variable, type_: NamedTypeAny) -> Self {
         Self { span, var, type_ }
     }
 }
@@ -160,11 +160,11 @@ impl fmt::Display for Output {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Stream {
     pub span: Option<Span>,
-    pub types: Vec<TypeRefAny>,
+    pub types: Vec<NamedTypeAny>,
 }
 
 impl Stream {
-    pub fn new(span: Option<Span>, types: Vec<TypeRefAny>) -> Self {
+    pub fn new(span: Option<Span>, types: Vec<NamedTypeAny>) -> Self {
         Self { span, types }
     }
 }
@@ -188,11 +188,11 @@ impl fmt::Display for Stream {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Single {
     pub span: Option<Span>,
-    pub types: Vec<TypeRefAny>,
+    pub types: Vec<NamedTypeAny>,
 }
 
 impl Single {
-    pub fn new(span: Option<Span>, types: Vec<TypeRefAny>) -> Self {
+    pub fn new(span: Option<Span>, types: Vec<NamedTypeAny>) -> Self {
         Self { span, types }
     }
 }

--- a/rust/schema/definable/struct_.rs
+++ b/rust/schema/definable/struct_.rs
@@ -10,7 +10,7 @@ use crate::{
     common::{identifier::Identifier, Span, Spanned},
     pretty::{indent, Pretty},
     token,
-    type_::TypeRefAny,
+    type_::{NamedTypeAny, TypeRefAny},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -64,11 +64,11 @@ impl fmt::Display for Struct {
 pub struct Field {
     pub span: Option<Span>,
     pub key: Identifier,
-    pub type_: TypeRefAny,
+    pub type_: NamedTypeAny,
 }
 
 impl Field {
-    pub fn new(span: Option<Span>, key: Identifier, type_: TypeRefAny) -> Self {
+    pub fn new(span: Option<Span>, key: Identifier, type_: NamedTypeAny) -> Self {
         Self { span, key, type_ }
     }
 }

--- a/rust/statement/type_.rs
+++ b/rust/statement/type_.rs
@@ -17,12 +17,12 @@ use crate::{
 pub struct Type {
     pub span: Option<Span>,
     pub kind: Option<token::Kind>,
-    pub type_: TypeRefAny,
+    pub type_: TypeRef,
     pub constraints: Vec<Constraint>,
 }
 
 impl Type {
-    pub fn new(span: Option<Span>, kind: Option<token::Kind>, type_: TypeRefAny, constraints: Vec<Constraint>) -> Self {
+    pub fn new(span: Option<Span>, kind: Option<token::Kind>, type_: TypeRef, constraints: Vec<Constraint>) -> Self {
         Self { span, kind, type_, constraints }
     }
 }
@@ -168,11 +168,11 @@ impl fmt::Display for SubKind {
 pub struct Sub {
     pub span: Option<Span>,
     pub kind: SubKind,
-    pub supertype: TypeRefAny,
+    pub supertype: TypeRef,
 }
 
 impl Sub {
-    pub fn new(span: Option<Span>, kind: SubKind, supertype: TypeRefAny) -> Self {
+    pub fn new(span: Option<Span>, kind: SubKind, supertype: TypeRef) -> Self {
         Self { span, kind, supertype }
     }
 }


### PR DESCRIPTION
## Usage and product changes
Restrict by grammar refactoring type_ref and named_type

## Implementation
We notice the two distinct uses of `type_ref` and `named_type` and decide to separate them, allowing for less inapplicable cases during translation to server IR.
