### PR TITLE
Allow leading comma in redefine constraints

### DIFF
--- a/rust/parser/test/fetch.rs
+++ b/rust/parser/test/fetch.rs
@@ -76,3 +76,14 @@ fetch {
     // .fetch(projections);
     assert_valid_eq_repr!(expected, parsed, query);
 }
+
+#[test]
+fn fetch_with_commas_is_accepted() {
+    let query = r#"match
+$x isa person;
+fetch {
+    "name": $x.name,
+    "age": $x.age,
+};"#;
+    parse_query(query).unwrap();
+}

--- a/rust/parser/test/match_queries.rs
+++ b/rust/parser/test/match_queries.rs
@@ -8,6 +8,21 @@ use super::assert_valid_eq_repr;
 use crate::parse_query;
 
 #[test]
+fn match_with_commas_is_accepted() {
+    let query = r#"match
+$x isa person, has name $n, has age $a,;
+($a, $b,) isa friendship;
+let $list = [$a, $b,];
+let $f = max($a, $b,);
+let $u, $v, in [$a, $b,];
+select $x, $n, $a,;
+sort $a asc, $n desc,;
+require $x, $n,;
+reduce $count = count, $total = sum($a),;"#;
+    parse_query(query).unwrap();
+}
+
+#[test]
 fn test_simple_query() {
     let query = r#"match
 $x isa movie;"#;

--- a/rust/parser/test/schema_queries.rs
+++ b/rust/parser/test/schema_queries.rs
@@ -167,3 +167,18 @@ fn undefine_attribute_type_regex() {
     // let expected = undefine!(type_("digit").regex(r"\d"));
     assert_valid_eq_repr!(expected, parsed, query);
 }
+
+#[test]
+fn redefine_with_leading_comma_is_accepted() {
+    // Mirrors `define`'s leading-comma sugar: `define person, owns name;` is
+    // accepted, and `redefine` should accept the same form.
+    let with_comma = r#"redefine
+person, owns name @card(0..10);
+entity person, owns email @card(0..1);"#;
+    parse_query(with_comma).unwrap();
+
+    let without_comma = r#"redefine
+person owns name @card(0..10);
+entity person owns email @card(0..1);"#;
+    parse_query(without_comma).unwrap();
+}

--- a/rust/parser/test/schema_queries.rs
+++ b/rust/parser/test/schema_queries.rs
@@ -170,8 +170,6 @@ fn undefine_attribute_type_regex() {
 
 #[test]
 fn redefine_with_leading_comma_is_accepted() {
-    // Mirrors `define`'s leading-comma sugar: `define person, owns name;` is
-    // accepted, and `redefine` should accept the same form.
     let with_comma = r#"redefine
 person, owns name @card(0..10);
 entity person, owns email @card(0..1);"#;
@@ -181,4 +179,16 @@ entity person, owns email @card(0..1);"#;
 person owns name @card(0..10);
 entity person owns email @card(0..1);"#;
     parse_query(without_comma).unwrap();
+}
+
+#[test]
+fn define_with_commas_is_accepted() {
+    let query = r#"define
+entity person,
+    owns name,
+    owns age,;
+struct point: x value double, y value double,;
+fun greet($p: person, $g: string,) -> string:
+    match $p has name $n; return first $n;"#;
+    parse_query(query).unwrap();
 }

--- a/rust/parser/test/write_queries.rs
+++ b/rust/parser/test/write_queries.rs
@@ -61,6 +61,14 @@ $x has age 25;"#;
 }
 
 #[test]
+fn insert_with_commas_is_accepted() {
+    let query = r#"insert
+$x isa person, has name "alice", has age 30,;
+(parent: $p, child: $c,) isa family;"#;
+    parse_query(query).unwrap();
+}
+
+#[test]
 fn test_match_insert_query() {
     let query = r#"match
 $x isa language;

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -258,7 +258,7 @@ struct_destructor_value = { var | struct_destructor }
 
 query_redefine = { REDEFINE ~ ( redefinable )* }
 redefinable = { redefinable_type | definition_function }
-redefinable_type = { kind? ~ label ~ ( annotations | type_capability ) ~ SEMICOLON }
+redefinable_type = { kind? ~ label ~ COMMA? ~ ( annotations | type_capability ) ~ SEMICOLON }
 // TODO: add `redefine <person> label <new_person_label>
 
 // UNDEFINE QUERY ==============================================================


### PR DESCRIPTION

## Product change and motivation

Mirrors the leading-comma sugar already accepted by `define`: `define person, owns name;` parses, but `redefine person, owns name @card(0..10);` did not. Make `redefinable_type` accept an optional COMMA between the label and the constraint so concat-based query generation has the same shape for define and redefine.

## Implementation
