### PR TITLE
Allow duration literals without date component

### DIFF
--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -557,7 +557,7 @@ date_literal = ${ date_fragment ~ WB }
 datetime_literal = ${ date_fragment ~ "T" ~ time ~ WB }
 datetime_tz_literal = ${ date_fragment ~ "T" ~ time ~ ( " " ~ iana_timezone | iso8601_timezone_offset ) ~ WB }
 
-duration_literal = ${ "P" ~ ( duration_weeks | duration_date ~ ( "T" ~ duration_time )? ) ~ WB}
+duration_literal = ${ "P" ~ ( duration_weeks | duration_date ~ ( "T" ~ duration_time )? | "T" ~ duration_time ) ~ WB}
 
 quoted_string_literal = @{ "\"" ~ ( !"\"" ~ !"\\" ~ ANY | escape_seq )* ~ "\""
                          | "'" ~ ( !"'" ~ !"\\" ~ ANY | escape_seq )* ~ "'" }


### PR DESCRIPTION
## Usage and product changes

We modify the grammar to accept a `duration_literal` without a date component (e.g. `PT1S`) as per the standard. 

## Implementation

The valid duration literals are:

- `"P" ~ duration_weeks` 
- `"P" ~ duration_date`
- `"P" ~ duration_date ~ "T" ~ duration_time`
- `"PT" ~ duration_time`

The last option was missing from the grammar.