### PR TITLE
Use XID_START and XID_CONTINUE character classes

### DIFF
--- a/rust/parser/test/autogenerated.rs
+++ b/rust/parser/test/autogenerated.rs
@@ -118,6 +118,20 @@ impl GrammarTree {
             Expansion::Alternatives(('a'..='z').map(|digit| Expansion::Literal(digit.to_string())).collect()),
         );
         tree.rules.insert(
+            "XID_START".into(),
+            Expansion::Alternatives(('a'..='z').map(|char| Expansion::Literal(char.to_string())).collect()),
+        );
+        tree.rules.insert(
+            "XID_CONTINUE".into(),
+            Expansion::Alternatives(
+                ('a'..='z')
+                    .chain('0'..='9')
+                    .chain(['-', '_'])
+                    .map(|char| Expansion::Literal(char.to_string()))
+                    .collect(),
+            ),
+        );
+        tree.rules.insert(
             "ANY".into(),
             Expansion::Alternatives(
                 ['a', 'x', 'Y', '1', '人'].into_iter().map(|char| Expansion::Literal(char.to_string())).collect(),

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -588,11 +588,14 @@ ARROW = _{ "->" }
 
 // FRAGMENTS OF KEYWORDS =======================================================
 
-IDENTIFIER_LABEL_H = @{ XID_START }
-IDENTIFIER_LABEL_T = @{ XID_CONTINUE }
+IDENTIFIER_START = @{ XID_START }
+IDENTIFIER_CONTINUE = @{ "-" | XID_CONTINUE }
 
-IDENTIFIER_VAR_H = @{ XID_START | ASCII_DIGIT }
-IDENTIFIER_VAR_T = @{ XID_CONTINUE }
+IDENTIFIER_LABEL_H = @{ IDENTIFIER_START }
+IDENTIFIER_LABEL_T = @{ IDENTIFIER_CONTINUE }
+
+IDENTIFIER_VAR_H = @{ IDENTIFIER_START | ASCII_DIGIT }
+IDENTIFIER_VAR_T = @{ IDENTIFIER_CONTINUE }
 
 date_fragment = ${ year ~ "-" ~ month ~ "-" ~ day }
 month = @{ "0" ~ ( '1'..'9' ) | "10" | "11" | "12" }
@@ -628,7 +631,7 @@ duration_seconds = ${ numeric_literal ~ "S" }
 
 escape_seq = @{ "\\" ~ ANY }
 
-WB = _{ &( !XID_CONTINUE | COMMENT | EOI ) } // Word boundary
+WB = _{ &( !IDENTIFIER_CONTINUE | COMMENT | EOI ) } // Word boundary
 
 COMMENT = _{ "#" ~ ( !NEWLINE ~ ANY )* ~ ( NEWLINE | EOI ) }
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -588,31 +588,11 @@ ARROW = _{ "->" }
 
 // FRAGMENTS OF KEYWORDS =======================================================
 
-IDENTIFIER_CHAR = @{ ASCII_ALPHA
-                   | '\u{00C0}'..'\u{00D6}'
-                   | '\u{00D8}'..'\u{00F6}'
-                   | '\u{00F8}'..'\u{02FF}'
-                   | '\u{0370}'..'\u{037D}'
-                   | '\u{037F}'..'\u{1FFF}'
-                   | '\u{200C}'..'\u{200D}'
-                   | '\u{2070}'..'\u{218F}'
-                   | '\u{2C00}'..'\u{2FEF}'
-                   | '\u{3001}'..'\u{D7FF}'
-                   | '\u{F900}'..'\u{FDCF}'
-                   | '\u{FDF0}'..'\u{FFFD}'
-                   }
-IDENTIFIER_CONNECTOR = @{ "_"
-                        | "-"
-                        | "\u{00B7}"
-                        | '\u{0300}'..'\u{036F}'
-                        | '\u{203F}'..'\u{2040}'
-                        }
+IDENTIFIER_LABEL_H = @{ XID_START }
+IDENTIFIER_LABEL_T = @{ XID_CONTINUE }
 
-IDENTIFIER_LABEL_H = @{ IDENTIFIER_CHAR }
-IDENTIFIER_LABEL_T = @{ IDENTIFIER_LABEL_H | ASCII_DIGIT | IDENTIFIER_CONNECTOR }
-
-IDENTIFIER_VAR_H = @{ IDENTIFIER_CHAR | ASCII_DIGIT }
-IDENTIFIER_VAR_T = @{ IDENTIFIER_VAR_H | IDENTIFIER_CONNECTOR }
+IDENTIFIER_VAR_H = @{ XID_START | ASCII_DIGIT }
+IDENTIFIER_VAR_T = @{ XID_CONTINUE }
 
 date_fragment = ${ year ~ "-" ~ month ~ "-" ~ day }
 month = @{ "0" ~ ( '1'..'9' ) | "10" | "11" | "12" }
@@ -648,7 +628,7 @@ duration_seconds = ${ numeric_literal ~ "S" }
 
 escape_seq = @{ "\\" ~ ANY }
 
-WB = _{ &( !IDENTIFIER_CONNECTOR ~ PUNCTUATION | WHITESPACE | COMMENT | EOI ) } // Word boundary
+WB = _{ &( !XID_CONTINUE | COMMENT | EOI ) } // Word boundary
 
 COMMENT = _{ "#" ~ ( !NEWLINE ~ ANY )* ~ ( NEWLINE | EOI ) }
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -631,7 +631,7 @@ duration_seconds = ${ numeric_literal ~ "S" }
 
 escape_seq = @{ "\\" ~ ANY }
 
-WB = _{ !IDENTIFIER_CONTINUE | EOI } // Word boundary
+WB = _{ !IDENTIFIER_CONTINUE } // Word boundary
 
 COMMENT = _{ "#" ~ ( !NEWLINE ~ ANY )* ~ ( NEWLINE | EOI ) }
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -631,7 +631,7 @@ duration_seconds = ${ numeric_literal ~ "S" }
 
 escape_seq = @{ "\\" ~ ANY }
 
-WB = _{ &( !IDENTIFIER_CONTINUE | COMMENT | EOI ) } // Word boundary
+WB = _{ !IDENTIFIER_CONTINUE | EOI } // Word boundary
 
 COMMENT = _{ "#" ~ ( !NEWLINE ~ ANY )* ~ ( NEWLINE | EOI ) }
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }


### PR DESCRIPTION
## Product change and motivation

We use `XID_START` and `XID_CONTINUE` character classes provided by pest instead of manually listing unicode codepoint ranges for our identifiers. We also change the definition of the word boundary (`WB`) to be "any character that is not an identifier continuation character" that resolves parsing bugs such as `let $var= 4;` failing to parse: `=` is not `PUNCTUATION`, so not valid word boundary.

## Implementation
