### PR TITLE
Update TypeDB Rust dependencies

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -8,7 +8,7 @@ def typedb_dependencies():
     git_repository(
         name = "typedb_dependencies",
         remote = "https://github.com/typedb/typedb-dependencies",
-        commit = "ab777bf067b1930e35146fd8e25a76a4a360aa74", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        commit = "f6e710f9857b1c30ad1764c1c41afce4e4e02981", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typedb_behaviour():

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dev-dependencies.tokio]
 		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.44.2"
+		version = "1.47.1"
 		default-features = false
 
 	[dev-dependencies.cucumber]
@@ -26,12 +26,12 @@ features = {}
 
 	[dev-dependencies.syn]
 		features = ["clone-impls", "default", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "visit", "visit-mut"]
-		version = "2.0.100"
+		version = "2.0.106"
 		default-features = false
 
 	[dev-dependencies.proc-macro2]
 		features = ["default", "proc-macro"]
-		version = "1.0.94"
+		version = "1.0.101"
 		default-features = false
 
 	[dev-dependencies.futures]
@@ -48,7 +48,7 @@ features = {}
 
 	[dependencies.pest]
 		features = ["default", "memchr", "std"]
-		version = "2.8.0"
+		version = "2.8.1"
 		default-features = false
 
 	[dependencies.regex]
@@ -58,12 +58,12 @@ features = {}
 
 	[dependencies.pest_derive]
 		features = ["default", "std"]
-		version = "2.8.0"
+		version = "2.8.1"
 		default-features = false
 
 	[dependencies.chrono]
 		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.40"
+		version = "0.4.41"
 		default-features = false
 
 	[dependencies.itertools]


### PR DESCRIPTION
## Product change and motivation
Update TypeDB Rust dependencies to avoid conflicts in the dependent repositories (e.g., TypeDB).

## Implementation
