### PR TITLE
Allow relates overrides to have lists

### DIFF
--- a/rust/parser/define/type_.rs
+++ b/rust/parser/define/type_.rs
@@ -110,7 +110,13 @@ pub(in crate::parser) fn visit_relates_declaration(node: Node<'_>) -> Relates {
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: related_label.to_string() }),
     };
     let specialised = if children.try_consume_expected(Rule::AS).is_some() {
-        Some(visit_label(children.consume_expected(Rule::label)))
+        let node = children.consume_any();
+        let specialised = match node.as_rule() {
+            Rule::label_list => TypeRefAny::List(visit_label_list(node)),
+            Rule::label => TypeRefAny::Type(TypeRef::Label(visit_label(node))),
+            _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: node.to_string() }),
+        };
+        Some(specialised)
     } else {
         None
     };

--- a/rust/parser/statement/type_.rs
+++ b/rust/parser/statement/type_.rs
@@ -127,7 +127,13 @@ fn visit_relates_constraint(node: Node<'_>) -> Relates {
     };
 
     let specialised = if children.try_consume_expected(Rule::AS).is_some() {
-        Some(visit_type_ref(children.consume_expected(Rule::type_ref)))
+        let next = children.consume_any();
+        let specialised = match next.as_rule() {
+            Rule::type_ref => TypeRefAny::Type(visit_type_ref(next)),
+            Rule::type_ref_list => TypeRefAny::List(visit_type_ref_list(next)),
+            _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: next.to_string() }),
+        };
+        Some(specialised)
     } else {
         None
     };

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -125,18 +125,3 @@ reduce $c1 = count($x);"#;
     // let expected = typeql_match!(var("x").isa("movie")).count();
     assert_valid_eq_repr!(expected, parsed, uncommented);
 }
-
-#[test]
-fn tmp() {
-    let query = r#"define
-    relation light, relates color[];
-    relation traffic-light, relates tlight[] as color[];"#;
-    let parsed = match parse_query(query) {
-        Ok(parsed) => parsed,
-        Err(err) => {
-            println!("{}", err);
-            panic!("")
-        }
-    };
-    // let expected = typeql_match!(var("x").isa("movie")).count();
-}

--- a/rust/parser/test/mod.rs
+++ b/rust/parser/test/mod.rs
@@ -125,3 +125,18 @@ reduce $c1 = count($x);"#;
     // let expected = typeql_match!(var("x").isa("movie")).count();
     assert_valid_eq_repr!(expected, parsed, uncommented);
 }
+
+#[test]
+fn tmp() {
+    let query = r#"define
+    relation light, relates color[];
+    relation traffic-light, relates tlight[] as color[];"#;
+    let parsed = match parse_query(query) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            println!("{}", err);
+            panic!("")
+        }
+    };
+    // let expected = typeql_match!(var("x").isa("movie")).count();
+}

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -211,7 +211,7 @@ owns_declaration = { OWNS ~ label_list
                    | OWNS ~ label
                    }
 plays_declaration = { PLAYS ~ label_scoped }
-relates_declaration = { RELATES ~ label_list
+relates_declaration = { RELATES ~ label_list ~ ( AS ~ label_list )?
                       | RELATES ~ label ~ ( AS ~ label )?
                       }
 

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -91,7 +91,7 @@ label_constraint = { LABEL ~ ( label_scoped | label ) }
 owns_constraint = { OWNS ~ type_ref_list
                   | OWNS ~ type_ref
                   }
-relates_constraint = { RELATES ~ type_ref_list
+relates_constraint = { RELATES ~ type_ref_list ~ ( AS ~ type_ref_list )?
                      | RELATES ~ type_ref ~ ( AS ~ type_ref )?
                      }
 plays_constraint = { PLAYS ~ type_ref }

--- a/rust/schema/definable/type_/capability.rs
+++ b/rust/schema/definable/type_/capability.rs
@@ -126,11 +126,11 @@ impl fmt::Display for Owns {
 pub struct Relates {
     pub span: Option<Span>,
     pub related: TypeRefAny,
-    pub specialised: Option<Label>,
+    pub specialised: Option<TypeRefAny>,
 }
 
 impl Relates {
-    pub fn new(span: Option<Span>, related: TypeRefAny, specialised: Option<Label>) -> Self {
+    pub fn new(span: Option<Span>, related: TypeRefAny, specialised: Option<TypeRefAny>) -> Self {
         Self { span, related, specialised }
     }
 }

--- a/rust/statement/type_.rs
+++ b/rust/statement/type_.rs
@@ -248,11 +248,11 @@ impl fmt::Display for Owns {
 pub struct Relates {
     pub span: Option<Span>,
     pub related: TypeRefAny,
-    pub specialised: Option<TypeRef>,
+    pub specialised: Option<TypeRefAny>,
 }
 
 impl Relates {
-    pub fn new(span: Option<Span>, related: TypeRefAny, specialised: Option<TypeRef>) -> Self {
+    pub fn new(span: Option<Span>, related: TypeRefAny, specialised: Option<TypeRefAny>) -> Self {
         Self { span, related, specialised }
     }
 }


### PR DESCRIPTION
## Product change and motivation

We fix one syntactic inconsistency, grammatically allowing list overrides for relation's roles:
```
define
  relation sub-rel, relates sub-role[] as super-role[];
```


## Implementation

We relax the grammar to allow specialisations of relation's roles with ordering.