### PR TITLE
Allow decimal syntax without a period

### DIFF
--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -557,7 +557,7 @@ TRUE = @{ "true" ~ WB }
 FALSE = @{ "false" ~ WB }
 
 integer_literal = @{ ASCII_DIGIT+ }
-decimal_literal = @{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ "dec" }
+decimal_literal = @{ ASCII_DIGIT+ ~ ( "." ~ ASCII_DIGIT+ )? ~ "dec" }
 double_literal = @{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ ( ^"e" ~ sign? ~ integer_literal )? }
 numeric_literal = @{ double_literal | integer_literal }
 


### PR DESCRIPTION
## Product change and motivation

To give both humans and LLMs more flexibility when writing `decimal` value types, we no longer requiring the `.0` in `xxx.0dec`. This is unambiguous since the `dec` suffix already syntactically differentiates when a value is a decimal.

## Implementation

- Make the `.yyyy+` part of the decimal value optional