### PR TITLE
Support vector value type

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -256,6 +256,104 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
+      "general": {
+        "bzlTransitiveDigest": "qh0n9IrXU/xS94wxKQrG1J63zrLkA1Wy2Y3BQxptPcI=",
+        "usagesDigest": "tCi55FyqtOJ2jXh9vcjrHCl4ov3kpWiwKl103nA9BOI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "system_python": {
+            "repoRuleId": "@@protobuf+//python/dist:system_python.bzl%system_python",
+            "attributes": {
+              "minimum_python_version": "3.9"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "uxP2cZuW027Q8wpZbeJeuW5MXcNBO8GcOK/LNN2sPvQ=",
+        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel+//MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.12.0",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_android+//bzlmod_extensions:apksig.bzl%apksig_extension": {
+      "general": {
+        "bzlTransitiveDigest": "xeN+uPP1PKslnv5h3+uyhGaFXC4IIzcFwX/nQHlNwZk=",
+        "usagesDigest": "zr/niBQ/s2fHozWAsg4vI70wAxcuFjG+QtM15qGkq9o=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "apksig": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://android.googlesource.com/platform/tools/apksig/+archive/24e3075e68ebe17c0b529bb24bfda819db5e2f3b.tar.gz",
+              "build_file": "@@rules_android+//bzlmod_extensions:apksig.BUILD"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_android+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_android+//bzlmod_extensions:com_android_dex.bzl%com_android_dex_extension": {
+      "general": {
+        "bzlTransitiveDigest": "2icqERrdWnpamgt/akEgAtfBsjNG1/st+AAFRZx9aH4=",
+        "usagesDigest": "c1Y/KGGjUYCyd8zNIVTUh1bynVXRFz6xGKaSCBpQANM=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_android_dex": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://android.googlesource.com/platform/dalvik/+archive/5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz",
+              "build_file": "@@rules_android+//bzlmod_extensions:com_android_dex.BUILD"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_android+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_android+//rules/android_sdk_repository:rule.bzl%android_sdk_repository_extension": {
       "general": {
         "bzlTransitiveDigest": "+rMrzIrv7sImYmkbXJYv+gFpTJQ79X3MpwwMLI2A+oA=",
@@ -334,6 +432,2760 @@
             "rules_dotnet+",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_dotnet+//dotnet:paket.paket2bazel_dependencies_extension.bzl%paket2bazel_dependencies_extension": {
+      "general": {
+        "bzlTransitiveDigest": "T/ODjgQMknoSIiSatcheY20h1v7xgVSlCkHCvarYWgo=",
+        "usagesDigest": "mL39UjUqNtEezZL+bUIfu+p8mLY0uBEV3cDZIFkyUrU=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nuget.argu.v6.1.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "argu",
+              "version": "6.1.1",
+              "sha512": "sha512-ed1N3RMohnxS54MYuMgPz3766hXItY3L12IrPazZ+F8CXPKkxyV+p8xVkWmE5NDnRhEvaWptRhBrXstK9DhS/w=="
+            }
+          },
+          "nuget.chessie.v0.6.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "chessie",
+              "version": "0.6.0",
+              "sha512": "sha512-VUcf1SFTXQDf1ULVQ/IddKISCuVICj9OC+wW1LFSIDqpHfihP2M2CvLetBxsCvcplu8ugI4mo9ZV5gmdefHxPg=="
+            }
+          },
+          "nuget.fsharp.control.asyncseq.v3.2.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharp.control.asyncseq",
+              "version": "3.2.1",
+              "sha512": "sha512-oV4Xx1MMOqpnZAon10bhN/JSUjwuc/H4hXq2SM7IWimfghk5yK85alZiqVH4momfGBKpr/RsBVfgCrqbmkaxJg=="
+            }
+          },
+          "nuget.fsharp.core.v6.0.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharp.core",
+              "version": "6.0.3",
+              "sha512": "sha512-aDyKHiVFMwXWJrfW90iAeKyvw/lN+x98DPfx4oXke9Qnl4dz1sOi8KT2iczGeunqyWXh7nm+XUJ18i/0P3pZYw=="
+            }
+          },
+          "nuget.fsharp.systemtextjson.v0.16.6": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharp.systemtextjson",
+              "version": "0.16.6",
+              "sha512": "sha512-7SoZOjo4dY6Ez47RSL5pWVAGiy8SPCzpjD4oBoGEkMNsnrRcy1WhD8jB2XyRufrboyBxKbGp7ZKMAQlDIc1Crg=="
+            }
+          },
+          "nuget.fsharpx.async.v1.14.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharpx.async",
+              "version": "1.14.1",
+              "sha512": "sha512-8Ye/hgNHsnHWFtanfED+tgJJzPq4QEt+LUQ87Ie2JOiqb6WUP+vtF3WRBO2NIDqGQpivh207nwmCoFdK+T6jwQ=="
+            }
+          },
+          "nuget.fsharpx.collections.v2.1.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharpx.collections",
+              "version": "2.1.3",
+              "sha512": "sha512-1KSJLhLpqOTPRKYkgi0YvPrvGybiYi642r53VrQb1U7LNd3VQNsh3z++v69ky8FEj4y+kP6NPbgZbFyJ8mumqA=="
+            }
+          },
+          "nuget.fsharpx.extras.v3.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharpx.extras",
+              "version": "3.0.0",
+              "sha512": "sha512-7Wv7LF8hZfGG6KuXcQoGTnm6keDAtMwvI6S2lK90Z23Dvs44XGeRAGOsLRO3dg2k6atckdt6xd0SDqQ9FSa4vA=="
+            }
+          },
+          "nuget.microsoft.bcl.asyncinterfaces.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.bcl.asyncinterfaces",
+              "version": "6.0.0",
+              "sha512": "sha512-IhoFoMkQ96h7Yg2PODHtOStOuV0RK+4nTTXycAmtKiZEXenXzSNf5vtKA/JVCHS9o7493dlu2vnAhSqcI9ewmQ=="
+            }
+          },
+          "nuget.microsoft.csharp.v4.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.csharp",
+              "version": "4.7.0",
+              "sha512": "sha512-LJaYhRX5VxTUuD9WUPGD3GpWTgs89SVfoOPvSEdt66tL3lQvny9sR/ZiC3px1qUV5EFebS44i2CBeiliHVaQ3w=="
+            }
+          },
+          "nuget.microsoft.extensions.fileproviders.abstractions.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.extensions.fileproviders.abstractions",
+              "version": "8.0.0",
+              "sha512": "sha512-/pqhjy6BlpTyDjIsk+B14nvuLVfd1TgGJPxIqVZpxSbCcKtcdPWMakch0Y7NtbL+vwMV+HlFha5lYXgxRZ4qCw=="
+            }
+          },
+          "nuget.microsoft.extensions.filesystemglobbing.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.extensions.filesystemglobbing",
+              "version": "8.0.0",
+              "sha512": "sha512-I6XlDPaVuhjHp398BQ5A1vsGWVdIDbF/XnXlzyacj1B2PJlsKNDc/KCeLBJIVAiYq1PEdMrccFVI9f5JHdJj/Q=="
+            }
+          },
+          "nuget.microsoft.extensions.primitives.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.extensions.primitives",
+              "version": "8.0.0",
+              "sha512": "sha512-H1R1yj084YRjRW3RNa+sUC1vgv6m5OSBSmH4ZhbDSN7PKLc9FcK7J20aPAOepgZPdeEyn286ZMqjUg1wq5LDLQ=="
+            }
+          },
+          "nuget.microsoft.netcore.app.ref.v6.0.5": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.app.ref",
+              "version": "6.0.5",
+              "sha512": "sha512-quj/gyLoZLypJO7PwsZ8ib6ZSgFv1C9s5SJgwzl/gztynTJ/3oO/stA2gNMf0C33vTJ0J3SSF/kRPQ/ifY5xZg=="
+            }
+          },
+          "nuget.microsoft.netcore.platforms.v6.0.5": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.platforms",
+              "version": "6.0.5",
+              "sha512": "sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA=="
+            }
+          },
+          "nuget.microsoft.netcore.targets.v5.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.targets",
+              "version": "5.0.0",
+              "sha512": "sha512-hYHm3JAjQO/nySxcl1EpZhYEW+2P3H1eLZNr+QxgO5TnLS6hqtfi5WchjQzjid45MYmhy2X7IOmcWtDP4fpMGw=="
+            }
+          },
+          "nuget.microsoft.web.xdt.v3.1.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.web.xdt",
+              "version": "3.1.0",
+              "sha512": "sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw=="
+            }
+          },
+          "nuget.microsoft.win32.systemevents.v6.0.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.win32.systemevents",
+              "version": "6.0.1",
+              "sha512": "sha512-tCbvWn9ymrxUuAlYZCQ7eDwVSn7571UIeMYWizWCXPjQlESdfIGr1W6EXhrFm8BgPt2e9G5bJfxVrzx2knWR6A=="
+            }
+          },
+          "nuget.mono.cecil.v0.11.4": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "mono.cecil",
+              "version": "0.11.4",
+              "sha512": "sha512-CnjwUMmFHnScNG8e/4DRZQQX67H5ajekRDudmZ6Fy1jCLhyH1jjzbQCOEFhBLa2NjPWQpMF+RHdBJY8a7GgmlA=="
+            }
+          },
+          "nuget.netstandard.library.v2.0.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "netstandard.library",
+              "version": "2.0.3",
+              "sha512": "sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ=="
+            }
+          },
+          "nuget.newtonsoft.json.v13.0.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "newtonsoft.json",
+              "version": "13.0.1",
+              "sha512": "sha512-g3MbZi6vBTeaI/hEbvR7vBETSd1DWLe9i1E4P+nPY34v5i94zqUqDXvdWC3G+7tYN9SnsdU9zzegrnRz4h7nsQ=="
+            }
+          },
+          "nuget.nuget.commands.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.commands",
+              "version": "6.7.0",
+              "sha512": "sha512-+fjzHcRYfT61xykFQfdAtRW5OMrqKRm2jwCPmGLWQn/uSGE9zEdKJD+HByWjV1EzJ/01FIYrKB94zg0ShDKjJQ=="
+            }
+          },
+          "nuget.nuget.common.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.common",
+              "version": "6.7.0",
+              "sha512": "sha512-xxmTBZqBfMCaou4rJFKReYbTrfQXb4OfcT9QyVLN1nEe36KditRl0Uki0R03RVimNKeTzKjBUF6I4CZTAeu2YQ=="
+            }
+          },
+          "nuget.nuget.configuration.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.configuration",
+              "version": "6.7.0",
+              "sha512": "sha512-MqkkKtRGH3Z73v1WylGpDMoUrVlNqoEFcaWE1Apudb6AWJYqGh4vyZUMdXsitoVpiakP3iiAMtprh4Gfa/Cv6Q=="
+            }
+          },
+          "nuget.nuget.credentials.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.credentials",
+              "version": "6.7.0",
+              "sha512": "sha512-G5JCMbC24Cd0wFz7fZCXRKF5ZqWcm6UGwA3Y+nC9/pbV9sIkPKEsDYk6/QUBLIVnXbB3J1o5zgULa95QJ99bAg=="
+            }
+          },
+          "nuget.nuget.dependencyresolver.core.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.dependencyresolver.core",
+              "version": "6.7.0",
+              "sha512": "sha512-8SGR7UF/A+tAgdTRIsh3v8qg47w9farAAXvHlbYylL+sFRIp36yGF0C1sXMuD/DEIl6GLc2M/UdawB+FpHg/tw=="
+            }
+          },
+          "nuget.nuget.frameworks.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.frameworks",
+              "version": "6.7.0",
+              "sha512": "sha512-weGyDjVXp4LUKR9ZjMrtd38J6MkUC5xPU9hcGdksZBB0r+bJmKoZ5NJQAXLFbP3m5BhPLYIl3/aEmPlkCV25Og=="
+            }
+          },
+          "nuget.nuget.librarymodel.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.librarymodel",
+              "version": "6.7.0",
+              "sha512": "sha512-YPHMmVII4QqjShzNUX61qg4u/j9mFhBD5iLDCnk8UgEmiWzQRLDFCvXCmbRoYznLJz2995sD7idtqWsvOh4YnA=="
+            }
+          },
+          "nuget.nuget.packagemanagement.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packagemanagement",
+              "version": "6.7.0",
+              "sha512": "sha512-QMP/PiheJgBQsP66XNmhdBqnpeyRmqfZjhsfAhjMgm8gfd2k6OGXb2LOV7hN6xbfbj9KrtMiwfzOvuZA6q27KQ=="
+            }
+          },
+          "nuget.nuget.packaging.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packaging",
+              "version": "6.7.0",
+              "sha512": "sha512-jEfG/a8hNhTDSWOadBi0nZRdTO+PXR98j4u6RnZ68Nyuw4LHviEXOG1kqZvraU3uYGssAoJatkFDYAM8kEX+WQ=="
+            }
+          },
+          "nuget.nuget.projectmodel.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.projectmodel",
+              "version": "6.7.0",
+              "sha512": "sha512-BnheauzOjo1U/hCg0jyhflaNbffCbfZnquHc18+VneSANMB54Mg/xjHPLibx3R5zneQ6E3n0K50wtfRntrkH8g=="
+            }
+          },
+          "nuget.nuget.protocol.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.protocol",
+              "version": "6.7.0",
+              "sha512": "sha512-/r+i3gmVYWa8KMETanGyaCqMPVLTwe8Gqza5khiDiETATeGEd+y7erJsy/pLwBpnl0/jSYpf+kxPq16xoiej6A=="
+            }
+          },
+          "nuget.nuget.resolver.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.resolver",
+              "version": "6.7.0",
+              "sha512": "sha512-kLoXgmxb0dpzK5Dx1SiaTj2l0EXtU42HSMD9bQgjoc3BWi/5Fn6VvGe8Pd7U4firGmvxgkmmO0lJx6iF0dLLxQ=="
+            }
+          },
+          "nuget.nuget.versioning.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.versioning",
+              "version": "6.7.0",
+              "sha512": "sha512-aZ0/Fd85juLKrg0rZw4rWJAFDuv0aW3SJj3fqwp5etkRZOwHO/11vmGh0eeMZ7gMAvnktvxax7h5Vaxkllv2ZA=="
+            }
+          },
+          "nuget.paket.core.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "paket.core",
+              "version": "8.0.0",
+              "sha512": "sha512-Wn1E0lIbjitqogRA6sLRJLxKeIjqLLi5oeFClqGCwUBixPIZ58KM75NwtDAtbiyTqo7KdNBSoAuBI7z4P8lL5w=="
+            }
+          },
+          "nuget.runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-s9AMelYhmifrJqGjkRkqyoP7NMudky0vJPdYzjGKryWYhofREwzC4EesqYm+dooMQB++vbgvGrtrcZpU36Q+sA=="
+            }
+          },
+          "nuget.runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-1kcSfJKTg00KxR43jsnYjjYTPoUh+f+OLpL4/yF/bzKikgxV6QPlz74UyrypYprz3NUHHOcsa12E7+Xp4RtTng=="
+            }
+          },
+          "nuget.runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-DPcJlXiNYg8lqqCAFTgaL9Yqs1brKG3H6b1XVimLf9RYxW7zOLujvf3HfTlvrYEWsAulgJ/+7Gh0mCw4FUt+IQ=="
+            }
+          },
+          "nuget.runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-2p9EjZTy8LkH/wx6OwRuk0ORuVL7PzqJ3cdvL/SY58Ep+XW0AYEBjyy7kloJ/nPZGYVUT+NS8kNwPU5ICV/DwQ=="
+            }
+          },
+          "nuget.runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-2v5kHzEZgBFCz+5NJgZn3Dmi9gaYY/loR5PJEXvOJ018XIF6BmSGYNyHNXTmdFPq50EjwaGpHj8cQmR3z5oeGA=="
+            }
+          },
+          "nuget.runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-qfB0WU/HXLYhTlXpDZi0eY1p1x9jlwxDlVFcWrj9u+2gFEesUKux9IoR9bzQLPPj//B0dSWolKEgW/1X70VWCA=="
+            }
+          },
+          "nuget.runtime.native.system.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system",
+              "version": "4.3.1",
+              "sha512": "sha512-AJsN0GLPijYtmFZdvPYnfTdAMTlvMttusjye6ZC1Edg5XUneNv1BCHzXfM0SWpqf+Gt/31WthibAPAorcN4F1g=="
+            }
+          },
+          "nuget.runtime.native.system.net.http.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system.net.http",
+              "version": "4.3.1",
+              "sha512": "sha512-n3clBjCv4nEoDl/hV4/DYwi/yoRrFZk9Tpe0TenLiITLHvtijO+OSYhwV7JmACcsZlLFKMaYW+P5yN3sK/xU0Q=="
+            }
+          },
+          "nuget.runtime.native.system.security.cryptography.apple.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system.security.cryptography.apple",
+              "version": "4.3.1",
+              "sha512": "sha512-C+AZUmQBFgXR/NxF80q0Sy7SgYiW+C3CcIuA7yd0f1FXWN16xhIRSmXN92IUSGx/ebGN3XmaeuVUZpd+NuY/jQ=="
+            }
+          },
+          "nuget.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-CiS94rEK+DWQJJbFqOc+SboSZQeswgRiao5QMZjHjhhRPi2NkawZZ0l99i8+eGNTVo6f4cYTOXVmNr0BeJTiYQ=="
+            }
+          },
+          "nuget.runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-kbvMwf5iS0oM7qiHPy3sHADQa2ncqFXVz7bQKCiPKcnNu5NTDz4cO/Nk4gy54iYjU0SSma/z2IfYIpPGVsdiZA=="
+            }
+          },
+          "nuget.runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-anMSS/nfTUvTuvUE3jg+sSEx7JUgLkeYS7T9dbb8ZE42XYWdaLJjRlp3qA/yYyoewJuVJ6ZPeI8w9QrlKgVSow=="
+            }
+          },
+          "nuget.runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-KHQzsD6iTnD3Rpr+Odhe0II9LMwTJkIOMKekGzBz5TQlNbEpuc0LwQxMuCE4FZnzcefRYw3kDd5Xyu+AFND8FQ=="
+            }
+          },
+          "nuget.runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple",
+              "version": "4.3.1",
+              "sha512": "sha512-YVeP6XccbJen1k3sjfntjqWS+vAcVt37VW3eBuZvjH7ZlTmQz3t6n8gLNh342IeDSBM+06SPYtBqP1roAlIpDA=="
+            }
+          },
+          "nuget.runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-KBHT4RWCC3klyYzHWLweXSAPRzPLuzFdfixnzojA+tNUE6kHpyABhtbgTiwhGHyA3+TlyLOn1viw1NBoG7ZOxQ=="
+            }
+          },
+          "nuget.runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-Lmw34chaD1jDOrmiEl2jIXVoCfYhTFMWQWtC47RDRLKYpwLOjOkSa6E2LM5K28UNpkSOZu579Os/t+eZ+wAhOw=="
+            }
+          },
+          "nuget.runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-K6KLKN1ICpOqvVG2Dub+uX3gb/MqqiS1deVZpuj46M7ya9ranrGzFYVIMsQFI8f7vhc+sf0gyTtN0es9tN4jmw=="
+            }
+          },
+          "nuget.runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-IXiZH+OL4lP8dRKieebADFgWPgyq/vbMbYqXCz9EhfaU4CcRl1ygb3pmpNWhVJsVEV3fRb3tEaEFowmkb56WCQ=="
+            }
+          },
+          "nuget.runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-uOpq6ML3XC+QioF01mDpg6zuJEZs23+vjpbnOKQkZxyMSOGNanyleAjNgXLZyUo0NPa5c8QIMB878SvxLSxjhA=="
+            }
+          },
+          "nuget.runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-fefg8Dxuv7BKypFbd1HKIdO/x51l+NN4WP5GIqe+Gx6El1Aut7zZA5a9B8WPowDiGCwPIqEJaIhdwCjmbHqscQ=="
+            }
+          },
+          "nuget.system.collections.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.collections",
+              "version": "4.3.0",
+              "sha512": "sha512-ynuVLTDaFIfKTkOqUigXte4m5+EFNwYoEBEvxnp1EnZsOdQC85S7BCbREIu8+bu2Tpzh9a9zbvIVpRo15V8FGw=="
+            }
+          },
+          "nuget.system.collections.concurrent.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.collections.concurrent",
+              "version": "4.3.0",
+              "sha512": "sha512-NcGqPmNiFv5dwuvrUEKT5prWNV0m4iRTrwYK+U2CefqpO9z+EnrssLMWx+fZGFvKxy6ZSYTv238thRXx9Vz2gg=="
+            }
+          },
+          "nuget.system.componentmodel.composition.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.componentmodel.composition",
+              "version": "6.0.0",
+              "sha512": "sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA=="
+            }
+          },
+          "nuget.system.configuration.configurationmanager.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.configuration.configurationmanager",
+              "version": "6.0.0",
+              "sha512": "sha512-3ljLko1jA6FjAf16qO2sN53+bEfm2AshZl+SurndX/UrPiRM9t8PlF8ccucckjN1YdvydS/DMkF0qMnsxwwyRw=="
+            }
+          },
+          "nuget.system.diagnostics.debug.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.diagnostics.debug",
+              "version": "4.3.0",
+              "sha512": "sha512-bFj+HjYY5/h2hMHOp+/H07Gb19+NJTX54ntixS9EHxG2eyEiXWvNYvQJ4CwqFiMcTbGb4zuPq1ubClyGYN2rJA=="
+            }
+          },
+          "nuget.system.diagnostics.diagnosticsource.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.diagnostics.diagnosticsource",
+              "version": "6.0.0",
+              "sha512": "sha512-dYnmo66bitfHxLjNBU2LPp6Dn98n7hRyk7ZKGVzaAPw2MHy+40dLxfw7susxMkWfL3C//aJF+/UDAPgH2YhUZg=="
+            }
+          },
+          "nuget.system.diagnostics.tracing.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.diagnostics.tracing",
+              "version": "4.3.0",
+              "sha512": "sha512-0KXTDiYc1Ft9+rArf/vXa2TgybiS7YJuphSByYPAIIsFtpmBzXnpHNTlgR4c1MPOoGoa/OBYEezli+XkwgFp6g=="
+            }
+          },
+          "nuget.system.drawing.common.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.drawing.common",
+              "version": "6.0.0",
+              "sha512": "sha512-1h8KPgHD6sFfE/wboEosfOTqyVZACy+qNh/sq9ODbUnVvTRPOYXuPZTNw/anK44H5CPNspZbT1yiIitd4ymI5A=="
+            }
+          },
+          "nuget.system.formats.asn1.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.formats.asn1",
+              "version": "8.0.0",
+              "sha512": "sha512-KAcODhtEEDJs6494uw0/s/BxymRWD1yV4JHd0QOx8IV4B8JocCvk2mfOmmwVptBxydT25WJvOnzmh2vjoqbbwg=="
+            }
+          },
+          "nuget.system.globalization.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.globalization",
+              "version": "4.3.0",
+              "sha512": "sha512-gj0rowjLBztAoxRuzM0Nn9exYVrD+++xb3PYc+QR/YHDvch98gbT3H4vFMnNU6r8poSjVwwlRxKAqtqN6AXs4g=="
+            }
+          },
+          "nuget.system.globalization.calendars.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.globalization.calendars",
+              "version": "4.3.0",
+              "sha512": "sha512-6XGQIxQCs5N3S5Je/AKiv6QdHRF6F/uH2m45n1I0VGlidn6c2POZcO+kCOT0U80eZ1Giph42a8l0BuGwuKS+hg=="
+            }
+          },
+          "nuget.system.globalization.extensions.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.globalization.extensions",
+              "version": "4.3.0",
+              "sha512": "sha512-pNNgAD+V4MMe3znAuR4cc4UKYKxdADKxfbiIo8fXE0zvms2XIZ0UF0rSE7fARPSbNkzFcgBz6/y24b9uTsJM5Q=="
+            }
+          },
+          "nuget.system.io.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.io",
+              "version": "4.3.0",
+              "sha512": "sha512-v8paIePhmGuXZbE9xvvNb4uJ5ME4OFXR1+8la/G/L1GIl2nbU2WFnddgb79kVK3U2us7q1aZT/uY/R0D/ovB5g=="
+            }
+          },
+          "nuget.system.io.filesystem.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.io.filesystem",
+              "version": "4.3.0",
+              "sha512": "sha512-T7WB1vhblSmgkaDpdGM3Uqo55Qsr5sip5eyowrwiXOoHBkzOx3ePd9+Zh97r9NzOwFCxqX7awO6RBxQuao7n7g=="
+            }
+          },
+          "nuget.system.io.filesystem.primitives.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.io.filesystem.primitives",
+              "version": "4.3.0",
+              "sha512": "sha512-WIWVPQlYLP/Zc9I6IakpBk1y8ryVGK83MtZx//zGKKi2hvHQWKAB7moRQCOz5Is/wNDksiYpocf3FeA3le6e5Q=="
+            }
+          },
+          "nuget.system.linq.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.linq",
+              "version": "4.3.0",
+              "sha512": "sha512-6sx/4exSb0BfW6DmcfYW0OW+nBgo1UOp4vjGXfQJnWsupKn6LNrk80sXDcNxQvYOJn4TfKOfNQKB7XDS3GIEWA=="
+            }
+          },
+          "nuget.system.net.http.v4.3.4": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.net.http",
+              "version": "4.3.4",
+              "sha512": "sha512-Fj7e73NNHwof97gFPTJuq8gv6G895yxkZt14DVnZdEh4gvKl8WrksCwNjIp/JeYX/yu/qxM/iOv9ai+ZY3Fp7Q=="
+            }
+          },
+          "nuget.system.net.http.winhttphandler.v6.0.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.net.http.winhttphandler",
+              "version": "6.0.1",
+              "sha512": "sha512-uLH7CWm9PZaO0SNhnEL8wvLCwcLCjC9M/jWgl7kTwp5PuFCfeCn7hrq6c0Bpfq2s1SCkx9lNUoRWnM76wMpnxQ=="
+            }
+          },
+          "nuget.system.net.primitives.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.net.primitives",
+              "version": "4.3.1",
+              "sha512": "sha512-BgdlyYCI7rrdh36p3lMTqbkvaafPETpB1bk9iQlFdQxYE692kiXvmseXs8ghL+gEgQF2xgDc8GH4QLkSgUUs+Q=="
+            }
+          },
+          "nuget.system.reflection.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.reflection",
+              "version": "4.3.0",
+              "sha512": "sha512-IyW2ftYNzgMCgHBk8lQiy+G3+ydbU5tE+6PEqM5JJvIdeFKaXDSzHAPYDREPe6zpr5WJ1Fcma+rAFCIAV6+DMw=="
+            }
+          },
+          "nuget.system.reflection.emit.lightweight.v4.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.reflection.emit.lightweight",
+              "version": "4.7.0",
+              "sha512": "sha512-Blr1A9Vqk+ZUknlk6sFrhOcpuqx4bp7kqwZfhwkmmhz+9dgOl8cZ9CnSXbalbL9rfHmi5HDFydxQsfozl2PvjQ=="
+            }
+          },
+          "nuget.system.reflection.primitives.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.reflection.primitives",
+              "version": "4.3.0",
+              "sha512": "sha512-1LnMkF9aXKuQAgYzjoiQaL9mwY7oY6KdaO/zzeLMynNBEqKoUfLi5TiKIewoAF+hkxfGTZsjkjsF1jRL4uSeqg=="
+            }
+          },
+          "nuget.system.resources.resourcemanager.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.resources.resourcemanager",
+              "version": "4.3.0",
+              "sha512": "sha512-kGfbKPHEjQj8Uq1Apgj4jBStkRJkZ0Hdr0Jv3+aL7WGrAZVLF5Rh5h0Yc3FgDB5uXDbHiJk/WhBaZPVwKmuB1A=="
+            }
+          },
+          "nuget.system.runtime.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime",
+              "version": "4.3.1",
+              "sha512": "sha512-Al69mPDfzdD+bKGK2HAfB+lNFOHFqnkqzNnUJmmvUe1/qEPK9M7EiTT4zuycKDPy7ev11xz8XVgJWKP0hm7NIA=="
+            }
+          },
+          "nuget.system.runtime.compilerservices.unsafe.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.compilerservices.unsafe",
+              "version": "6.0.0",
+              "sha512": "sha512-1AVzAb5OxJNvJLnOADtexNmWgattm2XVOT3TjQTN7Dd4SqoSwai1CsN2fth42uQldJSQdz/sAec0+TzxBFgisw=="
+            }
+          },
+          "nuget.system.runtime.extensions.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.extensions",
+              "version": "4.3.1",
+              "sha512": "sha512-VSbBNw3UQxuHk4aALPsYo154l+TKUR4Ij+Nj9GPnyJkzAmMewY1AyHXuaE+KCJ6JBj2SoO4uwLqY4ORKW9JRTw=="
+            }
+          },
+          "nuget.system.runtime.handles.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.handles",
+              "version": "4.3.0",
+              "sha512": "sha512-CluvHdVUv54BvLTOCCyybugreDNk/rR8unMPruzXDtxSjvrQOU3M4R831/lQf4YI8VYp668FGQa/01E+Rq8PEQ=="
+            }
+          },
+          "nuget.system.runtime.interopservices.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.interopservices",
+              "version": "4.3.0",
+              "sha512": "sha512-ZQeZw+ZU77ua1nFXycYM5G8oioFZe+N84qC/XUg1BEBl7z9luZcyjLu7+4H0yJuNfn1hOAiAAZ3u5us/lj9w2Q=="
+            }
+          },
+          "nuget.system.runtime.numerics.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.numerics",
+              "version": "4.3.0",
+              "sha512": "sha512-PjR/qo5+xITUgeU7HCGf4c40augniiFLRQjPDiM8Fie9nGxsfGVOjB9BQycYON3ZWT9joQQ1d62HxA45Kvf9NA=="
+            }
+          },
+          "nuget.system.security.accesscontrol.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.accesscontrol",
+              "version": "6.0.0",
+              "sha512": "sha512-ZKNqEDuVSrS36KdsDodleb1ITDCOREwtkV+5oP0FrWNhRQHtI1xUSvybQxy4pM8PBxW47UFOhZWObWhXkWj7RQ=="
+            }
+          },
+          "nuget.system.security.cryptography.algorithms.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.algorithms",
+              "version": "4.3.1",
+              "sha512": "sha512-NLArYLaaVOExC1EVEuMhCkm/sFhMUPgLWcWG1xgK2XPjtUGfelV4ODeIQ5VGDbPg2xPI+yfebRcLjS2rHJCtzw=="
+            }
+          },
+          "nuget.system.security.cryptography.cng.v5.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.cng",
+              "version": "5.0.0",
+              "sha512": "sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w=="
+            }
+          },
+          "nuget.system.security.cryptography.csp.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.csp",
+              "version": "4.3.0",
+              "sha512": "sha512-QzF1kXR6GPUvaDGH4Jrf4OA1c+baxDC/O6E/RAzbHHux+SBTadXzsqDz/flgTVuh5tlKiZol0sUz5FMzhXjzUQ=="
+            }
+          },
+          "nuget.system.security.cryptography.encoding.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.encoding",
+              "version": "4.3.0",
+              "sha512": "sha512-XCat0j5jVC83UG9fofcuiYDwN0PVKc2OWD0QVLjYpXn7dz+gNaANkHPbhNtr5PR8rDQNHrxtI912Hb29YAB14A=="
+            }
+          },
+          "nuget.system.security.cryptography.openssl.v5.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.openssl",
+              "version": "5.0.0",
+              "sha512": "sha512-+8P4Eo9HMcke1V4bPK6JjBaHilI5MAYLcqPKVHcpbJmW3O6qOCxutBmEiuT3e6CZvk8cE4v2wqC5J3woxqEF/Q=="
+            }
+          },
+          "nuget.system.security.cryptography.pkcs.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.pkcs",
+              "version": "8.0.0",
+              "sha512": "sha512-zWk9gw+KSXYnBfrm+nUF7u17gexrNmJOwj0WcLw7kxJB9VAabPTsj9PwPod8QIkSp0q4M/4DTHKhMbc7op2GlQ=="
+            }
+          },
+          "nuget.system.security.cryptography.primitives.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.primitives",
+              "version": "4.3.0",
+              "sha512": "sha512-WtgnP5mOu5zKL3vQMUPT9tV7XVYGV7Jtb0540DgBD7MMN5ojonwIcw8VybZvS6VloGmE7CRt/Hms8adBsN1DRw=="
+            }
+          },
+          "nuget.system.security.cryptography.protecteddata.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.protecteddata",
+              "version": "6.0.0",
+              "sha512": "sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA=="
+            }
+          },
+          "nuget.system.security.cryptography.x509certificates.v4.3.2": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.x509certificates",
+              "version": "4.3.2",
+              "sha512": "sha512-Ax8SNsw9NCe5pBEysVjrPiGgmcw9ToUMQyNOsbKL0BAGO3VQ+Gis2eleJ7KVmJ5j2gFdgh42yc9U2hboXdy+3A=="
+            }
+          },
+          "nuget.system.security.permissions.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.permissions",
+              "version": "6.0.0",
+              "sha512": "sha512-1PIXLMOxZPEE+i46Mwti8qFfUOBQqRZZ21co8o1NXWyoZg7sOk+SIJAYGlS8Hp9mNMpJdQOYNgcn0bxZ22ICeA=="
+            }
+          },
+          "nuget.system.text.encoding.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.text.encoding",
+              "version": "4.3.0",
+              "sha512": "sha512-b/f+7HMTpxIfeV7H03bkuHKMFylCGfr9/U6gePnfFFW0aF8LOWLDgQCY6V1oWUqDksC3mdNuyChM1vy9TP4sZw=="
+            }
+          },
+          "nuget.system.text.json.v5.0.2": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.text.json",
+              "version": "5.0.2",
+              "sha512": "sha512-PTL4h2MLbKEqZ/9TE6SEmJp1txIh0GjzYPQrWGbfJ5sgbPrpXzb9sOoXe3cid51zDBE+2KCLd95e/04JiNr0TQ=="
+            }
+          },
+          "nuget.system.threading.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.threading",
+              "version": "4.3.0",
+              "sha512": "sha512-l6J1G9zmn6r5xU+DSp/Vxgx6eG+qUvQgdpgo28m1gEwfNyG6HqlF6h2ESDXZCYEPnngsmkTQ+q7MyyMMTNlaiA=="
+            }
+          },
+          "nuget.system.threading.tasks.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.threading.tasks",
+              "version": "4.3.0",
+              "sha512": "sha512-fUiP+CyyCjs872OA8trl6p97qma/da1xGq3h4zAbJZk8zyaU4zyEfqW5vbkP80xG/Nimun1vlWBboMEk7XxdEw=="
+            }
+          },
+          "nuget.system.windows.extensions.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.windows.extensions",
+              "version": "6.0.0",
+              "sha512": "sha512-9R7sgWb5e1/OokgW7HN8JNXFpcsUXvLTMnfJoWBE9AvD+5e0z+f5ojr3BO3pFYbGq9Ks8AsndTi7ME13ocpU8A=="
+            }
+          },
+          "paket.paket2bazel_dependencies": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_repo.bzl%_nuget_repo",
+            "attributes": {
+              "repo_name": "paket.paket2bazel_dependencies",
+              "packages": [
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net462\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net47\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net471\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net472\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net48\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net5.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net6.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net7.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net8.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp2.1\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp2.2\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp3.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp3.1\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netstandard2.1\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"]},\"framework_list\":[],\"id\":\"Argu\",\"sha512\":\"sha512-ed1N3RMohnxS54MYuMgPz3766hXItY3L12IrPazZ+F8CXPKkxyV+p8xVkWmE5NDnRhEvaWptRhBrXstK9DhS/w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.1.1\"}",
+                "{\"dependencies\":{\"net11\":[\"FSharp.Core\"],\"net20\":[\"FSharp.Core\"],\"net30\":[\"FSharp.Core\"],\"net35\":[\"FSharp.Core\"],\"net40\":[\"FSharp.Core\"],\"net403\":[\"FSharp.Core\"],\"net45\":[\"FSharp.Core\"],\"net451\":[\"FSharp.Core\"],\"net452\":[\"FSharp.Core\"],\"net46\":[\"FSharp.Core\"],\"net461\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net462\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net47\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net471\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net472\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net48\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net5.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net6.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net7.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net8.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp1.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp1.1\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp2.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp2.1\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp2.2\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp3.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp3.1\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netstandard\":[\"FSharp.Core\"],\"netstandard1.0\":[\"FSharp.Core\"],\"netstandard1.1\":[\"FSharp.Core\"],\"netstandard1.2\":[\"FSharp.Core\"],\"netstandard1.3\":[\"FSharp.Core\"],\"netstandard1.4\":[\"FSharp.Core\"],\"netstandard1.5\":[\"FSharp.Core\"],\"netstandard1.6\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netstandard2.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netstandard2.1\":[\"NETStandard.Library\",\"FSharp.Core\"]},\"framework_list\":[],\"id\":\"Chessie\",\"sha512\":\"sha512-VUcf1SFTXQDf1ULVQ/IddKISCuVICj9OC+wW1LFSIDqpHfihP2M2CvLetBxsCvcplu8ugI4mo9ZV5gmdefHxPg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"0.6.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net462\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net47\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net471\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net472\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net48\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net5.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net6.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net7.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net8.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netcoreapp2.1\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netcoreapp2.2\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netcoreapp3.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netcoreapp3.1\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netstandard2.1\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"]},\"framework_list\":[],\"id\":\"FSharp.Control.AsyncSeq\",\"sha512\":\"sha512-oV4Xx1MMOqpnZAon10bhN/JSUjwuc/H4hXq2SM7IWimfghk5yK85alZiqVH4momfGBKpr/RsBVfgCrqbmkaxJg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.2.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"FSharp.Core\",\"sha512\":\"sha512-aDyKHiVFMwXWJrfW90iAeKyvw/lN+x98DPfx4oXke9Qnl4dz1sOi8KT2iczGeunqyWXh7nm+XUJ18i/0P3pZYw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"FSharp.Core\",\"System.Text.Json\"],\"net462\":[\"FSharp.Core\",\"System.Text.Json\"],\"net47\":[\"FSharp.Core\",\"System.Text.Json\"],\"net471\":[\"FSharp.Core\",\"System.Text.Json\"],\"net472\":[\"FSharp.Core\",\"System.Text.Json\"],\"net48\":[\"FSharp.Core\",\"System.Text.Json\"],\"net5.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"net6.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"net7.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"net8.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"netcoreapp2.1\":[\"FSharp.Core\",\"System.Text.Json\"],\"netcoreapp2.2\":[\"FSharp.Core\",\"System.Text.Json\"],\"netcoreapp3.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"netcoreapp3.1\":[\"FSharp.Core\",\"System.Text.Json\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"netstandard2.1\":[\"FSharp.Core\",\"System.Text.Json\"]},\"framework_list\":[],\"id\":\"FSharp.SystemTextJson\",\"sha512\":\"sha512-7SoZOjo4dY6Ez47RSL5pWVAGiy8SPCzpjD4oBoGEkMNsnrRcy1WhD8jB2XyRufrboyBxKbGp7ZKMAQlDIc1Crg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"0.16.6\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net46\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net461\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net462\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net47\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net471\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net472\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net48\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net5.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net6.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net7.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net8.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netcoreapp2.1\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netcoreapp2.2\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netcoreapp3.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netcoreapp3.1\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netstandard2.1\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"]},\"framework_list\":[],\"id\":\"FSharpx.Async\",\"sha512\":\"sha512-8Ye/hgNHsnHWFtanfED+tgJJzPq4QEt+LUQ87Ie2JOiqb6WUP+vtF3WRBO2NIDqGQpivh207nwmCoFdK+T6jwQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"1.14.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"FSharp.Core\"],\"net451\":[\"FSharp.Core\"],\"net452\":[\"FSharp.Core\"],\"net46\":[\"FSharp.Core\"],\"net461\":[\"FSharp.Core\"],\"net462\":[\"FSharp.Core\"],\"net47\":[\"FSharp.Core\"],\"net471\":[\"FSharp.Core\"],\"net472\":[\"FSharp.Core\"],\"net48\":[\"FSharp.Core\"],\"net5.0\":[\"FSharp.Core\"],\"net6.0\":[\"FSharp.Core\"],\"net7.0\":[\"FSharp.Core\"],\"net8.0\":[\"FSharp.Core\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\"],\"netcoreapp2.1\":[\"FSharp.Core\"],\"netcoreapp2.2\":[\"FSharp.Core\"],\"netcoreapp3.0\":[\"FSharp.Core\"],\"netcoreapp3.1\":[\"FSharp.Core\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\"],\"netstandard2.1\":[\"FSharp.Core\"]},\"framework_list\":[],\"id\":\"FSharpx.Collections\",\"sha512\":\"sha512-1KSJLhLpqOTPRKYkgi0YvPrvGybiYi642r53VrQb1U7LNd3VQNsh3z++v69ky8FEj4y+kP6NPbgZbFyJ8mumqA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.1.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net46\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net461\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net462\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net47\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net471\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net472\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net48\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net5.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net6.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net7.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net8.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netcoreapp2.1\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netcoreapp2.2\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netcoreapp3.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netcoreapp3.1\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netstandard2.1\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"]},\"framework_list\":[],\"id\":\"FSharpx.Extras\",\"sha512\":\"sha512-7Wv7LF8hZfGG6KuXcQoGTnm6keDAtMwvI6S2lK90Z23Dvs44XGeRAGOsLRO3dg2k6atckdt6xd0SDqQ9FSa4vA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Bcl.AsyncInterfaces\",\"sha512\":\"sha512-IhoFoMkQ96h7Yg2PODHtOStOuV0RK+4nTTXycAmtKiZEXenXzSNf5vtKA/JVCHS9o7493dlu2vnAhSqcI9ewmQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"NETStandard.Library\"],\"netstandard1.1\":[\"NETStandard.Library\"],\"netstandard1.2\":[\"NETStandard.Library\"],\"netstandard1.3\":[\"NETStandard.Library\"],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.CSharp\",\"sha512\":\"sha512-LJaYhRX5VxTUuD9WUPGD3GpWTgs89SVfoOPvSEdt66tL3lQvny9sR/ZiC3px1qUV5EFebS44i2CBeiliHVaQ3w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"Microsoft.Extensions.Primitives\"],\"net462\":[\"Microsoft.Extensions.Primitives\"],\"net47\":[\"Microsoft.Extensions.Primitives\"],\"net471\":[\"Microsoft.Extensions.Primitives\"],\"net472\":[\"Microsoft.Extensions.Primitives\"],\"net48\":[\"Microsoft.Extensions.Primitives\"],\"net5.0\":[\"Microsoft.Extensions.Primitives\"],\"net6.0\":[\"Microsoft.Extensions.Primitives\"],\"net7.0\":[\"Microsoft.Extensions.Primitives\"],\"net8.0\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp2.1\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp2.2\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp3.0\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp3.1\":[\"Microsoft.Extensions.Primitives\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"Microsoft.Extensions.Primitives\"],\"netstandard2.1\":[\"Microsoft.Extensions.Primitives\"]},\"framework_list\":[],\"id\":\"Microsoft.Extensions.FileProviders.Abstractions\",\"sha512\":\"sha512-/pqhjy6BlpTyDjIsk+B14nvuLVfd1TgGJPxIqVZpxSbCcKtcdPWMakch0Y7NtbL+vwMV+HlFha5lYXgxRZ4qCw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Extensions.FileSystemGlobbing\",\"sha512\":\"sha512-I6XlDPaVuhjHp398BQ5A1vsGWVdIDbF/XnXlzyacj1B2PJlsKNDc/KCeLBJIVAiYq1PEdMrccFVI9f5JHdJj/Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net462\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net47\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net471\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net472\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net48\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net5.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net6.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.2\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard2.1\":[\"System.Runtime.CompilerServices.Unsafe\"]},\"framework_list\":[],\"id\":\"Microsoft.Extensions.Primitives\",\"sha512\":\"sha512-H1R1yj084YRjRW3RNa+sUC1vgv6m5OSBSmH4ZhbDSN7PKLc9FcK7J20aPAOepgZPdeEyn286ZMqjUg1wq5LDLQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[\"Microsoft.CSharp|6.0.0.0\",\"Microsoft.VisualBasic.Core|11.0.0.0\",\"Microsoft.VisualBasic|10.0.0.0\",\"Microsoft.Win32.Primitives|6.0.0.0\",\"Microsoft.Win32.Registry|6.0.0.0\",\"System.AppContext|6.0.0.0\",\"System.Buffers|6.0.0.0\",\"System.Collections.Concurrent|6.0.0.0\",\"System.Collections.Immutable|6.0.0.0\",\"System.Collections.NonGeneric|6.0.0.0\",\"System.Collections.Specialized|6.0.0.0\",\"System.Collections|6.0.0.0\",\"System.ComponentModel.Annotations|6.0.0.0\",\"System.ComponentModel.DataAnnotations|4.0.0.0\",\"System.ComponentModel.EventBasedAsync|6.0.0.0\",\"System.ComponentModel.Primitives|6.0.0.0\",\"System.ComponentModel.TypeConverter|6.0.0.0\",\"System.ComponentModel|6.0.0.0\",\"System.Configuration|4.0.0.0\",\"System.Console|6.0.0.0\",\"System.Core|4.0.0.0\",\"System.Data.Common|6.0.0.0\",\"System.Data.DataSetExtensions|4.0.0.0\",\"System.Data|4.0.0.0\",\"System.Diagnostics.Contracts|6.0.0.0\",\"System.Diagnostics.Debug|6.0.0.0\",\"System.Diagnostics.DiagnosticSource|6.0.0.0\",\"System.Diagnostics.FileVersionInfo|6.0.0.0\",\"System.Diagnostics.Process|6.0.0.0\",\"System.Diagnostics.StackTrace|6.0.0.0\",\"System.Diagnostics.TextWriterTraceListener|6.0.0.0\",\"System.Diagnostics.Tools|6.0.0.0\",\"System.Diagnostics.TraceSource|6.0.0.0\",\"System.Diagnostics.Tracing|6.0.0.0\",\"System.Drawing.Primitives|6.0.0.0\",\"System.Drawing|4.0.0.0\",\"System.Dynamic.Runtime|6.0.0.0\",\"System.Formats.Asn1|6.0.0.0\",\"System.Globalization.Calendars|6.0.0.0\",\"System.Globalization.Extensions|6.0.0.0\",\"System.Globalization|6.0.0.0\",\"System.IO.Compression.Brotli|6.0.0.0\",\"System.IO.Compression.FileSystem|4.0.0.0\",\"System.IO.Compression.ZipFile|6.0.0.0\",\"System.IO.Compression|6.0.0.0\",\"System.IO.FileSystem.AccessControl|6.0.0.0\",\"System.IO.FileSystem.DriveInfo|6.0.0.0\",\"System.IO.FileSystem.Primitives|6.0.0.0\",\"System.IO.FileSystem.Watcher|6.0.0.0\",\"System.IO.FileSystem|6.0.0.0\",\"System.IO.IsolatedStorage|6.0.0.0\",\"System.IO.MemoryMappedFiles|6.0.0.0\",\"System.IO.Pipes.AccessControl|6.0.0.0\",\"System.IO.Pipes|6.0.0.0\",\"System.IO.UnmanagedMemoryStream|6.0.0.0\",\"System.IO|6.0.0.0\",\"System.Linq.Expressions|6.0.0.0\",\"System.Linq.Parallel|6.0.0.0\",\"System.Linq.Queryable|6.0.0.0\",\"System.Linq|6.0.0.0\",\"System.Memory|6.0.0.0\",\"System.Net.Http.Json|6.0.0.0\",\"System.Net.Http|6.0.0.0\",\"System.Net.HttpListener|6.0.0.0\",\"System.Net.Mail|6.0.0.0\",\"System.Net.NameResolution|6.0.0.0\",\"System.Net.NetworkInformation|6.0.0.0\",\"System.Net.Ping|6.0.0.0\",\"System.Net.Primitives|6.0.0.0\",\"System.Net.Requests|6.0.0.0\",\"System.Net.Security|6.0.0.0\",\"System.Net.ServicePoint|6.0.0.0\",\"System.Net.Sockets|6.0.0.0\",\"System.Net.WebClient|6.0.0.0\",\"System.Net.WebHeaderCollection|6.0.0.0\",\"System.Net.WebProxy|6.0.0.0\",\"System.Net.WebSockets.Client|6.0.0.0\",\"System.Net.WebSockets|6.0.0.0\",\"System.Net|4.0.0.0\",\"System.Numerics.Vectors|6.0.0.0\",\"System.Numerics|4.0.0.0\",\"System.ObjectModel|6.0.0.0\",\"System.Reflection.DispatchProxy|6.0.0.0\",\"System.Reflection.Emit.ILGeneration|6.0.0.0\",\"System.Reflection.Emit.Lightweight|6.0.0.0\",\"System.Reflection.Emit|6.0.0.0\",\"System.Reflection.Extensions|6.0.0.0\",\"System.Reflection.Metadata|6.0.0.0\",\"System.Reflection.Primitives|6.0.0.0\",\"System.Reflection.TypeExtensions|6.0.0.0\",\"System.Reflection|6.0.0.0\",\"System.Resources.Reader|6.0.0.0\",\"System.Resources.ResourceManager|6.0.0.0\",\"System.Resources.Writer|6.0.0.0\",\"System.Runtime.CompilerServices.Unsafe|6.0.0.0\",\"System.Runtime.CompilerServices.VisualC|6.0.0.0\",\"System.Runtime.Extensions|6.0.0.0\",\"System.Runtime.Handles|6.0.0.0\",\"System.Runtime.InteropServices.RuntimeInformation|6.0.0.0\",\"System.Runtime.InteropServices|6.0.0.0\",\"System.Runtime.Intrinsics|6.0.0.0\",\"System.Runtime.Loader|6.0.0.0\",\"System.Runtime.Numerics|6.0.0.0\",\"System.Runtime.Serialization.Formatters|6.0.0.0\",\"System.Runtime.Serialization.Json|6.0.0.0\",\"System.Runtime.Serialization.Primitives|6.0.0.0\",\"System.Runtime.Serialization.Xml|6.0.0.0\",\"System.Runtime.Serialization|4.0.0.0\",\"System.Runtime|6.0.0.0\",\"System.Security.AccessControl|6.0.0.0\",\"System.Security.Claims|6.0.0.0\",\"System.Security.Cryptography.Algorithms|6.0.0.0\",\"System.Security.Cryptography.Cng|6.0.0.0\",\"System.Security.Cryptography.Csp|6.0.0.0\",\"System.Security.Cryptography.Encoding|6.0.0.0\",\"System.Security.Cryptography.OpenSsl|6.0.0.0\",\"System.Security.Cryptography.Primitives|6.0.0.0\",\"System.Security.Cryptography.X509Certificates|6.0.0.0\",\"System.Security.Principal.Windows|6.0.0.0\",\"System.Security.Principal|6.0.0.0\",\"System.Security.SecureString|6.0.0.0\",\"System.Security|4.0.0.0\",\"System.ServiceModel.Web|4.0.0.0\",\"System.ServiceProcess|4.0.0.0\",\"System.Text.Encoding.CodePages|6.0.0.0\",\"System.Text.Encoding.Extensions|6.0.0.0\",\"System.Text.Encoding|6.0.0.0\",\"System.Text.Encodings.Web|6.0.0.0\",\"System.Text.Json|6.0.0.0\",\"System.Text.RegularExpressions|6.0.0.0\",\"System.Threading.Channels|6.0.0.0\",\"System.Threading.Overlapped|6.0.0.0\",\"System.Threading.Tasks.Dataflow|6.0.0.0\",\"System.Threading.Tasks.Extensions|6.0.0.0\",\"System.Threading.Tasks.Parallel|6.0.0.0\",\"System.Threading.Tasks|6.0.0.0\",\"System.Threading.Thread|6.0.0.0\",\"System.Threading.ThreadPool|6.0.0.0\",\"System.Threading.Timer|6.0.0.0\",\"System.Threading|6.0.0.0\",\"System.Transactions.Local|6.0.0.0\",\"System.Transactions|4.0.0.0\",\"System.ValueTuple|4.0.3.0\",\"System.Web.HttpUtility|6.0.0.0\",\"System.Web|4.0.0.0\",\"System.Windows|4.0.0.0\",\"System.Xml.Linq|4.0.0.0\",\"System.Xml.ReaderWriter|6.0.0.0\",\"System.Xml.Serialization|4.0.0.0\",\"System.Xml.XDocument|6.0.0.0\",\"System.Xml.XPath.XDocument|6.0.0.0\",\"System.Xml.XPath|6.0.0.0\",\"System.Xml.XmlDocument|6.0.0.0\",\"System.Xml.XmlSerializer|6.0.0.0\",\"System.Xml|4.0.0.0\",\"System|4.0.0.0\",\"WindowsBase|4.0.0.0\",\"mscorlib|4.0.0.0\",\"netstandard|2.1.0.0\"],\"id\":\"Microsoft.NETCore.App.Ref\",\"sha512\":\"sha512-quj/gyLoZLypJO7PwsZ8ib6ZSgFv1C9s5SJgwzl/gztynTJ/3oO/stA2gNMf0C33vTJ0J3SSF/kRPQ/ifY5xZg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[\"Microsoft.CSharp|4.4.0\",\"Microsoft.Win32.Primitives|4.3.0\",\"Microsoft.Win32.Registry|4.4.0\",\"runtime.debian.8-x64.runtime.native.System|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"System.AppContext|4.3.0\",\"System.Buffers|4.4.0\",\"System.Collections|4.3.0\",\"System.Collections.Concurrent|4.3.0\",\"System.Collections.Immutable|1.4.0\",\"System.Collections.NonGeneric|4.3.0\",\"System.Collections.Specialized|4.3.0\",\"System.ComponentModel|4.3.0\",\"System.ComponentModel.EventBasedAsync|4.3.0\",\"System.ComponentModel.Primitives|4.3.0\",\"System.ComponentModel.TypeConverter|4.3.0\",\"System.Console|4.3.0\",\"System.Data.Common|4.3.0\",\"System.Diagnostics.Contracts|4.3.0\",\"System.Diagnostics.Debug|4.3.0\",\"System.Diagnostics.DiagnosticSource|4.4.0\",\"System.Diagnostics.FileVersionInfo|4.3.0\",\"System.Diagnostics.Process|4.3.0\",\"System.Diagnostics.StackTrace|4.3.0\",\"System.Diagnostics.TextWriterTraceListener|4.3.0\",\"System.Diagnostics.Tools|4.3.0\",\"System.Diagnostics.TraceSource|4.3.0\",\"System.Diagnostics.Tracing|4.3.0\",\"System.Dynamic.Runtime|4.3.0\",\"System.Globalization|4.3.0\",\"System.Globalization.Calendars|4.3.0\",\"System.Globalization.Extensions|4.3.0\",\"System.IO|4.3.0\",\"System.IO.Compression|4.3.0\",\"System.IO.Compression.ZipFile|4.3.0\",\"System.IO.FileSystem|4.3.0\",\"System.IO.FileSystem.AccessControl|4.4.0\",\"System.IO.FileSystem.DriveInfo|4.3.0\",\"System.IO.FileSystem.Primitives|4.3.0\",\"System.IO.FileSystem.Watcher|4.3.0\",\"System.IO.IsolatedStorage|4.3.0\",\"System.IO.MemoryMappedFiles|4.3.0\",\"System.IO.Pipes|4.3.0\",\"System.IO.UnmanagedMemoryStream|4.3.0\",\"System.Linq|4.3.0\",\"System.Linq.Expressions|4.3.0\",\"System.Linq.Queryable|4.3.0\",\"System.Net.Http|4.3.0\",\"System.Net.NameResolution|4.3.0\",\"System.Net.Primitives|4.3.0\",\"System.Net.Requests|4.3.0\",\"System.Net.Security|4.3.0\",\"System.Net.Sockets|4.3.0\",\"System.Net.WebHeaderCollection|4.3.0\",\"System.ObjectModel|4.3.0\",\"System.Private.DataContractSerialization|4.3.0\",\"System.Reflection|4.3.0\",\"System.Reflection.Emit|4.3.0\",\"System.Reflection.Emit.ILGeneration|4.3.0\",\"System.Reflection.Emit.Lightweight|4.3.0\",\"System.Reflection.Extensions|4.3.0\",\"System.Reflection.Metadata|1.5.0\",\"System.Reflection.Primitives|4.3.0\",\"System.Reflection.TypeExtensions|4.3.0\",\"System.Resources.ResourceManager|4.3.0\",\"System.Runtime|4.3.0\",\"System.Runtime.Extensions|4.3.0\",\"System.Runtime.Handles|4.3.0\",\"System.Runtime.InteropServices|4.3.0\",\"System.Runtime.InteropServices.RuntimeInformation|4.3.0\",\"System.Runtime.Loader|4.3.0\",\"System.Runtime.Numerics|4.3.0\",\"System.Runtime.Serialization.Formatters|4.3.0\",\"System.Runtime.Serialization.Json|4.3.0\",\"System.Runtime.Serialization.Primitives|4.3.0\",\"System.Security.AccessControl|4.4.0\",\"System.Security.Claims|4.3.0\",\"System.Security.Cryptography.Algorithms|4.3.0\",\"System.Security.Cryptography.Cng|4.4.0\",\"System.Security.Cryptography.Csp|4.3.0\",\"System.Security.Cryptography.Encoding|4.3.0\",\"System.Security.Cryptography.OpenSsl|4.4.0\",\"System.Security.Cryptography.Primitives|4.3.0\",\"System.Security.Cryptography.X509Certificates|4.3.0\",\"System.Security.Cryptography.Xml|4.4.0\",\"System.Security.Principal|4.3.0\",\"System.Security.Principal.Windows|4.4.0\",\"System.Text.Encoding|4.3.0\",\"System.Text.Encoding.Extensions|4.3.0\",\"System.Text.RegularExpressions|4.3.0\",\"System.Threading|4.3.0\",\"System.Threading.Overlapped|4.3.0\",\"System.Threading.Tasks|4.3.0\",\"System.Threading.Tasks.Extensions|4.3.0\",\"System.Threading.Tasks.Parallel|4.3.0\",\"System.Threading.Thread|4.3.0\",\"System.Threading.ThreadPool|4.3.0\",\"System.Threading.Timer|4.3.0\",\"System.ValueTuple|4.3.0\",\"System.Xml.ReaderWriter|4.3.0\",\"System.Xml.XDocument|4.3.0\",\"System.Xml.XmlDocument|4.3.0\",\"System.Xml.XmlSerializer|4.3.0\",\"System.Xml.XPath|4.3.0\",\"System.Xml.XPath.XDocument|4.3.0\"],\"version\":\"6.0.5\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.NETCore.Platforms\",\"sha512\":\"sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.5\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.NETCore.Targets\",\"sha512\":\"sha512-hYHm3JAjQO/nySxcl1EpZhYEW+2P3H1eLZNr+QxgO5TnLS6hqtfi5WchjQzjid45MYmhy2X7IOmcWtDP4fpMGw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Web.Xdt\",\"sha512\":\"sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.1.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Win32.SystemEvents\",\"sha512\":\"sha512-tCbvWn9ymrxUuAlYZCQ7eDwVSn7571UIeMYWizWCXPjQlESdfIGr1W6EXhrFm8BgPt2e9G5bJfxVrzx2knWR6A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Mono.Cecil\",\"sha512\":\"sha512-CnjwUMmFHnScNG8e/4DRZQQX67H5ajekRDudmZ6Fy1jCLhyH1jjzbQCOEFhBLa2NjPWQpMF+RHdBJY8a7GgmlA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"0.11.4\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"Microsoft.NETCore.Platforms\"],\"net451\":[\"Microsoft.NETCore.Platforms\"],\"net452\":[\"Microsoft.NETCore.Platforms\"],\"net46\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization.Calendars\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Net.Http\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\"],\"net461\":[\"Microsoft.NETCore.Platforms\"],\"net462\":[\"Microsoft.NETCore.Platforms\"],\"net47\":[\"Microsoft.NETCore.Platforms\"],\"net471\":[\"Microsoft.NETCore.Platforms\"],\"net472\":[\"Microsoft.NETCore.Platforms\"],\"net48\":[\"Microsoft.NETCore.Platforms\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Linq\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\"]},\"framework_list\":[],\"id\":\"NETStandard.Library\",\"sha512\":\"sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.0.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netcoreapp1.1\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.1\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.2\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.3\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.4\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.5\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.6\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Newtonsoft.Json\",\"sha512\":\"sha512-g3MbZi6vBTeaI/hEbvR7vBETSd1DWLe9i1E4P+nPY34v5i94zqUqDXvdWC3G+7tYN9SnsdU9zzegrnRz4h7nsQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"13.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net462\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net47\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net471\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net472\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net48\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net5.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net6.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net7.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net8.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp2.2\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp3.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp3.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netstandard2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"]},\"framework_list\":[],\"id\":\"NuGet.Commands\",\"sha512\":\"sha512-+fjzHcRYfT61xykFQfdAtRW5OMrqKRm2jwCPmGLWQn/uSGE9zEdKJD+HByWjV1EzJ/01FIYrKB94zg0ShDKjJQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Frameworks\"],\"net462\":[\"NuGet.Frameworks\"],\"net47\":[\"NuGet.Frameworks\"],\"net471\":[\"NuGet.Frameworks\"],\"net472\":[\"NuGet.Frameworks\"],\"net48\":[\"NuGet.Frameworks\"],\"net5.0\":[\"NuGet.Frameworks\"],\"net6.0\":[\"NuGet.Frameworks\"],\"net7.0\":[\"NuGet.Frameworks\"],\"net8.0\":[\"NuGet.Frameworks\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Frameworks\"],\"netcoreapp2.1\":[\"NuGet.Frameworks\"],\"netcoreapp2.2\":[\"NuGet.Frameworks\"],\"netcoreapp3.0\":[\"NuGet.Frameworks\"],\"netcoreapp3.1\":[\"NuGet.Frameworks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Frameworks\"],\"netstandard2.1\":[\"NuGet.Frameworks\"]},\"framework_list\":[],\"id\":\"NuGet.Common\",\"sha512\":\"sha512-xxmTBZqBfMCaou4rJFKReYbTrfQXb4OfcT9QyVLN1nEe36KditRl0Uki0R03RVimNKeTzKjBUF6I4CZTAeu2YQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net462\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net47\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net471\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net472\":[\"NuGet.Common\"],\"net48\":[\"NuGet.Common\"],\"net5.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net6.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net7.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net8.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"]},\"framework_list\":[],\"id\":\"NuGet.Configuration\",\"sha512\":\"sha512-MqkkKtRGH3Z73v1WylGpDMoUrVlNqoEFcaWE1Apudb6AWJYqGh4vyZUMdXsitoVpiakP3iiAMtprh4Gfa/Cv6Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Credentials\",\"sha512\":\"sha512-G5JCMbC24Cd0wFz7fZCXRKF5ZqWcm6UGwA3Y+nC9/pbV9sIkPKEsDYk6/QUBLIVnXbB3J1o5zgULa95QJ99bAg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net462\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net47\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net471\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net472\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net48\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.DependencyResolver.Core\",\"sha512\":\"sha512-8SGR7UF/A+tAgdTRIsh3v8qg47w9farAAXvHlbYylL+sFRIp36yGF0C1sXMuD/DEIl6GLc2M/UdawB+FpHg/tw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Frameworks\",\"sha512\":\"sha512-weGyDjVXp4LUKR9ZjMrtd38J6MkUC5xPU9hcGdksZBB0r+bJmKoZ5NJQAXLFbP3m5BhPLYIl3/aEmPlkCV25Og==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net462\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net47\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net471\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net472\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net48\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net5.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net6.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net7.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net8.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"]},\"framework_list\":[],\"id\":\"NuGet.LibraryModel\",\"sha512\":\"sha512-YPHMmVII4QqjShzNUX61qg4u/j9mFhBD5iLDCnk8UgEmiWzQRLDFCvXCmbRoYznLJz2995sD7idtqWsvOh4YnA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net462\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net47\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net471\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net472\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\"],\"net48\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\"],\"net5.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net6.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net7.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net8.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.2\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"]},\"framework_list\":[],\"id\":\"NuGet.PackageManagement\",\"sha512\":\"sha512-QMP/PiheJgBQsP66XNmhdBqnpeyRmqfZjhsfAhjMgm8gfd2k6OGXb2LOV7hN6xbfbj9KrtMiwfzOvuZA6q27KQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net462\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net47\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net471\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net472\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net48\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net5.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net6.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net7.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net8.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.2\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netstandard2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"]},\"framework_list\":[],\"id\":\"Nuget.Packaging\",\"sha512\":\"sha512-jEfG/a8hNhTDSWOadBi0nZRdTO+PXR98j4u6RnZ68Nyuw4LHviEXOG1kqZvraU3uYGssAoJatkFDYAM8kEX+WQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.DependencyResolver.Core\"],\"net462\":[\"NuGet.DependencyResolver.Core\"],\"net47\":[\"NuGet.DependencyResolver.Core\"],\"net471\":[\"NuGet.DependencyResolver.Core\"],\"net472\":[\"NuGet.DependencyResolver.Core\"],\"net48\":[\"NuGet.DependencyResolver.Core\"],\"net5.0\":[\"NuGet.DependencyResolver.Core\"],\"net6.0\":[\"NuGet.DependencyResolver.Core\"],\"net7.0\":[\"NuGet.DependencyResolver.Core\"],\"net8.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.1\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.2\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.1\":[\"NuGet.DependencyResolver.Core\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.DependencyResolver.Core\"],\"netstandard2.1\":[\"NuGet.DependencyResolver.Core\"]},\"framework_list\":[],\"id\":\"NuGet.ProjectModel\",\"sha512\":\"sha512-BnheauzOjo1U/hCg0jyhflaNbffCbfZnquHc18+VneSANMB54Mg/xjHPLibx3R5zneQ6E3n0K50wtfRntrkH8g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Protocol\",\"sha512\":\"sha512-/r+i3gmVYWa8KMETanGyaCqMPVLTwe8Gqza5khiDiETATeGEd+y7erJsy/pLwBpnl0/jSYpf+kxPq16xoiej6A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Resolver\",\"sha512\":\"sha512-kLoXgmxb0dpzK5Dx1SiaTj2l0EXtU42HSMD9bQgjoc3BWi/5Fn6VvGe8Pd7U4firGmvxgkmmO0lJx6iF0dLLxQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Versioning\",\"sha512\":\"sha512-aZ0/Fd85juLKrg0rZw4rWJAFDuv0aW3SJj3fqwp5etkRZOwHO/11vmGh0eeMZ7gMAvnktvxax7h5Vaxkllv2ZA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net462\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net47\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net471\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net472\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net48\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net5.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net6.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net7.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net8.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.1\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.2\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.1\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard2.1\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"]},\"framework_list\":[],\"id\":\"Paket.Core\",\"sha512\":\"sha512-Wn1E0lIbjitqogRA6sLRJLxKeIjqLLi5oeFClqGCwUBixPIZ58KM75NwtDAtbiyTqo7KdNBSoAuBI7z4P8lL5w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-s9AMelYhmifrJqGjkRkqyoP7NMudky0vJPdYzjGKryWYhofREwzC4EesqYm+dooMQB++vbgvGrtrcZpU36Q+sA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-1kcSfJKTg00KxR43jsnYjjYTPoUh+f+OLpL4/yF/bzKikgxV6QPlz74UyrypYprz3NUHHOcsa12E7+Xp4RtTng==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-DPcJlXiNYg8lqqCAFTgaL9Yqs1brKG3H6b1XVimLf9RYxW7zOLujvf3HfTlvrYEWsAulgJ/+7Gh0mCw4FUt+IQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-2p9EjZTy8LkH/wx6OwRuk0ORuVL7PzqJ3cdvL/SY58Ep+XW0AYEBjyy7kloJ/nPZGYVUT+NS8kNwPU5ICV/DwQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-2v5kHzEZgBFCz+5NJgZn3Dmi9gaYY/loR5PJEXvOJ018XIF6BmSGYNyHNXTmdFPq50EjwaGpHj8cQmR3z5oeGA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-qfB0WU/HXLYhTlXpDZi0eY1p1x9jlwxDlVFcWrj9u+2gFEesUKux9IoR9bzQLPPj//B0dSWolKEgW/1X70VWCA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net20\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net30\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net35\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net40\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net403\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net45\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net451\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net452\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net46\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net461\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net462\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net47\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net471\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net472\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net48\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"]},\"framework_list\":[],\"id\":\"runtime.native.System\",\"sha512\":\"sha512-AJsN0GLPijYtmFZdvPYnfTdAMTlvMttusjye6ZC1Edg5XUneNv1BCHzXfM0SWpqf+Gt/31WthibAPAorcN4F1g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net20\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net30\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net35\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net40\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net403\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net45\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net451\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net452\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net46\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net461\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net462\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net47\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net471\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net472\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net48\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"]},\"framework_list\":[],\"id\":\"runtime.native.System.Net.Http\",\"sha512\":\"sha512-n3clBjCv4nEoDl/hV4/DYwi/yoRrFZk9Tpe0TenLiITLHvtijO+OSYhwV7JmACcsZlLFKMaYW+P5yN3sK/xU0Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net20\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net30\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net35\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net40\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net403\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net45\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net451\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net452\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net46\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net461\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net462\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net47\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net471\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net472\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net48\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net5.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net6.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net7.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net8.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp1.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp1.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp2.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp2.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp2.2\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp3.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp3.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.2\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.3\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.4\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.5\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.6\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard2.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard2.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"]},\"framework_list\":[],\"id\":\"runtime.native.System.Security.Cryptography.Apple\",\"sha512\":\"sha512-C+AZUmQBFgXR/NxF80q0Sy7SgYiW+C3CcIuA7yd0f1FXWN16xhIRSmXN92IUSGx/ebGN3XmaeuVUZpd+NuY/jQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net20\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net30\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net35\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net40\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net403\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net45\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net451\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net452\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net46\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net461\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net462\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net47\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net471\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net472\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net48\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net5.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net6.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net7.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net8.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp1.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp1.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp2.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp2.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp2.2\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp3.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp3.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.2\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.3\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.4\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.5\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.6\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard2.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard2.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"]},\"framework_list\":[],\"id\":\"runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-CiS94rEK+DWQJJbFqOc+SboSZQeswgRiao5QMZjHjhhRPi2NkawZZ0l99i8+eGNTVo6f4cYTOXVmNr0BeJTiYQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-kbvMwf5iS0oM7qiHPy3sHADQa2ncqFXVz7bQKCiPKcnNu5NTDz4cO/Nk4gy54iYjU0SSma/z2IfYIpPGVsdiZA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-anMSS/nfTUvTuvUE3jg+sSEx7JUgLkeYS7T9dbb8ZE42XYWdaLJjRlp3qA/yYyoewJuVJ6ZPeI8w9QrlKgVSow==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-KHQzsD6iTnD3Rpr+Odhe0II9LMwTJkIOMKekGzBz5TQlNbEpuc0LwQxMuCE4FZnzcefRYw3kDd5Xyu+AFND8FQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\",\"sha512\":\"sha512-YVeP6XccbJen1k3sjfntjqWS+vAcVt37VW3eBuZvjH7ZlTmQz3t6n8gLNh342IeDSBM+06SPYtBqP1roAlIpDA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-KBHT4RWCC3klyYzHWLweXSAPRzPLuzFdfixnzojA+tNUE6kHpyABhtbgTiwhGHyA3+TlyLOn1viw1NBoG7ZOxQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-Lmw34chaD1jDOrmiEl2jIXVoCfYhTFMWQWtC47RDRLKYpwLOjOkSa6E2LM5K28UNpkSOZu579Os/t+eZ+wAhOw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-K6KLKN1ICpOqvVG2Dub+uX3gb/MqqiS1deVZpuj46M7ya9ranrGzFYVIMsQFI8f7vhc+sf0gyTtN0es9tN4jmw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-IXiZH+OL4lP8dRKieebADFgWPgyq/vbMbYqXCz9EhfaU4CcRl1ygb3pmpNWhVJsVEV3fRb3tEaEFowmkb56WCQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-uOpq6ML3XC+QioF01mDpg6zuJEZs23+vjpbnOKQkZxyMSOGNanyleAjNgXLZyUo0NPa5c8QIMB878SvxLSxjhA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-fefg8Dxuv7BKypFbd1HKIdO/x51l+NN4WP5GIqe+Gx6El1Aut7zZA5a9B8WPowDiGCwPIqEJaIhdwCjmbHqscQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Collections\",\"sha512\":\"sha512-ynuVLTDaFIfKTkOqUigXte4m5+EFNwYoEBEvxnp1EnZsOdQC85S7BCbREIu8+bu2Tpzh9a9zbvIVpRo15V8FGw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"net6.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"net7.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"net8.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Collections.Concurrent\",\"sha512\":\"sha512-NcGqPmNiFv5dwuvrUEKT5prWNV0m4iRTrwYK+U2CefqpO9z+EnrssLMWx+fZGFvKxy6ZSYTv238thRXx9Vz2gg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.ComponentModel.Composition\",\"sha512\":\"sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Security.Permissions\"],\"net462\":[\"System.Security.Permissions\"],\"net47\":[\"System.Security.Permissions\"],\"net471\":[\"System.Security.Permissions\"],\"net472\":[\"System.Security.Permissions\"],\"net48\":[\"System.Security.Permissions\"],\"net5.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"net6.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"net7.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"net8.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp2.1\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp2.2\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp3.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp3.1\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netstandard2.1\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"]},\"framework_list\":[],\"id\":\"System.Configuration.ConfigurationManager\",\"sha512\":\"sha512-3ljLko1jA6FjAf16qO2sN53+bEfm2AshZl+SurndX/UrPiRM9t8PlF8ccucckjN1YdvydS/DMkF0qMnsxwwyRw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Diagnostics.Debug\",\"sha512\":\"sha512-bFj+HjYY5/h2hMHOp+/H07Gb19+NJTX54ntixS9EHxG2eyEiXWvNYvQJ4CwqFiMcTbGb4zuPq1ubClyGYN2rJA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net462\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net47\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net471\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net472\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net48\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net5.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net6.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net7.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net8.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.2\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard2.1\":[\"System.Runtime.CompilerServices.Unsafe\"]},\"framework_list\":[],\"id\":\"System.Diagnostics.DiagnosticSource\",\"sha512\":\"sha512-dYnmo66bitfHxLjNBU2LPp6Dn98n7hRyk7ZKGVzaAPw2MHy+40dLxfw7susxMkWfL3C//aJF+/UDAPgH2YhUZg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Diagnostics.Tracing\",\"sha512\":\"sha512-0KXTDiYc1Ft9+rArf/vXa2TgybiS7YJuphSByYPAIIsFtpmBzXnpHNTlgR4c1MPOoGoa/OBYEezli+XkwgFp6g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.Win32.SystemEvents\"],\"net6.0\":[\"Microsoft.Win32.SystemEvents\"],\"net7.0\":[\"Microsoft.Win32.SystemEvents\"],\"net8.0\":[\"Microsoft.Win32.SystemEvents\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[\"Microsoft.Win32.SystemEvents\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Drawing.Common\",\"sha512\":\"sha512-1h8KPgHD6sFfE/wboEosfOTqyVZACy+qNh/sq9ODbUnVvTRPOYXuPZTNw/anK44H5CPNspZbT1yiIitd4ymI5A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Formats.Asn1\",\"sha512\":\"sha512-KAcODhtEEDJs6494uw0/s/BxymRWD1yV4JHd0QOx8IV4B8JocCvk2mfOmmwVptBxydT25WJvOnzmh2vjoqbbwg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Globalization\",\"sha512\":\"sha512-gj0rowjLBztAoxRuzM0Nn9exYVrD+++xb3PYc+QR/YHDvch98gbT3H4vFMnNU6r8poSjVwwlRxKAqtqN6AXs4g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Globalization.Calendars\",\"sha512\":\"sha512-6XGQIxQCs5N3S5Je/AKiv6QdHRF6F/uH2m45n1I0VGlidn6c2POZcO+kCOT0U80eZ1Giph42a8l0BuGwuKS+hg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"]},\"framework_list\":[],\"id\":\"System.Globalization.Extensions\",\"sha512\":\"sha512-pNNgAD+V4MMe3znAuR4cc4UKYKxdADKxfbiIo8fXE0zvms2XIZ0UF0rSE7fARPSbNkzFcgBz6/y24b9uTsJM5Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.IO\",\"sha512\":\"sha512-v8paIePhmGuXZbE9xvvNb4uJ5ME4OFXR1+8la/G/L1GIl2nbU2WFnddgb79kVK3U2us7q1aZT/uY/R0D/ovB5g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.IO.FileSystem.Primitives\"],\"net461\":[\"System.IO.FileSystem.Primitives\"],\"net462\":[\"System.IO.FileSystem.Primitives\"],\"net47\":[\"System.IO.FileSystem.Primitives\"],\"net471\":[\"System.IO.FileSystem.Primitives\"],\"net472\":[\"System.IO.FileSystem.Primitives\"],\"net48\":[\"System.IO.FileSystem.Primitives\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.IO.FileSystem\",\"sha512\":\"sha512-T7WB1vhblSmgkaDpdGM3Uqo55Qsr5sip5eyowrwiXOoHBkzOx3ePd9+Zh97r9NzOwFCxqX7awO6RBxQuao7n7g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Runtime\"],\"net6.0\":[\"System.Runtime\"],\"net7.0\":[\"System.Runtime\"],\"net8.0\":[\"System.Runtime\"],\"netcoreapp1.0\":[\"System.Runtime\"],\"netcoreapp1.1\":[\"System.Runtime\"],\"netcoreapp2.0\":[\"System.Runtime\"],\"netcoreapp2.1\":[\"System.Runtime\"],\"netcoreapp2.2\":[\"System.Runtime\"],\"netcoreapp3.0\":[\"System.Runtime\"],\"netcoreapp3.1\":[\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.Runtime\"],\"netstandard1.4\":[\"System.Runtime\"],\"netstandard1.5\":[\"System.Runtime\"],\"netstandard1.6\":[\"System.Runtime\"],\"netstandard2.0\":[\"System.Runtime\"],\"netstandard2.1\":[\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.IO.FileSystem.Primitives\",\"sha512\":\"sha512-WIWVPQlYLP/Zc9I6IakpBk1y8ryVGK83MtZx//zGKKi2hvHQWKAB7moRQCOz5Is/wNDksiYpocf3FeA3le6e5Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net6.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net7.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net8.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.2\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard\":[],\"netstandard1.0\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.1\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.2\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.3\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.4\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.5\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.6\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"]},\"framework_list\":[],\"id\":\"System.Linq\",\"sha512\":\"sha512-6sx/4exSb0BfW6DmcfYW0OW+nBgo1UOp4vjGXfQJnWsupKn6LNrk80sXDcNxQvYOJn4TfKOfNQKB7XDS3GIEWA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.X509Certificates\"],\"net461\":[\"System.Security.Cryptography.X509Certificates\"],\"net462\":[\"System.Security.Cryptography.X509Certificates\"],\"net47\":[\"System.Security.Cryptography.X509Certificates\"],\"net471\":[\"System.Security.Cryptography.X509Certificates\"],\"net472\":[\"System.Security.Cryptography.X509Certificates\"],\"net48\":[\"System.Security.Cryptography.X509Certificates\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"System.IO\",\"System.Net.Primitives\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"System.IO\",\"System.Net.Primitives\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Net.Http\",\"sha512\":\"sha512-Fj7e73NNHwof97gFPTJuq8gv6G895yxkZt14DVnZdEh4gvKl8WrksCwNjIp/JeYX/yu/qxM/iOv9ai+ZY3Fp7Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.4\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Net.Http.WinHttpHandler\",\"sha512\":\"sha512-uLH7CWm9PZaO0SNhnEL8wvLCwcLCjC9M/jWgl7kTwp5PuFCfeCn7hrq6c0Bpfq2s1SCkx9lNUoRWnM76wMpnxQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"]},\"framework_list\":[],\"id\":\"System.Net.Primitives\",\"sha512\":\"sha512-BgdlyYCI7rrdh36p3lMTqbkvaafPETpB1bk9iQlFdQxYE692kiXvmseXs8ghL+gEgQF2xgDc8GH4QLkSgUUs+Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Reflection\",\"sha512\":\"sha512-IyW2ftYNzgMCgHBk8lQiy+G3+ydbU5tE+6PEqM5JJvIdeFKaXDSzHAPYDREPe6zpr5WJ1Fcma+rAFCIAV6+DMw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netcoreapp1.1\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.1\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.2\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.3\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.4\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.5\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.6\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Reflection.Emit.Lightweight\",\"sha512\":\"sha512-Blr1A9Vqk+ZUknlk6sFrhOcpuqx4bp7kqwZfhwkmmhz+9dgOl8cZ9CnSXbalbL9rfHmi5HDFydxQsfozl2PvjQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Reflection.Primitives\",\"sha512\":\"sha512-1LnMkF9aXKuQAgYzjoiQaL9mwY7oY6KdaO/zzeLMynNBEqKoUfLi5TiKIewoAF+hkxfGTZsjkjsF1jRL4uSeqg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Resources.ResourceManager\",\"sha512\":\"sha512-kGfbKPHEjQj8Uq1Apgj4jBStkRJkZ0Hdr0Jv3+aL7WGrAZVLF5Rh5h0Yc3FgDB5uXDbHiJk/WhBaZPVwKmuB1A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"]},\"framework_list\":[],\"id\":\"System.Runtime\",\"sha512\":\"sha512-Al69mPDfzdD+bKGK2HAfB+lNFOHFqnkqzNnUJmmvUe1/qEPK9M7EiTT4zuycKDPy7ev11xz8XVgJWKP0hm7NIA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Runtime.CompilerServices.Unsafe\",\"sha512\":\"sha512-1AVzAb5OxJNvJLnOADtexNmWgattm2XVOT3TjQTN7Dd4SqoSwai1CsN2fth42uQldJSQdz/sAec0+TzxBFgisw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Runtime.Extensions\",\"sha512\":\"sha512-VSbBNw3UQxuHk4aALPsYo154l+TKUR4Ij+Nj9GPnyJkzAmMewY1AyHXuaE+KCJ6JBj2SoO4uwLqY4ORKW9JRTw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Runtime.Handles\",\"sha512\":\"sha512-CluvHdVUv54BvLTOCCyybugreDNk/rR8unMPruzXDtxSjvrQOU3M4R831/lQf4YI8VYp668FGQa/01E+Rq8PEQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[\"System.Runtime\"],\"net47\":[\"System.Runtime\"],\"net471\":[\"System.Runtime\"],\"net472\":[\"System.Runtime\"],\"net48\":[\"System.Runtime\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"]},\"framework_list\":[],\"id\":\"System.Runtime.InteropServices\",\"sha512\":\"sha512-ZQeZw+ZU77ua1nFXycYM5G8oioFZe+N84qC/XUg1BEBl7z9luZcyjLu7+4H0yJuNfn1hOAiAAZ3u5us/lj9w2Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net6.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net7.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net8.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.2\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"System.Runtime\"],\"netstandard1.2\":[\"System.Runtime\"],\"netstandard1.3\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard1.4\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard1.5\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard1.6\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"]},\"framework_list\":[],\"id\":\"System.Runtime.Numerics\",\"sha512\":\"sha512-PjR/qo5+xITUgeU7HCGf4c40augniiFLRQjPDiM8Fie9nGxsfGVOjB9BQycYON3ZWT9joQQ1d62HxA45Kvf9NA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.AccessControl\",\"sha512\":\"sha512-ZKNqEDuVSrS36KdsDodleb1ITDCOREwtkV+5oP0FrWNhRQHtI1xUSvybQxy4pM8PBxW47UFOhZWObWhXkWj7RQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Primitives\"],\"net461\":[\"System.Security.Cryptography.Primitives\"],\"net462\":[\"System.Security.Cryptography.Primitives\"],\"net47\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net471\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net472\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net48\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.4\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.5\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Algorithms\",\"sha512\":\"sha512-NLArYLaaVOExC1EVEuMhCkm/sFhMUPgLWcWG1xgK2XPjtUGfelV4ODeIQ5VGDbPg2xPI+yfebRcLjS2rHJCtzw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net461\":[\"System.Security.Cryptography.Algorithms\"],\"net462\":[\"System.Security.Cryptography.Algorithms\"],\"net47\":[\"System.Security.Cryptography.Algorithms\"],\"net471\":[\"System.Security.Cryptography.Algorithms\"],\"net472\":[\"System.Security.Cryptography.Algorithms\"],\"net48\":[\"System.Security.Cryptography.Algorithms\"],\"net5.0\":[\"System.Formats.Asn1\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[\"System.Formats.Asn1\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.4\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.5\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.6\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Cng\",\"sha512\":\"sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net461\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net462\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net47\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net471\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net472\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net48\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Csp\",\"sha512\":\"sha512-QzF1kXR6GPUvaDGH4Jrf4OA1c+baxDC/O6E/RAzbHHux+SBTadXzsqDz/flgTVuh5tlKiZol0sUz5FMzhXjzUQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Encoding\",\"sha512\":\"sha512-XCat0j5jVC83UG9fofcuiYDwN0PVKc2OWD0QVLjYpXn7dz+gNaANkHPbhNtr5PR8rDQNHrxtI912Hb29YAB14A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Security.Cryptography.Algorithms\"],\"net462\":[\"System.Security.Cryptography.Algorithms\"],\"net47\":[\"System.Security.Cryptography.Algorithms\"],\"net471\":[\"System.Security.Cryptography.Algorithms\"],\"net472\":[\"System.Security.Cryptography.Algorithms\"],\"net48\":[\"System.Security.Cryptography.Algorithms\"],\"net5.0\":[\"System.Formats.Asn1\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[\"System.Formats.Asn1\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-+8P4Eo9HMcke1V4bPK6JjBaHilI5MAYLcqPKVHcpbJmW3O6qOCxutBmEiuT3e6CZvk8cE4v2wqC5J3woxqEF/Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.2\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Pkcs\",\"sha512\":\"sha512-zWk9gw+KSXYnBfrm+nUF7u17gexrNmJOwj0WcLw7kxJB9VAabPTsj9PwPod8QIkSp0q4M/4DTHKhMbc7op2GlQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"net6.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"net7.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"net8.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Primitives\",\"sha512\":\"sha512-WtgnP5mOu5zKL3vQMUPT9tV7XVYGV7Jtb0540DgBD7MMN5ojonwIcw8VybZvS6VloGmE7CRt/Hms8adBsN1DRw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.ProtectedData\",\"sha512\":\"sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net461\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net462\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net47\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net471\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net472\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net48\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.Runtime\",\"System.Runtime.Handles\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"netstandard1.4\":[\"System.Runtime\",\"System.Runtime.Handles\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"netstandard1.5\":[\"System.Runtime\",\"System.Runtime.Handles\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.X509Certificates\",\"sha512\":\"sha512-Ax8SNsw9NCe5pBEysVjrPiGgmcw9ToUMQyNOsbKL0BAGO3VQ+Gis2eleJ7KVmJ5j2gFdgh42yc9U2hboXdy+3A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.2\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Security.AccessControl\"],\"net462\":[\"System.Security.AccessControl\"],\"net47\":[\"System.Security.AccessControl\"],\"net471\":[\"System.Security.AccessControl\"],\"net472\":[\"System.Security.AccessControl\"],\"net48\":[\"System.Security.AccessControl\"],\"net5.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"net6.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"net7.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"net8.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Security.AccessControl\"],\"netcoreapp2.1\":[\"System.Security.AccessControl\"],\"netcoreapp2.2\":[\"System.Security.AccessControl\"],\"netcoreapp3.0\":[\"System.Security.AccessControl\"],\"netcoreapp3.1\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Security.AccessControl\"],\"netstandard2.1\":[\"System.Security.AccessControl\"]},\"framework_list\":[],\"id\":\"System.Security.Permissions\",\"sha512\":\"sha512-1PIXLMOxZPEE+i46Mwti8qFfUOBQqRZZ21co8o1NXWyoZg7sOk+SIJAYGlS8Hp9mNMpJdQOYNgcn0bxZ22ICeA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Text.Encoding\",\"sha512\":\"sha512-b/f+7HMTpxIfeV7H03bkuHKMFylCGfr9/U6gePnfFFW0aF8LOWLDgQCY6V1oWUqDksC3mdNuyChM1vy9TP4sZw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net462\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net47\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net471\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net472\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net48\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.1\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.2\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard2.1\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"]},\"framework_list\":[],\"id\":\"System.Text.Json\",\"sha512\":\"sha512-PTL4h2MLbKEqZ/9TE6SEmJp1txIh0GjzYPQrWGbfJ5sgbPrpXzb9sOoXe3cid51zDBE+2KCLd95e/04JiNr0TQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.2\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"net6.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"net7.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"net8.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"System.Runtime\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Threading\",\"sha512\":\"sha512-l6J1G9zmn6r5xU+DSp/Vxgx6eG+qUvQgdpgo28m1gEwfNyG6HqlF6h2ESDXZCYEPnngsmkTQ+q7MyyMMTNlaiA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Threading.Tasks\",\"sha512\":\"sha512-fUiP+CyyCjs872OA8trl6p97qma/da1xGq3h4zAbJZk8zyaU4zyEfqW5vbkP80xG/Nimun1vlWBboMEk7XxdEw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Drawing.Common\"],\"net6.0\":[\"System.Drawing.Common\"],\"net7.0\":[\"System.Drawing.Common\"],\"net8.0\":[\"System.Drawing.Common\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[\"System.Drawing.Common\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Windows.Extensions\",\"sha512\":\"sha512-9R7sgWb5e1/OokgW7HN8JNXFpcsUXvLTMnfJoWBE9AvD+5e0z+f5ojr3BO3pFYbGq9Ks8AsndTi7ME13ocpU8A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}"
+              ],
+              "targeting_pack_overrides": {
+                "argu": [],
+                "chessie": [],
+                "fsharp.control.asyncseq": [],
+                "fsharp.core": [],
+                "fsharp.systemtextjson": [],
+                "fsharpx.async": [],
+                "fsharpx.collections": [],
+                "fsharpx.extras": [],
+                "microsoft.bcl.asyncinterfaces": [],
+                "microsoft.csharp": [],
+                "microsoft.extensions.fileproviders.abstractions": [],
+                "microsoft.extensions.filesystemglobbing": [],
+                "microsoft.extensions.primitives": [],
+                "microsoft.netcore.app.ref": [
+                  "Microsoft.CSharp|4.4.0",
+                  "Microsoft.Win32.Primitives|4.3.0",
+                  "Microsoft.Win32.Registry|4.4.0",
+                  "runtime.debian.8-x64.runtime.native.System|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "System.AppContext|4.3.0",
+                  "System.Buffers|4.4.0",
+                  "System.Collections|4.3.0",
+                  "System.Collections.Concurrent|4.3.0",
+                  "System.Collections.Immutable|1.4.0",
+                  "System.Collections.NonGeneric|4.3.0",
+                  "System.Collections.Specialized|4.3.0",
+                  "System.ComponentModel|4.3.0",
+                  "System.ComponentModel.EventBasedAsync|4.3.0",
+                  "System.ComponentModel.Primitives|4.3.0",
+                  "System.ComponentModel.TypeConverter|4.3.0",
+                  "System.Console|4.3.0",
+                  "System.Data.Common|4.3.0",
+                  "System.Diagnostics.Contracts|4.3.0",
+                  "System.Diagnostics.Debug|4.3.0",
+                  "System.Diagnostics.DiagnosticSource|4.4.0",
+                  "System.Diagnostics.FileVersionInfo|4.3.0",
+                  "System.Diagnostics.Process|4.3.0",
+                  "System.Diagnostics.StackTrace|4.3.0",
+                  "System.Diagnostics.TextWriterTraceListener|4.3.0",
+                  "System.Diagnostics.Tools|4.3.0",
+                  "System.Diagnostics.TraceSource|4.3.0",
+                  "System.Diagnostics.Tracing|4.3.0",
+                  "System.Dynamic.Runtime|4.3.0",
+                  "System.Globalization|4.3.0",
+                  "System.Globalization.Calendars|4.3.0",
+                  "System.Globalization.Extensions|4.3.0",
+                  "System.IO|4.3.0",
+                  "System.IO.Compression|4.3.0",
+                  "System.IO.Compression.ZipFile|4.3.0",
+                  "System.IO.FileSystem|4.3.0",
+                  "System.IO.FileSystem.AccessControl|4.4.0",
+                  "System.IO.FileSystem.DriveInfo|4.3.0",
+                  "System.IO.FileSystem.Primitives|4.3.0",
+                  "System.IO.FileSystem.Watcher|4.3.0",
+                  "System.IO.IsolatedStorage|4.3.0",
+                  "System.IO.MemoryMappedFiles|4.3.0",
+                  "System.IO.Pipes|4.3.0",
+                  "System.IO.UnmanagedMemoryStream|4.3.0",
+                  "System.Linq|4.3.0",
+                  "System.Linq.Expressions|4.3.0",
+                  "System.Linq.Queryable|4.3.0",
+                  "System.Net.Http|4.3.0",
+                  "System.Net.NameResolution|4.3.0",
+                  "System.Net.Primitives|4.3.0",
+                  "System.Net.Requests|4.3.0",
+                  "System.Net.Security|4.3.0",
+                  "System.Net.Sockets|4.3.0",
+                  "System.Net.WebHeaderCollection|4.3.0",
+                  "System.ObjectModel|4.3.0",
+                  "System.Private.DataContractSerialization|4.3.0",
+                  "System.Reflection|4.3.0",
+                  "System.Reflection.Emit|4.3.0",
+                  "System.Reflection.Emit.ILGeneration|4.3.0",
+                  "System.Reflection.Emit.Lightweight|4.3.0",
+                  "System.Reflection.Extensions|4.3.0",
+                  "System.Reflection.Metadata|1.5.0",
+                  "System.Reflection.Primitives|4.3.0",
+                  "System.Reflection.TypeExtensions|4.3.0",
+                  "System.Resources.ResourceManager|4.3.0",
+                  "System.Runtime|4.3.0",
+                  "System.Runtime.Extensions|4.3.0",
+                  "System.Runtime.Handles|4.3.0",
+                  "System.Runtime.InteropServices|4.3.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|4.3.0",
+                  "System.Runtime.Loader|4.3.0",
+                  "System.Runtime.Numerics|4.3.0",
+                  "System.Runtime.Serialization.Formatters|4.3.0",
+                  "System.Runtime.Serialization.Json|4.3.0",
+                  "System.Runtime.Serialization.Primitives|4.3.0",
+                  "System.Security.AccessControl|4.4.0",
+                  "System.Security.Claims|4.3.0",
+                  "System.Security.Cryptography.Algorithms|4.3.0",
+                  "System.Security.Cryptography.Cng|4.4.0",
+                  "System.Security.Cryptography.Csp|4.3.0",
+                  "System.Security.Cryptography.Encoding|4.3.0",
+                  "System.Security.Cryptography.OpenSsl|4.4.0",
+                  "System.Security.Cryptography.Primitives|4.3.0",
+                  "System.Security.Cryptography.X509Certificates|4.3.0",
+                  "System.Security.Cryptography.Xml|4.4.0",
+                  "System.Security.Principal|4.3.0",
+                  "System.Security.Principal.Windows|4.4.0",
+                  "System.Text.Encoding|4.3.0",
+                  "System.Text.Encoding.Extensions|4.3.0",
+                  "System.Text.RegularExpressions|4.3.0",
+                  "System.Threading|4.3.0",
+                  "System.Threading.Overlapped|4.3.0",
+                  "System.Threading.Tasks|4.3.0",
+                  "System.Threading.Tasks.Extensions|4.3.0",
+                  "System.Threading.Tasks.Parallel|4.3.0",
+                  "System.Threading.Thread|4.3.0",
+                  "System.Threading.ThreadPool|4.3.0",
+                  "System.Threading.Timer|4.3.0",
+                  "System.ValueTuple|4.3.0",
+                  "System.Xml.ReaderWriter|4.3.0",
+                  "System.Xml.XDocument|4.3.0",
+                  "System.Xml.XmlDocument|4.3.0",
+                  "System.Xml.XmlSerializer|4.3.0",
+                  "System.Xml.XPath|4.3.0",
+                  "System.Xml.XPath.XDocument|4.3.0"
+                ],
+                "microsoft.netcore.platforms": [],
+                "microsoft.netcore.targets": [],
+                "microsoft.web.xdt": [],
+                "microsoft.win32.systemevents": [],
+                "mono.cecil": [],
+                "netstandard.library": [],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "paket.core": [],
+                "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.native.system": [],
+                "runtime.native.system.net.http": [],
+                "runtime.native.system.security.cryptography.apple": [],
+                "runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "system.collections": [],
+                "system.collections.concurrent": [],
+                "system.componentmodel.composition": [],
+                "system.configuration.configurationmanager": [],
+                "system.diagnostics.debug": [],
+                "system.diagnostics.diagnosticsource": [],
+                "system.diagnostics.tracing": [],
+                "system.drawing.common": [],
+                "system.formats.asn1": [],
+                "system.globalization": [],
+                "system.globalization.calendars": [],
+                "system.globalization.extensions": [],
+                "system.io": [],
+                "system.io.filesystem": [],
+                "system.io.filesystem.primitives": [],
+                "system.linq": [],
+                "system.net.http": [],
+                "system.net.http.winhttphandler": [],
+                "system.net.primitives": [],
+                "system.reflection": [],
+                "system.reflection.emit.lightweight": [],
+                "system.reflection.primitives": [],
+                "system.resources.resourcemanager": [],
+                "system.runtime": [],
+                "system.runtime.compilerservices.unsafe": [],
+                "system.runtime.extensions": [],
+                "system.runtime.handles": [],
+                "system.runtime.interopservices": [],
+                "system.runtime.numerics": [],
+                "system.security.accesscontrol": [],
+                "system.security.cryptography.algorithms": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.csp": [],
+                "system.security.cryptography.encoding": [],
+                "system.security.cryptography.openssl": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.primitives": [],
+                "system.security.cryptography.protecteddata": [],
+                "system.security.cryptography.x509certificates": [],
+                "system.security.permissions": [],
+                "system.text.encoding": [],
+                "system.text.json": [],
+                "system.threading": [],
+                "system.threading.tasks": [],
+                "system.windows.extensions": []
+              },
+              "framework_list": {
+                "argu": [],
+                "chessie": [],
+                "fsharp.control.asyncseq": [],
+                "fsharp.core": [],
+                "fsharp.systemtextjson": [],
+                "fsharpx.async": [],
+                "fsharpx.collections": [],
+                "fsharpx.extras": [],
+                "microsoft.bcl.asyncinterfaces": [],
+                "microsoft.csharp": [],
+                "microsoft.extensions.fileproviders.abstractions": [],
+                "microsoft.extensions.filesystemglobbing": [],
+                "microsoft.extensions.primitives": [],
+                "microsoft.netcore.app.ref": [
+                  "Microsoft.CSharp|6.0.0.0",
+                  "Microsoft.VisualBasic.Core|11.0.0.0",
+                  "Microsoft.VisualBasic|10.0.0.0",
+                  "Microsoft.Win32.Primitives|6.0.0.0",
+                  "Microsoft.Win32.Registry|6.0.0.0",
+                  "System.AppContext|6.0.0.0",
+                  "System.Buffers|6.0.0.0",
+                  "System.Collections.Concurrent|6.0.0.0",
+                  "System.Collections.Immutable|6.0.0.0",
+                  "System.Collections.NonGeneric|6.0.0.0",
+                  "System.Collections.Specialized|6.0.0.0",
+                  "System.Collections|6.0.0.0",
+                  "System.ComponentModel.Annotations|6.0.0.0",
+                  "System.ComponentModel.DataAnnotations|4.0.0.0",
+                  "System.ComponentModel.EventBasedAsync|6.0.0.0",
+                  "System.ComponentModel.Primitives|6.0.0.0",
+                  "System.ComponentModel.TypeConverter|6.0.0.0",
+                  "System.ComponentModel|6.0.0.0",
+                  "System.Configuration|4.0.0.0",
+                  "System.Console|6.0.0.0",
+                  "System.Core|4.0.0.0",
+                  "System.Data.Common|6.0.0.0",
+                  "System.Data.DataSetExtensions|4.0.0.0",
+                  "System.Data|4.0.0.0",
+                  "System.Diagnostics.Contracts|6.0.0.0",
+                  "System.Diagnostics.Debug|6.0.0.0",
+                  "System.Diagnostics.DiagnosticSource|6.0.0.0",
+                  "System.Diagnostics.FileVersionInfo|6.0.0.0",
+                  "System.Diagnostics.Process|6.0.0.0",
+                  "System.Diagnostics.StackTrace|6.0.0.0",
+                  "System.Diagnostics.TextWriterTraceListener|6.0.0.0",
+                  "System.Diagnostics.Tools|6.0.0.0",
+                  "System.Diagnostics.TraceSource|6.0.0.0",
+                  "System.Diagnostics.Tracing|6.0.0.0",
+                  "System.Drawing.Primitives|6.0.0.0",
+                  "System.Drawing|4.0.0.0",
+                  "System.Dynamic.Runtime|6.0.0.0",
+                  "System.Formats.Asn1|6.0.0.0",
+                  "System.Globalization.Calendars|6.0.0.0",
+                  "System.Globalization.Extensions|6.0.0.0",
+                  "System.Globalization|6.0.0.0",
+                  "System.IO.Compression.Brotli|6.0.0.0",
+                  "System.IO.Compression.FileSystem|4.0.0.0",
+                  "System.IO.Compression.ZipFile|6.0.0.0",
+                  "System.IO.Compression|6.0.0.0",
+                  "System.IO.FileSystem.AccessControl|6.0.0.0",
+                  "System.IO.FileSystem.DriveInfo|6.0.0.0",
+                  "System.IO.FileSystem.Primitives|6.0.0.0",
+                  "System.IO.FileSystem.Watcher|6.0.0.0",
+                  "System.IO.FileSystem|6.0.0.0",
+                  "System.IO.IsolatedStorage|6.0.0.0",
+                  "System.IO.MemoryMappedFiles|6.0.0.0",
+                  "System.IO.Pipes.AccessControl|6.0.0.0",
+                  "System.IO.Pipes|6.0.0.0",
+                  "System.IO.UnmanagedMemoryStream|6.0.0.0",
+                  "System.IO|6.0.0.0",
+                  "System.Linq.Expressions|6.0.0.0",
+                  "System.Linq.Parallel|6.0.0.0",
+                  "System.Linq.Queryable|6.0.0.0",
+                  "System.Linq|6.0.0.0",
+                  "System.Memory|6.0.0.0",
+                  "System.Net.Http.Json|6.0.0.0",
+                  "System.Net.Http|6.0.0.0",
+                  "System.Net.HttpListener|6.0.0.0",
+                  "System.Net.Mail|6.0.0.0",
+                  "System.Net.NameResolution|6.0.0.0",
+                  "System.Net.NetworkInformation|6.0.0.0",
+                  "System.Net.Ping|6.0.0.0",
+                  "System.Net.Primitives|6.0.0.0",
+                  "System.Net.Requests|6.0.0.0",
+                  "System.Net.Security|6.0.0.0",
+                  "System.Net.ServicePoint|6.0.0.0",
+                  "System.Net.Sockets|6.0.0.0",
+                  "System.Net.WebClient|6.0.0.0",
+                  "System.Net.WebHeaderCollection|6.0.0.0",
+                  "System.Net.WebProxy|6.0.0.0",
+                  "System.Net.WebSockets.Client|6.0.0.0",
+                  "System.Net.WebSockets|6.0.0.0",
+                  "System.Net|4.0.0.0",
+                  "System.Numerics.Vectors|6.0.0.0",
+                  "System.Numerics|4.0.0.0",
+                  "System.ObjectModel|6.0.0.0",
+                  "System.Reflection.DispatchProxy|6.0.0.0",
+                  "System.Reflection.Emit.ILGeneration|6.0.0.0",
+                  "System.Reflection.Emit.Lightweight|6.0.0.0",
+                  "System.Reflection.Emit|6.0.0.0",
+                  "System.Reflection.Extensions|6.0.0.0",
+                  "System.Reflection.Metadata|6.0.0.0",
+                  "System.Reflection.Primitives|6.0.0.0",
+                  "System.Reflection.TypeExtensions|6.0.0.0",
+                  "System.Reflection|6.0.0.0",
+                  "System.Resources.Reader|6.0.0.0",
+                  "System.Resources.ResourceManager|6.0.0.0",
+                  "System.Resources.Writer|6.0.0.0",
+                  "System.Runtime.CompilerServices.Unsafe|6.0.0.0",
+                  "System.Runtime.CompilerServices.VisualC|6.0.0.0",
+                  "System.Runtime.Extensions|6.0.0.0",
+                  "System.Runtime.Handles|6.0.0.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|6.0.0.0",
+                  "System.Runtime.InteropServices|6.0.0.0",
+                  "System.Runtime.Intrinsics|6.0.0.0",
+                  "System.Runtime.Loader|6.0.0.0",
+                  "System.Runtime.Numerics|6.0.0.0",
+                  "System.Runtime.Serialization.Formatters|6.0.0.0",
+                  "System.Runtime.Serialization.Json|6.0.0.0",
+                  "System.Runtime.Serialization.Primitives|6.0.0.0",
+                  "System.Runtime.Serialization.Xml|6.0.0.0",
+                  "System.Runtime.Serialization|4.0.0.0",
+                  "System.Runtime|6.0.0.0",
+                  "System.Security.AccessControl|6.0.0.0",
+                  "System.Security.Claims|6.0.0.0",
+                  "System.Security.Cryptography.Algorithms|6.0.0.0",
+                  "System.Security.Cryptography.Cng|6.0.0.0",
+                  "System.Security.Cryptography.Csp|6.0.0.0",
+                  "System.Security.Cryptography.Encoding|6.0.0.0",
+                  "System.Security.Cryptography.OpenSsl|6.0.0.0",
+                  "System.Security.Cryptography.Primitives|6.0.0.0",
+                  "System.Security.Cryptography.X509Certificates|6.0.0.0",
+                  "System.Security.Principal.Windows|6.0.0.0",
+                  "System.Security.Principal|6.0.0.0",
+                  "System.Security.SecureString|6.0.0.0",
+                  "System.Security|4.0.0.0",
+                  "System.ServiceModel.Web|4.0.0.0",
+                  "System.ServiceProcess|4.0.0.0",
+                  "System.Text.Encoding.CodePages|6.0.0.0",
+                  "System.Text.Encoding.Extensions|6.0.0.0",
+                  "System.Text.Encoding|6.0.0.0",
+                  "System.Text.Encodings.Web|6.0.0.0",
+                  "System.Text.Json|6.0.0.0",
+                  "System.Text.RegularExpressions|6.0.0.0",
+                  "System.Threading.Channels|6.0.0.0",
+                  "System.Threading.Overlapped|6.0.0.0",
+                  "System.Threading.Tasks.Dataflow|6.0.0.0",
+                  "System.Threading.Tasks.Extensions|6.0.0.0",
+                  "System.Threading.Tasks.Parallel|6.0.0.0",
+                  "System.Threading.Tasks|6.0.0.0",
+                  "System.Threading.Thread|6.0.0.0",
+                  "System.Threading.ThreadPool|6.0.0.0",
+                  "System.Threading.Timer|6.0.0.0",
+                  "System.Threading|6.0.0.0",
+                  "System.Transactions.Local|6.0.0.0",
+                  "System.Transactions|4.0.0.0",
+                  "System.ValueTuple|4.0.3.0",
+                  "System.Web.HttpUtility|6.0.0.0",
+                  "System.Web|4.0.0.0",
+                  "System.Windows|4.0.0.0",
+                  "System.Xml.Linq|4.0.0.0",
+                  "System.Xml.ReaderWriter|6.0.0.0",
+                  "System.Xml.Serialization|4.0.0.0",
+                  "System.Xml.XDocument|6.0.0.0",
+                  "System.Xml.XPath.XDocument|6.0.0.0",
+                  "System.Xml.XPath|6.0.0.0",
+                  "System.Xml.XmlDocument|6.0.0.0",
+                  "System.Xml.XmlSerializer|6.0.0.0",
+                  "System.Xml|4.0.0.0",
+                  "System|4.0.0.0",
+                  "WindowsBase|4.0.0.0",
+                  "mscorlib|4.0.0.0",
+                  "netstandard|2.1.0.0"
+                ],
+                "microsoft.netcore.platforms": [],
+                "microsoft.netcore.targets": [],
+                "microsoft.web.xdt": [],
+                "microsoft.win32.systemevents": [],
+                "mono.cecil": [],
+                "netstandard.library": [],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "paket.core": [],
+                "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.native.system": [],
+                "runtime.native.system.net.http": [],
+                "runtime.native.system.security.cryptography.apple": [],
+                "runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "system.collections": [],
+                "system.collections.concurrent": [],
+                "system.componentmodel.composition": [],
+                "system.configuration.configurationmanager": [],
+                "system.diagnostics.debug": [],
+                "system.diagnostics.diagnosticsource": [],
+                "system.diagnostics.tracing": [],
+                "system.drawing.common": [],
+                "system.formats.asn1": [],
+                "system.globalization": [],
+                "system.globalization.calendars": [],
+                "system.globalization.extensions": [],
+                "system.io": [],
+                "system.io.filesystem": [],
+                "system.io.filesystem.primitives": [],
+                "system.linq": [],
+                "system.net.http": [],
+                "system.net.http.winhttphandler": [],
+                "system.net.primitives": [],
+                "system.reflection": [],
+                "system.reflection.emit.lightweight": [],
+                "system.reflection.primitives": [],
+                "system.resources.resourcemanager": [],
+                "system.runtime": [],
+                "system.runtime.compilerservices.unsafe": [],
+                "system.runtime.extensions": [],
+                "system.runtime.handles": [],
+                "system.runtime.interopservices": [],
+                "system.runtime.numerics": [],
+                "system.security.accesscontrol": [],
+                "system.security.cryptography.algorithms": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.csp": [],
+                "system.security.cryptography.encoding": [],
+                "system.security.cryptography.openssl": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.primitives": [],
+                "system.security.cryptography.protecteddata": [],
+                "system.security.cryptography.x509certificates": [],
+                "system.security.permissions": [],
+                "system.text.encoding": [],
+                "system.text.json": [],
+                "system.threading": [],
+                "system.threading.tasks": [],
+                "system.windows.extensions": []
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_dotnet+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_dotnet+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_dotnet+",
+            "rules_dotnet",
+            "rules_dotnet+"
+          ]
+        ]
+      }
+    },
+    "@@rules_dotnet+//dotnet:paket.rules_dotnet_nuget_packages_extension.bzl%rules_dotnet_nuget_packages_extension": {
+      "general": {
+        "bzlTransitiveDigest": "rB6WNMow7J14Mi1Vlo0OGUV4jUhn/z+wi56RRbgMjTw=",
+        "usagesDigest": "k/st7Gv6cOoXf48TERH77CT0otg817eM0yMATo2Ekzs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nuget.mcmaster.extensions.commandlineutils.v2.5.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "mcmaster.extensions.commandlineutils",
+              "version": "2.5.0",
+              "sha512": "sha512-00uJOWYKPCPqDB6RxyOLXNnoPGeRmzKTZhu5OdZJaWn5+JV/n6mzB3/M+Z1yMpkabag3Lym9S11G/ITLrptOiw=="
+            }
+          },
+          "nuget.microsoft.netcore.app.ref.v6.0.5": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.app.ref",
+              "version": "6.0.5",
+              "sha512": "sha512-quj/gyLoZLypJO7PwsZ8ib6ZSgFv1C9s5SJgwzl/gztynTJ/3oO/stA2gNMf0C33vTJ0J3SSF/kRPQ/ifY5xZg=="
+            }
+          },
+          "nuget.microsoft.netcore.platforms.v6.0.5": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.platforms",
+              "version": "6.0.5",
+              "sha512": "sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA=="
+            }
+          },
+          "nuget.microsoft.web.xdt.v3.1.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.web.xdt",
+              "version": "3.1.0",
+              "sha512": "sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw=="
+            }
+          },
+          "nuget.netstandard.library.v2.0.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "netstandard.library",
+              "version": "2.0.3",
+              "sha512": "sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ=="
+            }
+          },
+          "nuget.netstandard.library.ref.v2.1.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "netstandard.library.ref",
+              "version": "2.1.0",
+              "sha512": "sha512-Jr0OqnqkaJJGEVq3w9oNQrIEteD/4QBNg3YOh1cvRjydzwop07+5aWjO/SfEYu6CwBn+dSBKXj8niEvTNy2brA=="
+            }
+          },
+          "nuget.newtonsoft.json.v13.0.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "newtonsoft.json",
+              "version": "13.0.1",
+              "sha512": "sha512-g3MbZi6vBTeaI/hEbvR7vBETSd1DWLe9i1E4P+nPY34v5i94zqUqDXvdWC3G+7tYN9SnsdU9zzegrnRz4h7nsQ=="
+            }
+          },
+          "nuget.nuget.commands.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.commands",
+              "version": "5.10.0",
+              "sha512": "sha512-Q7ANXnmLUPC4pWgCZjBy2R7vRDABiaJz5NsBtoErE0dLylx/zQWRMyoa+m4Y478SKvUpt7S1V7LhAOlMRCTPpg=="
+            }
+          },
+          "nuget.nuget.common.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.common",
+              "version": "5.10.0",
+              "sha512": "sha512-8M9VtXAB1M15KmvL0F9QsItI96PH3WmYD0z3oxYm5H9G5AIhK8Ivi4kGzqtBJDTsZ/NkP91U1MnoCAeg4E4+zA=="
+            }
+          },
+          "nuget.nuget.configuration.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.configuration",
+              "version": "5.10.0",
+              "sha512": "sha512-ZJc2HY/D+UEk2U0jxamyBhUbKl2bgluViM/tnP4ObIIfJpOj8dHEJ6xzggulIGDlhe+ItK6yc+sqtCb6qV5+gw=="
+            }
+          },
+          "nuget.nuget.credentials.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.credentials",
+              "version": "5.10.0",
+              "sha512": "sha512-r/fzn5yJaCXyChbhxbGZ5d/4xV4n3NIjVdE3odLfQy0znmcYRCDIfjYGu5l7vO9Nx27F+q7YA+9QmG9sucxX9A=="
+            }
+          },
+          "nuget.nuget.dependencyresolver.core.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.dependencyresolver.core",
+              "version": "5.10.0",
+              "sha512": "sha512-+9mCFiBhnm5C2Cb3dtHaHyv/WarSr5HwRi2NaoVJgudpHoK3B9uy8wB7PNnUos0kOghZmVslemeLsmw7icQqTw=="
+            }
+          },
+          "nuget.nuget.frameworks.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.frameworks",
+              "version": "5.10.0",
+              "sha512": "sha512-l8KtHN2bzA391seLZ9Q2AWK0mbCHpfbwL1nmOSMDxBpWLxqh+nxMWaKL437bROpHltU+oP5LX/hc4Fxm89T9Tg=="
+            }
+          },
+          "nuget.nuget.librarymodel.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.librarymodel",
+              "version": "5.10.0",
+              "sha512": "sha512-xb8XLKJEMymZMAZJeXdSUaDNFRQMJ4MXkOPUaqafcgSKGz8M8BZgfLsBz9QCQVEyHIVYGbI4yroWZYed/c8xSg=="
+            }
+          },
+          "nuget.nuget.packagemanagement.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packagemanagement",
+              "version": "5.10.0",
+              "sha512": "sha512-Kr0CZuStXNsJRL86ecuWGhIHUhYy31rYZJ9WZ0tiFUaRwiPb7HpSQVsV/v3tqrKE7FWUZBpasX1bugXNqXcPjA=="
+            }
+          },
+          "nuget.nuget.packaging.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packaging",
+              "version": "5.10.0",
+              "sha512": "sha512-2HMq5gNgLMOHmqGb84pyEC7ctkCYBVXkhJfcYmHlkpo4FpDA6GQBoT//1h0Q4nGoybtgoBxiIbJu8VRn/9CZrQ=="
+            }
+          },
+          "nuget.nuget.packaging.core.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packaging.core",
+              "version": "5.10.0",
+              "sha512": "sha512-/WXGAbLb4T0pwEfEeY0j8zOVpS36OHNUANL95txANysbLoG7tUr9e+5je+Nfh3iIqzMaHIZXT6JKFvHOBwAotw=="
+            }
+          },
+          "nuget.nuget.projectmodel.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.projectmodel",
+              "version": "5.10.0",
+              "sha512": "sha512-gsZS2Kuat3ZjjPcBQ3Mc8QlRv6mP1OzNzkF4Dzybu3LgtG+kwvgQh4UMLbiIrko6WKbwVTbr8nQYpL+wsVZ4hA=="
+            }
+          },
+          "nuget.nuget.protocol.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.protocol",
+              "version": "5.10.0",
+              "sha512": "sha512-lY85Pgf7kr0JwTufdJmfDgBwN9BRQc96F4xxKrUGSALhuZRRC7y6f2RN1JQ0UTPIXlQx7HTG/h0UZEknQj3/UQ=="
+            }
+          },
+          "nuget.nuget.resolver.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.resolver",
+              "version": "5.10.0",
+              "sha512": "sha512-a2zWl9RkKDkcVUqfRJjz3O4uoPIWf3PGaFf6AntXtTKjvvsB6SZz8jjPSGdLgTTRIWzsFlybKp6yU+GaXeIQkg=="
+            }
+          },
+          "nuget.nuget.versioning.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.versioning",
+              "version": "5.10.0",
+              "sha512": "sha512-NW11tfXijCWeI8d71HKpNPKPzJqr30PtUyJHzCpKFMFTGZhsHh2YxgjKBuhpC5R59SMZUzqrFF5CgJ8uGaupqg=="
+            }
+          },
+          "nuget.nunit.v3.12.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nunit",
+              "version": "3.12.0",
+              "sha512": "sha512-HAhwFxr+Z+PJf8hXzc747NecvsDwEZ+3X8SA5+GIRM43GAy1Ap+TQPMHsWCnisfes5vPZ1/a2md/91u+shoTsQ=="
+            }
+          },
+          "nuget.nunitlite.v3.12.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nunitlite",
+              "version": "3.12.0",
+              "sha512": "sha512-M9VVS4x3KURXFS4HTl2b7uJOX7vOi2wzpHACmNX6ANlBmb0/hIehJLciiVvddD3ubIIL81EF4Qk54kpsUOtVFQ=="
+            }
+          },
+          "nuget.system.componentmodel.annotations.v5.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.componentmodel.annotations",
+              "version": "5.0.0",
+              "sha512": "sha512-WJqsTGaXAc55EPGjJylPFXiNPs/x1t9dklVlHlIBxUEcIxIob6sRGm9Un7TehkyEFM+vKjZd7rbwaMH/znw1PA=="
+            }
+          },
+          "nuget.system.componentmodel.composition.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.componentmodel.composition",
+              "version": "6.0.0",
+              "sha512": "sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA=="
+            }
+          },
+          "nuget.system.formats.asn1.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.formats.asn1",
+              "version": "6.0.0",
+              "sha512": "sha512-62YP6zLnvmFtFI3rjybbrnSeK6hHQCaFfJJfoNhQqrETJBPehSucQxIyQs5W+GGBW/rpSXD/0NqNW7mttIWXhA=="
+            }
+          },
+          "nuget.system.security.cryptography.cng.v5.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.cng",
+              "version": "5.0.0",
+              "sha512": "sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w=="
+            }
+          },
+          "nuget.system.security.cryptography.pkcs.v6.0.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.pkcs",
+              "version": "6.0.1",
+              "sha512": "sha512-ubxxZt0n9t8Xe/NtN53XMf6ZSfRKsk/T+mheDuoZbYrBJRLVyQ4pecXoROihl/DyC9uVOt6QrejwLAx1Raj1wg=="
+            }
+          },
+          "nuget.system.security.cryptography.protecteddata.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.protecteddata",
+              "version": "6.0.0",
+              "sha512": "sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA=="
+            }
+          },
+          "paket.rules_dotnet_nuget_packages": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_repo.bzl%_nuget_repo",
+            "attributes": {
+              "repo_name": "paket.rules_dotnet_nuget_packages",
+              "packages": [
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.ComponentModel.Annotations\"],\"net6.0\":[\"System.ComponentModel.Annotations\"],\"net7.0\":[\"System.ComponentModel.Annotations\"],\"net8.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp1.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp1.1\":[\"System.ComponentModel.Annotations\"],\"netcoreapp2.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp2.1\":[\"System.ComponentModel.Annotations\"],\"netcoreapp2.2\":[\"System.ComponentModel.Annotations\"],\"netcoreapp3.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp3.1\":[\"System.ComponentModel.Annotations\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[\"System.ComponentModel.Annotations\"],\"netstandard2.0\":[\"System.ComponentModel.Annotations\"],\"netstandard2.1\":[\"System.ComponentModel.Annotations\"]},\"framework_list\":[],\"id\":\"McMaster.Extensions.CommandLineUtils\",\"sha512\":\"sha512-00uJOWYKPCPqDB6RxyOLXNnoPGeRmzKTZhu5OdZJaWn5+JV/n6mzB3/M+Z1yMpkabag3Lym9S11G/ITLrptOiw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.5.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[\"Microsoft.CSharp|6.0.0.0\",\"Microsoft.VisualBasic.Core|11.0.0.0\",\"Microsoft.VisualBasic|10.0.0.0\",\"Microsoft.Win32.Primitives|6.0.0.0\",\"Microsoft.Win32.Registry|6.0.0.0\",\"System.AppContext|6.0.0.0\",\"System.Buffers|6.0.0.0\",\"System.Collections.Concurrent|6.0.0.0\",\"System.Collections.Immutable|6.0.0.0\",\"System.Collections.NonGeneric|6.0.0.0\",\"System.Collections.Specialized|6.0.0.0\",\"System.Collections|6.0.0.0\",\"System.ComponentModel.Annotations|6.0.0.0\",\"System.ComponentModel.DataAnnotations|4.0.0.0\",\"System.ComponentModel.EventBasedAsync|6.0.0.0\",\"System.ComponentModel.Primitives|6.0.0.0\",\"System.ComponentModel.TypeConverter|6.0.0.0\",\"System.ComponentModel|6.0.0.0\",\"System.Configuration|4.0.0.0\",\"System.Console|6.0.0.0\",\"System.Core|4.0.0.0\",\"System.Data.Common|6.0.0.0\",\"System.Data.DataSetExtensions|4.0.0.0\",\"System.Data|4.0.0.0\",\"System.Diagnostics.Contracts|6.0.0.0\",\"System.Diagnostics.Debug|6.0.0.0\",\"System.Diagnostics.DiagnosticSource|6.0.0.0\",\"System.Diagnostics.FileVersionInfo|6.0.0.0\",\"System.Diagnostics.Process|6.0.0.0\",\"System.Diagnostics.StackTrace|6.0.0.0\",\"System.Diagnostics.TextWriterTraceListener|6.0.0.0\",\"System.Diagnostics.Tools|6.0.0.0\",\"System.Diagnostics.TraceSource|6.0.0.0\",\"System.Diagnostics.Tracing|6.0.0.0\",\"System.Drawing.Primitives|6.0.0.0\",\"System.Drawing|4.0.0.0\",\"System.Dynamic.Runtime|6.0.0.0\",\"System.Formats.Asn1|6.0.0.0\",\"System.Globalization.Calendars|6.0.0.0\",\"System.Globalization.Extensions|6.0.0.0\",\"System.Globalization|6.0.0.0\",\"System.IO.Compression.Brotli|6.0.0.0\",\"System.IO.Compression.FileSystem|4.0.0.0\",\"System.IO.Compression.ZipFile|6.0.0.0\",\"System.IO.Compression|6.0.0.0\",\"System.IO.FileSystem.AccessControl|6.0.0.0\",\"System.IO.FileSystem.DriveInfo|6.0.0.0\",\"System.IO.FileSystem.Primitives|6.0.0.0\",\"System.IO.FileSystem.Watcher|6.0.0.0\",\"System.IO.FileSystem|6.0.0.0\",\"System.IO.IsolatedStorage|6.0.0.0\",\"System.IO.MemoryMappedFiles|6.0.0.0\",\"System.IO.Pipes.AccessControl|6.0.0.0\",\"System.IO.Pipes|6.0.0.0\",\"System.IO.UnmanagedMemoryStream|6.0.0.0\",\"System.IO|6.0.0.0\",\"System.Linq.Expressions|6.0.0.0\",\"System.Linq.Parallel|6.0.0.0\",\"System.Linq.Queryable|6.0.0.0\",\"System.Linq|6.0.0.0\",\"System.Memory|6.0.0.0\",\"System.Net.Http.Json|6.0.0.0\",\"System.Net.Http|6.0.0.0\",\"System.Net.HttpListener|6.0.0.0\",\"System.Net.Mail|6.0.0.0\",\"System.Net.NameResolution|6.0.0.0\",\"System.Net.NetworkInformation|6.0.0.0\",\"System.Net.Ping|6.0.0.0\",\"System.Net.Primitives|6.0.0.0\",\"System.Net.Requests|6.0.0.0\",\"System.Net.Security|6.0.0.0\",\"System.Net.ServicePoint|6.0.0.0\",\"System.Net.Sockets|6.0.0.0\",\"System.Net.WebClient|6.0.0.0\",\"System.Net.WebHeaderCollection|6.0.0.0\",\"System.Net.WebProxy|6.0.0.0\",\"System.Net.WebSockets.Client|6.0.0.0\",\"System.Net.WebSockets|6.0.0.0\",\"System.Net|4.0.0.0\",\"System.Numerics.Vectors|6.0.0.0\",\"System.Numerics|4.0.0.0\",\"System.ObjectModel|6.0.0.0\",\"System.Reflection.DispatchProxy|6.0.0.0\",\"System.Reflection.Emit.ILGeneration|6.0.0.0\",\"System.Reflection.Emit.Lightweight|6.0.0.0\",\"System.Reflection.Emit|6.0.0.0\",\"System.Reflection.Extensions|6.0.0.0\",\"System.Reflection.Metadata|6.0.0.0\",\"System.Reflection.Primitives|6.0.0.0\",\"System.Reflection.TypeExtensions|6.0.0.0\",\"System.Reflection|6.0.0.0\",\"System.Resources.Reader|6.0.0.0\",\"System.Resources.ResourceManager|6.0.0.0\",\"System.Resources.Writer|6.0.0.0\",\"System.Runtime.CompilerServices.Unsafe|6.0.0.0\",\"System.Runtime.CompilerServices.VisualC|6.0.0.0\",\"System.Runtime.Extensions|6.0.0.0\",\"System.Runtime.Handles|6.0.0.0\",\"System.Runtime.InteropServices.RuntimeInformation|6.0.0.0\",\"System.Runtime.InteropServices|6.0.0.0\",\"System.Runtime.Intrinsics|6.0.0.0\",\"System.Runtime.Loader|6.0.0.0\",\"System.Runtime.Numerics|6.0.0.0\",\"System.Runtime.Serialization.Formatters|6.0.0.0\",\"System.Runtime.Serialization.Json|6.0.0.0\",\"System.Runtime.Serialization.Primitives|6.0.0.0\",\"System.Runtime.Serialization.Xml|6.0.0.0\",\"System.Runtime.Serialization|4.0.0.0\",\"System.Runtime|6.0.0.0\",\"System.Security.AccessControl|6.0.0.0\",\"System.Security.Claims|6.0.0.0\",\"System.Security.Cryptography.Algorithms|6.0.0.0\",\"System.Security.Cryptography.Cng|6.0.0.0\",\"System.Security.Cryptography.Csp|6.0.0.0\",\"System.Security.Cryptography.Encoding|6.0.0.0\",\"System.Security.Cryptography.OpenSsl|6.0.0.0\",\"System.Security.Cryptography.Primitives|6.0.0.0\",\"System.Security.Cryptography.X509Certificates|6.0.0.0\",\"System.Security.Principal.Windows|6.0.0.0\",\"System.Security.Principal|6.0.0.0\",\"System.Security.SecureString|6.0.0.0\",\"System.Security|4.0.0.0\",\"System.ServiceModel.Web|4.0.0.0\",\"System.ServiceProcess|4.0.0.0\",\"System.Text.Encoding.CodePages|6.0.0.0\",\"System.Text.Encoding.Extensions|6.0.0.0\",\"System.Text.Encoding|6.0.0.0\",\"System.Text.Encodings.Web|6.0.0.0\",\"System.Text.Json|6.0.0.0\",\"System.Text.RegularExpressions|6.0.0.0\",\"System.Threading.Channels|6.0.0.0\",\"System.Threading.Overlapped|6.0.0.0\",\"System.Threading.Tasks.Dataflow|6.0.0.0\",\"System.Threading.Tasks.Extensions|6.0.0.0\",\"System.Threading.Tasks.Parallel|6.0.0.0\",\"System.Threading.Tasks|6.0.0.0\",\"System.Threading.Thread|6.0.0.0\",\"System.Threading.ThreadPool|6.0.0.0\",\"System.Threading.Timer|6.0.0.0\",\"System.Threading|6.0.0.0\",\"System.Transactions.Local|6.0.0.0\",\"System.Transactions|4.0.0.0\",\"System.ValueTuple|4.0.3.0\",\"System.Web.HttpUtility|6.0.0.0\",\"System.Web|4.0.0.0\",\"System.Windows|4.0.0.0\",\"System.Xml.Linq|4.0.0.0\",\"System.Xml.ReaderWriter|6.0.0.0\",\"System.Xml.Serialization|4.0.0.0\",\"System.Xml.XDocument|6.0.0.0\",\"System.Xml.XPath.XDocument|6.0.0.0\",\"System.Xml.XPath|6.0.0.0\",\"System.Xml.XmlDocument|6.0.0.0\",\"System.Xml.XmlSerializer|6.0.0.0\",\"System.Xml|4.0.0.0\",\"System|4.0.0.0\",\"WindowsBase|4.0.0.0\",\"mscorlib|4.0.0.0\",\"netstandard|2.1.0.0\"],\"id\":\"Microsoft.NETCore.App.Ref\",\"sha512\":\"sha512-quj/gyLoZLypJO7PwsZ8ib6ZSgFv1C9s5SJgwzl/gztynTJ/3oO/stA2gNMf0C33vTJ0J3SSF/kRPQ/ifY5xZg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[\"Microsoft.CSharp|4.4.0\",\"Microsoft.Win32.Primitives|4.3.0\",\"Microsoft.Win32.Registry|4.4.0\",\"runtime.debian.8-x64.runtime.native.System|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"System.AppContext|4.3.0\",\"System.Buffers|4.4.0\",\"System.Collections|4.3.0\",\"System.Collections.Concurrent|4.3.0\",\"System.Collections.Immutable|1.4.0\",\"System.Collections.NonGeneric|4.3.0\",\"System.Collections.Specialized|4.3.0\",\"System.ComponentModel|4.3.0\",\"System.ComponentModel.EventBasedAsync|4.3.0\",\"System.ComponentModel.Primitives|4.3.0\",\"System.ComponentModel.TypeConverter|4.3.0\",\"System.Console|4.3.0\",\"System.Data.Common|4.3.0\",\"System.Diagnostics.Contracts|4.3.0\",\"System.Diagnostics.Debug|4.3.0\",\"System.Diagnostics.DiagnosticSource|4.4.0\",\"System.Diagnostics.FileVersionInfo|4.3.0\",\"System.Diagnostics.Process|4.3.0\",\"System.Diagnostics.StackTrace|4.3.0\",\"System.Diagnostics.TextWriterTraceListener|4.3.0\",\"System.Diagnostics.Tools|4.3.0\",\"System.Diagnostics.TraceSource|4.3.0\",\"System.Diagnostics.Tracing|4.3.0\",\"System.Dynamic.Runtime|4.3.0\",\"System.Globalization|4.3.0\",\"System.Globalization.Calendars|4.3.0\",\"System.Globalization.Extensions|4.3.0\",\"System.IO|4.3.0\",\"System.IO.Compression|4.3.0\",\"System.IO.Compression.ZipFile|4.3.0\",\"System.IO.FileSystem|4.3.0\",\"System.IO.FileSystem.AccessControl|4.4.0\",\"System.IO.FileSystem.DriveInfo|4.3.0\",\"System.IO.FileSystem.Primitives|4.3.0\",\"System.IO.FileSystem.Watcher|4.3.0\",\"System.IO.IsolatedStorage|4.3.0\",\"System.IO.MemoryMappedFiles|4.3.0\",\"System.IO.Pipes|4.3.0\",\"System.IO.UnmanagedMemoryStream|4.3.0\",\"System.Linq|4.3.0\",\"System.Linq.Expressions|4.3.0\",\"System.Linq.Queryable|4.3.0\",\"System.Net.Http|4.3.0\",\"System.Net.NameResolution|4.3.0\",\"System.Net.Primitives|4.3.0\",\"System.Net.Requests|4.3.0\",\"System.Net.Security|4.3.0\",\"System.Net.Sockets|4.3.0\",\"System.Net.WebHeaderCollection|4.3.0\",\"System.ObjectModel|4.3.0\",\"System.Private.DataContractSerialization|4.3.0\",\"System.Reflection|4.3.0\",\"System.Reflection.Emit|4.3.0\",\"System.Reflection.Emit.ILGeneration|4.3.0\",\"System.Reflection.Emit.Lightweight|4.3.0\",\"System.Reflection.Extensions|4.3.0\",\"System.Reflection.Metadata|1.5.0\",\"System.Reflection.Primitives|4.3.0\",\"System.Reflection.TypeExtensions|4.3.0\",\"System.Resources.ResourceManager|4.3.0\",\"System.Runtime|4.3.0\",\"System.Runtime.Extensions|4.3.0\",\"System.Runtime.Handles|4.3.0\",\"System.Runtime.InteropServices|4.3.0\",\"System.Runtime.InteropServices.RuntimeInformation|4.3.0\",\"System.Runtime.Loader|4.3.0\",\"System.Runtime.Numerics|4.3.0\",\"System.Runtime.Serialization.Formatters|4.3.0\",\"System.Runtime.Serialization.Json|4.3.0\",\"System.Runtime.Serialization.Primitives|4.3.0\",\"System.Security.AccessControl|4.4.0\",\"System.Security.Claims|4.3.0\",\"System.Security.Cryptography.Algorithms|4.3.0\",\"System.Security.Cryptography.Cng|4.4.0\",\"System.Security.Cryptography.Csp|4.3.0\",\"System.Security.Cryptography.Encoding|4.3.0\",\"System.Security.Cryptography.OpenSsl|4.4.0\",\"System.Security.Cryptography.Primitives|4.3.0\",\"System.Security.Cryptography.X509Certificates|4.3.0\",\"System.Security.Cryptography.Xml|4.4.0\",\"System.Security.Principal|4.3.0\",\"System.Security.Principal.Windows|4.4.0\",\"System.Text.Encoding|4.3.0\",\"System.Text.Encoding.Extensions|4.3.0\",\"System.Text.RegularExpressions|4.3.0\",\"System.Threading|4.3.0\",\"System.Threading.Overlapped|4.3.0\",\"System.Threading.Tasks|4.3.0\",\"System.Threading.Tasks.Extensions|4.3.0\",\"System.Threading.Tasks.Parallel|4.3.0\",\"System.Threading.Thread|4.3.0\",\"System.Threading.ThreadPool|4.3.0\",\"System.Threading.Timer|4.3.0\",\"System.ValueTuple|4.3.0\",\"System.Xml.ReaderWriter|4.3.0\",\"System.Xml.XDocument|4.3.0\",\"System.Xml.XmlDocument|4.3.0\",\"System.Xml.XmlSerializer|4.3.0\",\"System.Xml.XPath|4.3.0\",\"System.Xml.XPath.XDocument|4.3.0\"],\"version\":\"6.0.5\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.NETCore.Platforms\",\"sha512\":\"sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.5\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Web.Xdt\",\"sha512\":\"sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.1.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"Microsoft.NETCore.Platforms\"],\"net451\":[\"Microsoft.NETCore.Platforms\"],\"net452\":[\"Microsoft.NETCore.Platforms\"],\"net46\":[\"Microsoft.NETCore.Platforms\"],\"net461\":[\"Microsoft.NETCore.Platforms\"],\"net462\":[\"Microsoft.NETCore.Platforms\"],\"net47\":[\"Microsoft.NETCore.Platforms\"],\"net471\":[\"Microsoft.NETCore.Platforms\"],\"net472\":[\"Microsoft.NETCore.Platforms\"],\"net48\":[\"Microsoft.NETCore.Platforms\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\"]},\"framework_list\":[],\"id\":\"NETStandard.Library\",\"sha512\":\"sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.0.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[\"Microsoft.Win32.Primitives|4.0.3.0\",\"System.AppContext|4.1.2.0\",\"System.Buffers|4.0.3.0\",\"System.Collections.Concurrent|4.0.11.0\",\"System.Collections.NonGeneric|4.0.3.0\",\"System.Collections.Specialized|4.0.3.0\",\"System.Collections|4.0.11.0\",\"System.ComponentModel.Composition|4.0.0.0\",\"System.ComponentModel.EventBasedAsync|4.0.11.0\",\"System.ComponentModel.Primitives|4.1.2.0\",\"System.ComponentModel.TypeConverter|4.1.2.0\",\"System.ComponentModel|4.0.1.0\",\"System.Console|4.0.2.0\",\"System.Core|4.0.0.0\",\"System.Data.Common|4.1.2.0\",\"System.Data|4.0.0.0\",\"System.Diagnostics.Contracts|4.0.1.0\",\"System.Diagnostics.Debug|4.0.11.0\",\"System.Diagnostics.FileVersionInfo|4.0.2.0\",\"System.Diagnostics.Process|4.1.2.0\",\"System.Diagnostics.StackTrace|4.0.4.0\",\"System.Diagnostics.TextWriterTraceListener|4.0.2.0\",\"System.Diagnostics.Tools|4.0.1.0\",\"System.Diagnostics.TraceSource|4.0.2.0\",\"System.Diagnostics.Tracing|4.1.2.0\",\"System.Drawing.Primitives|4.0.2.0\",\"System.Drawing|4.0.0.0\",\"System.Dynamic.Runtime|4.0.11.0\",\"System.Globalization.Calendars|4.0.3.0\",\"System.Globalization.Extensions|4.0.3.0\",\"System.Globalization|4.0.11.0\",\"System.IO.Compression.FileSystem|4.0.0.0\",\"System.IO.Compression.ZipFile|4.0.3.0\",\"System.IO.Compression|4.1.3.0\",\"System.IO.FileSystem.DriveInfo|4.0.2.0\",\"System.IO.FileSystem.Primitives|4.0.3.0\",\"System.IO.FileSystem.Watcher|4.0.2.0\",\"System.IO.FileSystem|4.0.3.0\",\"System.IO.IsolatedStorage|4.0.2.0\",\"System.IO.MemoryMappedFiles|4.0.2.0\",\"System.IO.Pipes|4.0.2.0\",\"System.IO.UnmanagedMemoryStream|4.0.3.0\",\"System.IO|4.1.2.0\",\"System.Linq.Expressions|4.1.2.0\",\"System.Linq.Parallel|4.0.1.0\",\"System.Linq.Queryable|4.0.1.0\",\"System.Linq|4.1.2.0\",\"System.Memory|4.0.2.0\",\"System.Net.Http|4.1.2.0\",\"System.Net.NameResolution|4.0.2.0\",\"System.Net.NetworkInformation|4.1.2.0\",\"System.Net.Ping|4.0.2.0\",\"System.Net.Primitives|4.0.11.0\",\"System.Net.Requests|4.0.11.0\",\"System.Net.Security|4.0.2.0\",\"System.Net.Sockets|4.1.2.0\",\"System.Net.WebHeaderCollection|4.0.1.0\",\"System.Net.WebSockets.Client|4.0.2.0\",\"System.Net.WebSockets|4.0.2.0\",\"System.Net|4.0.0.0\",\"System.Numerics.Vectors|4.1.5.0\",\"System.Numerics|4.0.0.0\",\"System.ObjectModel|4.0.11.0\",\"System.Reflection.DispatchProxy|4.0.5.0\",\"System.Reflection.Emit.ILGeneration|4.0.1.0\",\"System.Reflection.Emit.Lightweight|4.0.1.0\",\"System.Reflection.Emit|4.0.1.0\",\"System.Reflection.Extensions|4.0.1.0\",\"System.Reflection.Primitives|4.0.1.0\",\"System.Reflection|4.1.2.0\",\"System.Resources.Reader|4.0.2.0\",\"System.Resources.ResourceManager|4.0.1.0\",\"System.Resources.Writer|4.0.2.0\",\"System.Runtime.CompilerServices.VisualC|4.0.2.0\",\"System.Runtime.Extensions|4.1.2.0\",\"System.Runtime.Handles|4.0.1.0\",\"System.Runtime.InteropServices.RuntimeInformation|4.0.2.0\",\"System.Runtime.InteropServices|4.1.2.0\",\"System.Runtime.Numerics|4.0.1.0\",\"System.Runtime.Serialization.Formatters|4.0.2.0\",\"System.Runtime.Serialization.Json|4.0.1.0\",\"System.Runtime.Serialization.Primitives|4.1.3.0\",\"System.Runtime.Serialization.Xml|4.1.3.0\",\"System.Runtime.Serialization|4.0.0.0\",\"System.Runtime|4.1.2.0\",\"System.Security.Claims|4.0.3.0\",\"System.Security.Cryptography.Algorithms|4.2.2.0\",\"System.Security.Cryptography.Csp|4.0.2.0\",\"System.Security.Cryptography.Encoding|4.0.2.0\",\"System.Security.Cryptography.Primitives|4.0.2.0\",\"System.Security.Cryptography.X509Certificates|4.1.2.0\",\"System.Security.Principal|4.0.1.0\",\"System.Security.SecureString|4.0.2.0\",\"System.ServiceModel.Web|4.0.0.0\",\"System.Text.Encoding.Extensions|4.0.11.0\",\"System.Text.Encoding|4.0.11.0\",\"System.Text.RegularExpressions|4.1.1.0\",\"System.Threading.Overlapped|4.0.3.0\",\"System.Threading.Tasks.Extensions|4.2.1.0\",\"System.Threading.Tasks.Parallel|4.0.1.0\",\"System.Threading.Tasks|4.0.11.0\",\"System.Threading.Thread|4.0.2.0\",\"System.Threading.ThreadPool|4.0.12.0\",\"System.Threading.Timer|4.0.1.0\",\"System.Threading|4.0.11.0\",\"System.Transactions|4.0.0.0\",\"System.ValueTuple|4.0.2.0\",\"System.Web|4.0.0.0\",\"System.Windows|4.0.0.0\",\"System.Xml.Linq|4.0.0.0\",\"System.Xml.ReaderWriter|4.1.1.0\",\"System.Xml.Serialization|4.0.0.0\",\"System.Xml.XDocument|4.0.11.0\",\"System.Xml.XPath.XDocument|4.0.3.0\",\"System.Xml.XPath|4.0.3.0\",\"System.Xml.XmlDocument|4.0.3.0\",\"System.Xml.XmlSerializer|4.0.11.0\",\"System.Xml|4.0.0.0\",\"System|4.0.0.0\",\"mscorlib|4.0.0.0\",\"netstandard|2.1.0.0\"],\"id\":\"NETStandard.Library.Ref\",\"sha512\":\"sha512-Jr0OqnqkaJJGEVq3w9oNQrIEteD/4QBNg3YOh1cvRjydzwop07+5aWjO/SfEYu6CwBn+dSBKXj8niEvTNy2brA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[\"Microsoft.Win32.Primitives|4.3.0\",\"System.AppContext|4.3.0\",\"System.Collections|4.3.0\",\"System.Collections.Concurrent|4.3.0\",\"System.Collections.Immutable|1.4.0\",\"System.Collections.NonGeneric|4.3.0\",\"System.Collections.Specialized|4.3.0\",\"System.ComponentModel|4.3.0\",\"System.ComponentModel.EventBasedAsync|4.3.0\",\"System.ComponentModel.Primitives|4.3.0\",\"System.ComponentModel.TypeConverter|4.3.0\",\"System.Console|4.3.0\",\"System.Data.Common|4.3.0\",\"System.Diagnostics.Contracts|4.3.0\",\"System.Diagnostics.Debug|4.3.0\",\"System.Diagnostics.FileVersionInfo|4.3.0\",\"System.Diagnostics.Process|4.3.0\",\"System.Diagnostics.StackTrace|4.3.0\",\"System.Diagnostics.TextWriterTraceListener|4.3.0\",\"System.Diagnostics.Tools|4.3.0\",\"System.Diagnostics.TraceSource|4.3.0\",\"System.Diagnostics.Tracing|4.3.0\",\"System.Dynamic.Runtime|4.3.0\",\"System.Globalization|4.3.0\",\"System.Globalization.Calendars|4.3.0\",\"System.Globalization.Extensions|4.3.0\",\"System.IO|4.3.0\",\"System.IO.Compression|4.3.0\",\"System.IO.Compression.ZipFile|4.3.0\",\"System.IO.FileSystem|4.3.0\",\"System.IO.FileSystem.DriveInfo|4.3.0\",\"System.IO.FileSystem.Primitives|4.3.0\",\"System.IO.FileSystem.Watcher|4.3.0\",\"System.IO.IsolatedStorage|4.3.0\",\"System.IO.MemoryMappedFiles|4.3.0\",\"System.IO.Pipes|4.3.0\",\"System.IO.UnmanagedMemoryStream|4.3.0\",\"System.Linq|4.3.0\",\"System.Linq.Expressions|4.3.0\",\"System.Linq.Queryable|4.3.0\",\"System.Net.Http|4.3.0\",\"System.Net.NameResolution|4.3.0\",\"System.Net.Primitives|4.3.0\",\"System.Net.Requests|4.3.0\",\"System.Net.Security|4.3.0\",\"System.Net.Sockets|4.3.0\",\"System.Net.WebHeaderCollection|4.3.0\",\"System.ObjectModel|4.3.0\",\"System.Private.DataContractSerialization|4.3.0\",\"System.Reflection|4.3.0\",\"System.Reflection.Emit|4.3.0\",\"System.Reflection.Emit.ILGeneration|4.3.0\",\"System.Reflection.Emit.Lightweight|4.3.0\",\"System.Reflection.Extensions|4.3.0\",\"System.Reflection.Primitives|4.3.0\",\"System.Reflection.TypeExtensions|4.3.0\",\"System.Resources.ResourceManager|4.3.0\",\"System.Runtime|4.3.0\",\"System.Runtime.Extensions|4.3.0\",\"System.Runtime.Handles|4.3.0\",\"System.Runtime.InteropServices|4.3.0\",\"System.Runtime.InteropServices.RuntimeInformation|4.3.0\",\"System.Runtime.Loader|4.3.0\",\"System.Runtime.Numerics|4.3.0\",\"System.Runtime.Serialization.Formatters|4.3.0\",\"System.Runtime.Serialization.Json|4.3.0\",\"System.Runtime.Serialization.Primitives|4.3.0\",\"System.Security.AccessControl|4.4.0\",\"System.Security.Claims|4.3.0\",\"System.Security.Cryptography.Algorithms|4.3.0\",\"System.Security.Cryptography.Csp|4.3.0\",\"System.Security.Cryptography.Encoding|4.3.0\",\"System.Security.Cryptography.Primitives|4.3.0\",\"System.Security.Cryptography.X509Certificates|4.3.0\",\"System.Security.Cryptography.Xml|4.4.0\",\"System.Security.Principal|4.3.0\",\"System.Security.Principal.Windows|4.4.0\",\"System.Text.Encoding|4.3.0\",\"System.Text.Encoding.Extensions|4.3.0\",\"System.Text.RegularExpressions|4.3.0\",\"System.Threading|4.3.0\",\"System.Threading.Overlapped|4.3.0\",\"System.Threading.Tasks|4.3.0\",\"System.Threading.Tasks.Extensions|4.3.0\",\"System.Threading.Tasks.Parallel|4.3.0\",\"System.Threading.Thread|4.3.0\",\"System.Threading.ThreadPool|4.3.0\",\"System.Threading.Timer|4.3.0\",\"System.ValueTuple|4.3.0\",\"System.Xml.ReaderWriter|4.3.0\",\"System.Xml.XDocument|4.3.0\",\"System.Xml.XmlDocument|4.3.0\",\"System.Xml.XmlSerializer|4.3.0\",\"System.Xml.XPath|4.3.0\",\"System.Xml.XPath.XDocument|4.3.0\"],\"version\":\"2.1.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"NETStandard.Library\"],\"netstandard1.1\":[\"NETStandard.Library\"],\"netstandard1.2\":[\"NETStandard.Library\"],\"netstandard1.3\":[\"NETStandard.Library\"],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Newtonsoft.Json\",\"sha512\":\"sha512-g3MbZi6vBTeaI/hEbvR7vBETSd1DWLe9i1E4P+nPY34v5i94zqUqDXvdWC3G+7tYN9SnsdU9zzegrnRz4h7nsQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"13.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net462\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net47\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net471\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net472\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net48\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net5.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net6.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net7.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net8.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp2.2\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp3.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp3.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netstandard2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"]},\"framework_list\":[],\"id\":\"NuGet.Commands\",\"sha512\":\"sha512-Q7ANXnmLUPC4pWgCZjBy2R7vRDABiaJz5NsBtoErE0dLylx/zQWRMyoa+m4Y478SKvUpt7S1V7LhAOlMRCTPpg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"NuGet.Frameworks\"],\"net451\":[\"NuGet.Frameworks\"],\"net452\":[\"NuGet.Frameworks\"],\"net46\":[\"NuGet.Frameworks\"],\"net461\":[\"NuGet.Frameworks\"],\"net462\":[\"NuGet.Frameworks\"],\"net47\":[\"NuGet.Frameworks\"],\"net471\":[\"NuGet.Frameworks\"],\"net472\":[\"NuGet.Frameworks\"],\"net48\":[\"NuGet.Frameworks\"],\"net5.0\":[\"NuGet.Frameworks\"],\"net6.0\":[\"NuGet.Frameworks\"],\"net7.0\":[\"NuGet.Frameworks\"],\"net8.0\":[\"NuGet.Frameworks\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Frameworks\"],\"netcoreapp2.1\":[\"NuGet.Frameworks\"],\"netcoreapp2.2\":[\"NuGet.Frameworks\"],\"netcoreapp3.0\":[\"NuGet.Frameworks\"],\"netcoreapp3.1\":[\"NuGet.Frameworks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Frameworks\"],\"netstandard2.1\":[\"NuGet.Frameworks\"]},\"framework_list\":[],\"id\":\"NuGet.Common\",\"sha512\":\"sha512-8M9VtXAB1M15KmvL0F9QsItI96PH3WmYD0z3oxYm5H9G5AIhK8Ivi4kGzqtBJDTsZ/NkP91U1MnoCAeg4E4+zA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"NuGet.Common\"],\"net451\":[\"NuGet.Common\"],\"net452\":[\"NuGet.Common\"],\"net46\":[\"NuGet.Common\"],\"net461\":[\"NuGet.Common\"],\"net462\":[\"NuGet.Common\"],\"net47\":[\"NuGet.Common\"],\"net471\":[\"NuGet.Common\"],\"net472\":[\"NuGet.Common\"],\"net48\":[\"NuGet.Common\"],\"net5.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net6.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net7.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net8.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"]},\"framework_list\":[],\"id\":\"NuGet.Configuration\",\"sha512\":\"sha512-ZJc2HY/D+UEk2U0jxamyBhUbKl2bgluViM/tnP4ObIIfJpOj8dHEJ6xzggulIGDlhe+ItK6yc+sqtCb6qV5+gw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Credentials\",\"sha512\":\"sha512-r/fzn5yJaCXyChbhxbGZ5d/4xV4n3NIjVdE3odLfQy0znmcYRCDIfjYGu5l7vO9Nx27F+q7YA+9QmG9sucxX9A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net462\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net47\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net471\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net472\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net48\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.DependencyResolver.Core\",\"sha512\":\"sha512-+9mCFiBhnm5C2Cb3dtHaHyv/WarSr5HwRi2NaoVJgudpHoK3B9uy8wB7PNnUos0kOghZmVslemeLsmw7icQqTw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Frameworks\",\"sha512\":\"sha512-l8KtHN2bzA391seLZ9Q2AWK0mbCHpfbwL1nmOSMDxBpWLxqh+nxMWaKL437bROpHltU+oP5LX/hc4Fxm89T9Tg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net462\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net47\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net471\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net472\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net48\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net5.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net6.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net7.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net8.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"]},\"framework_list\":[],\"id\":\"NuGet.LibraryModel\",\"sha512\":\"sha512-xb8XLKJEMymZMAZJeXdSUaDNFRQMJ4MXkOPUaqafcgSKGz8M8BZgfLsBz9QCQVEyHIVYGbI4yroWZYed/c8xSg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net462\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net47\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net471\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net472\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\"],\"net48\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\"],\"net5.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net6.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net7.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net8.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.2\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"]},\"framework_list\":[],\"id\":\"NuGet.PackageManagement\",\"sha512\":\"sha512-Kr0CZuStXNsJRL86ecuWGhIHUhYy31rYZJ9WZ0tiFUaRwiPb7HpSQVsV/v3tqrKE7FWUZBpasX1bugXNqXcPjA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net462\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net47\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net471\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net472\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net48\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net5.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net6.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net7.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net8.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.2\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netstandard2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"]},\"framework_list\":[],\"id\":\"Nuget.Packaging\",\"sha512\":\"sha512-2HMq5gNgLMOHmqGb84pyEC7ctkCYBVXkhJfcYmHlkpo4FpDA6GQBoT//1h0Q4nGoybtgoBxiIbJu8VRn/9CZrQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Nuget.Packaging.Core\",\"sha512\":\"sha512-/WXGAbLb4T0pwEfEeY0j8zOVpS36OHNUANL95txANysbLoG7tUr9e+5je+Nfh3iIqzMaHIZXT6JKFvHOBwAotw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.DependencyResolver.Core\"],\"net462\":[\"NuGet.DependencyResolver.Core\"],\"net47\":[\"NuGet.DependencyResolver.Core\"],\"net471\":[\"NuGet.DependencyResolver.Core\"],\"net472\":[\"NuGet.DependencyResolver.Core\"],\"net48\":[\"NuGet.DependencyResolver.Core\"],\"net5.0\":[\"NuGet.DependencyResolver.Core\"],\"net6.0\":[\"NuGet.DependencyResolver.Core\"],\"net7.0\":[\"NuGet.DependencyResolver.Core\"],\"net8.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.1\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.2\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.1\":[\"NuGet.DependencyResolver.Core\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.DependencyResolver.Core\"],\"netstandard2.1\":[\"NuGet.DependencyResolver.Core\"]},\"framework_list\":[],\"id\":\"NuGet.ProjectModel\",\"sha512\":\"sha512-gsZS2Kuat3ZjjPcBQ3Mc8QlRv6mP1OzNzkF4Dzybu3LgtG+kwvgQh4UMLbiIrko6WKbwVTbr8nQYpL+wsVZ4hA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Protocol\",\"sha512\":\"sha512-lY85Pgf7kr0JwTufdJmfDgBwN9BRQc96F4xxKrUGSALhuZRRC7y6f2RN1JQ0UTPIXlQx7HTG/h0UZEknQj3/UQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Resolver\",\"sha512\":\"sha512-a2zWl9RkKDkcVUqfRJjz3O4uoPIWf3PGaFf6AntXtTKjvvsB6SZz8jjPSGdLgTTRIWzsFlybKp6yU+GaXeIQkg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Versioning\",\"sha512\":\"sha512-NW11tfXijCWeI8d71HKpNPKPzJqr30PtUyJHzCpKFMFTGZhsHh2YxgjKBuhpC5R59SMZUzqrFF5CgJ8uGaupqg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"NETStandard.Library\"],\"net6.0\":[\"NETStandard.Library\"],\"net7.0\":[\"NETStandard.Library\"],\"net8.0\":[\"NETStandard.Library\"],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[\"NETStandard.Library\"],\"netcoreapp2.1\":[\"NETStandard.Library\"],\"netcoreapp2.2\":[\"NETStandard.Library\"],\"netcoreapp3.0\":[\"NETStandard.Library\"],\"netcoreapp3.1\":[\"NETStandard.Library\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[\"NETStandard.Library\"],\"netstandard2.1\":[\"NETStandard.Library\"]},\"framework_list\":[],\"id\":\"NUnit\",\"sha512\":\"sha512-HAhwFxr+Z+PJf8hXzc747NecvsDwEZ+3X8SA5+GIRM43GAy1Ap+TQPMHsWCnisfes5vPZ1/a2md/91u+shoTsQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.12.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[\"NUnit\"],\"net40\":[\"NUnit\"],\"net403\":[\"NUnit\"],\"net45\":[\"NUnit\"],\"net451\":[\"NUnit\"],\"net452\":[\"NUnit\"],\"net46\":[\"NUnit\"],\"net461\":[\"NUnit\"],\"net462\":[\"NUnit\"],\"net47\":[\"NUnit\"],\"net471\":[\"NUnit\"],\"net472\":[\"NUnit\"],\"net48\":[\"NUnit\"],\"net5.0\":[\"NUnit\",\"NETStandard.Library\"],\"net6.0\":[\"NUnit\",\"NETStandard.Library\"],\"net7.0\":[\"NUnit\",\"NETStandard.Library\"],\"net8.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp1.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp2.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp2.1\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp2.2\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp3.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp3.1\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard1.5\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard1.6\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard2.0\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard2.1\":[\"NUnit\",\"NETStandard.Library\"]},\"framework_list\":[],\"id\":\"NUnitLite\",\"sha512\":\"sha512-M9VVS4x3KURXFS4HTl2b7uJOX7vOi2wzpHACmNX6ANlBmb0/hIehJLciiVvddD3ubIIL81EF4Qk54kpsUOtVFQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.12.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"NETStandard.Library\"],\"netstandard1.2\":[\"NETStandard.Library\"],\"netstandard1.3\":[\"NETStandard.Library\"],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.ComponentModel.Annotations\",\"sha512\":\"sha512-WJqsTGaXAc55EPGjJylPFXiNPs/x1t9dklVlHlIBxUEcIxIob6sRGm9Un7TehkyEFM+vKjZd7rbwaMH/znw1PA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.ComponentModel.Composition\",\"sha512\":\"sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Formats.Asn1\",\"sha512\":\"sha512-62YP6zLnvmFtFI3rjybbrnSeK6hHQCaFfJJfoNhQqrETJBPehSucQxIyQs5W+GGBW/rpSXD/0NqNW7mttIWXhA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Formats.Asn1\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[\"System.Formats.Asn1\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Cng\",\"sha512\":\"sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.2\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Pkcs\",\"sha512\":\"sha512-ubxxZt0n9t8Xe/NtN53XMf6ZSfRKsk/T+mheDuoZbYrBJRLVyQ4pecXoROihl/DyC9uVOt6QrejwLAx1Raj1wg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.ProtectedData\",\"sha512\":\"sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}"
+              ],
+              "targeting_pack_overrides": {
+                "mcmaster.extensions.commandlineutils": [],
+                "microsoft.netcore.app.ref": [
+                  "Microsoft.CSharp|4.4.0",
+                  "Microsoft.Win32.Primitives|4.3.0",
+                  "Microsoft.Win32.Registry|4.4.0",
+                  "runtime.debian.8-x64.runtime.native.System|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "System.AppContext|4.3.0",
+                  "System.Buffers|4.4.0",
+                  "System.Collections|4.3.0",
+                  "System.Collections.Concurrent|4.3.0",
+                  "System.Collections.Immutable|1.4.0",
+                  "System.Collections.NonGeneric|4.3.0",
+                  "System.Collections.Specialized|4.3.0",
+                  "System.ComponentModel|4.3.0",
+                  "System.ComponentModel.EventBasedAsync|4.3.0",
+                  "System.ComponentModel.Primitives|4.3.0",
+                  "System.ComponentModel.TypeConverter|4.3.0",
+                  "System.Console|4.3.0",
+                  "System.Data.Common|4.3.0",
+                  "System.Diagnostics.Contracts|4.3.0",
+                  "System.Diagnostics.Debug|4.3.0",
+                  "System.Diagnostics.DiagnosticSource|4.4.0",
+                  "System.Diagnostics.FileVersionInfo|4.3.0",
+                  "System.Diagnostics.Process|4.3.0",
+                  "System.Diagnostics.StackTrace|4.3.0",
+                  "System.Diagnostics.TextWriterTraceListener|4.3.0",
+                  "System.Diagnostics.Tools|4.3.0",
+                  "System.Diagnostics.TraceSource|4.3.0",
+                  "System.Diagnostics.Tracing|4.3.0",
+                  "System.Dynamic.Runtime|4.3.0",
+                  "System.Globalization|4.3.0",
+                  "System.Globalization.Calendars|4.3.0",
+                  "System.Globalization.Extensions|4.3.0",
+                  "System.IO|4.3.0",
+                  "System.IO.Compression|4.3.0",
+                  "System.IO.Compression.ZipFile|4.3.0",
+                  "System.IO.FileSystem|4.3.0",
+                  "System.IO.FileSystem.AccessControl|4.4.0",
+                  "System.IO.FileSystem.DriveInfo|4.3.0",
+                  "System.IO.FileSystem.Primitives|4.3.0",
+                  "System.IO.FileSystem.Watcher|4.3.0",
+                  "System.IO.IsolatedStorage|4.3.0",
+                  "System.IO.MemoryMappedFiles|4.3.0",
+                  "System.IO.Pipes|4.3.0",
+                  "System.IO.UnmanagedMemoryStream|4.3.0",
+                  "System.Linq|4.3.0",
+                  "System.Linq.Expressions|4.3.0",
+                  "System.Linq.Queryable|4.3.0",
+                  "System.Net.Http|4.3.0",
+                  "System.Net.NameResolution|4.3.0",
+                  "System.Net.Primitives|4.3.0",
+                  "System.Net.Requests|4.3.0",
+                  "System.Net.Security|4.3.0",
+                  "System.Net.Sockets|4.3.0",
+                  "System.Net.WebHeaderCollection|4.3.0",
+                  "System.ObjectModel|4.3.0",
+                  "System.Private.DataContractSerialization|4.3.0",
+                  "System.Reflection|4.3.0",
+                  "System.Reflection.Emit|4.3.0",
+                  "System.Reflection.Emit.ILGeneration|4.3.0",
+                  "System.Reflection.Emit.Lightweight|4.3.0",
+                  "System.Reflection.Extensions|4.3.0",
+                  "System.Reflection.Metadata|1.5.0",
+                  "System.Reflection.Primitives|4.3.0",
+                  "System.Reflection.TypeExtensions|4.3.0",
+                  "System.Resources.ResourceManager|4.3.0",
+                  "System.Runtime|4.3.0",
+                  "System.Runtime.Extensions|4.3.0",
+                  "System.Runtime.Handles|4.3.0",
+                  "System.Runtime.InteropServices|4.3.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|4.3.0",
+                  "System.Runtime.Loader|4.3.0",
+                  "System.Runtime.Numerics|4.3.0",
+                  "System.Runtime.Serialization.Formatters|4.3.0",
+                  "System.Runtime.Serialization.Json|4.3.0",
+                  "System.Runtime.Serialization.Primitives|4.3.0",
+                  "System.Security.AccessControl|4.4.0",
+                  "System.Security.Claims|4.3.0",
+                  "System.Security.Cryptography.Algorithms|4.3.0",
+                  "System.Security.Cryptography.Cng|4.4.0",
+                  "System.Security.Cryptography.Csp|4.3.0",
+                  "System.Security.Cryptography.Encoding|4.3.0",
+                  "System.Security.Cryptography.OpenSsl|4.4.0",
+                  "System.Security.Cryptography.Primitives|4.3.0",
+                  "System.Security.Cryptography.X509Certificates|4.3.0",
+                  "System.Security.Cryptography.Xml|4.4.0",
+                  "System.Security.Principal|4.3.0",
+                  "System.Security.Principal.Windows|4.4.0",
+                  "System.Text.Encoding|4.3.0",
+                  "System.Text.Encoding.Extensions|4.3.0",
+                  "System.Text.RegularExpressions|4.3.0",
+                  "System.Threading|4.3.0",
+                  "System.Threading.Overlapped|4.3.0",
+                  "System.Threading.Tasks|4.3.0",
+                  "System.Threading.Tasks.Extensions|4.3.0",
+                  "System.Threading.Tasks.Parallel|4.3.0",
+                  "System.Threading.Thread|4.3.0",
+                  "System.Threading.ThreadPool|4.3.0",
+                  "System.Threading.Timer|4.3.0",
+                  "System.ValueTuple|4.3.0",
+                  "System.Xml.ReaderWriter|4.3.0",
+                  "System.Xml.XDocument|4.3.0",
+                  "System.Xml.XmlDocument|4.3.0",
+                  "System.Xml.XmlSerializer|4.3.0",
+                  "System.Xml.XPath|4.3.0",
+                  "System.Xml.XPath.XDocument|4.3.0"
+                ],
+                "microsoft.netcore.platforms": [],
+                "microsoft.web.xdt": [],
+                "netstandard.library": [],
+                "netstandard.library.ref": [
+                  "Microsoft.Win32.Primitives|4.3.0",
+                  "System.AppContext|4.3.0",
+                  "System.Collections|4.3.0",
+                  "System.Collections.Concurrent|4.3.0",
+                  "System.Collections.Immutable|1.4.0",
+                  "System.Collections.NonGeneric|4.3.0",
+                  "System.Collections.Specialized|4.3.0",
+                  "System.ComponentModel|4.3.0",
+                  "System.ComponentModel.EventBasedAsync|4.3.0",
+                  "System.ComponentModel.Primitives|4.3.0",
+                  "System.ComponentModel.TypeConverter|4.3.0",
+                  "System.Console|4.3.0",
+                  "System.Data.Common|4.3.0",
+                  "System.Diagnostics.Contracts|4.3.0",
+                  "System.Diagnostics.Debug|4.3.0",
+                  "System.Diagnostics.FileVersionInfo|4.3.0",
+                  "System.Diagnostics.Process|4.3.0",
+                  "System.Diagnostics.StackTrace|4.3.0",
+                  "System.Diagnostics.TextWriterTraceListener|4.3.0",
+                  "System.Diagnostics.Tools|4.3.0",
+                  "System.Diagnostics.TraceSource|4.3.0",
+                  "System.Diagnostics.Tracing|4.3.0",
+                  "System.Dynamic.Runtime|4.3.0",
+                  "System.Globalization|4.3.0",
+                  "System.Globalization.Calendars|4.3.0",
+                  "System.Globalization.Extensions|4.3.0",
+                  "System.IO|4.3.0",
+                  "System.IO.Compression|4.3.0",
+                  "System.IO.Compression.ZipFile|4.3.0",
+                  "System.IO.FileSystem|4.3.0",
+                  "System.IO.FileSystem.DriveInfo|4.3.0",
+                  "System.IO.FileSystem.Primitives|4.3.0",
+                  "System.IO.FileSystem.Watcher|4.3.0",
+                  "System.IO.IsolatedStorage|4.3.0",
+                  "System.IO.MemoryMappedFiles|4.3.0",
+                  "System.IO.Pipes|4.3.0",
+                  "System.IO.UnmanagedMemoryStream|4.3.0",
+                  "System.Linq|4.3.0",
+                  "System.Linq.Expressions|4.3.0",
+                  "System.Linq.Queryable|4.3.0",
+                  "System.Net.Http|4.3.0",
+                  "System.Net.NameResolution|4.3.0",
+                  "System.Net.Primitives|4.3.0",
+                  "System.Net.Requests|4.3.0",
+                  "System.Net.Security|4.3.0",
+                  "System.Net.Sockets|4.3.0",
+                  "System.Net.WebHeaderCollection|4.3.0",
+                  "System.ObjectModel|4.3.0",
+                  "System.Private.DataContractSerialization|4.3.0",
+                  "System.Reflection|4.3.0",
+                  "System.Reflection.Emit|4.3.0",
+                  "System.Reflection.Emit.ILGeneration|4.3.0",
+                  "System.Reflection.Emit.Lightweight|4.3.0",
+                  "System.Reflection.Extensions|4.3.0",
+                  "System.Reflection.Primitives|4.3.0",
+                  "System.Reflection.TypeExtensions|4.3.0",
+                  "System.Resources.ResourceManager|4.3.0",
+                  "System.Runtime|4.3.0",
+                  "System.Runtime.Extensions|4.3.0",
+                  "System.Runtime.Handles|4.3.0",
+                  "System.Runtime.InteropServices|4.3.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|4.3.0",
+                  "System.Runtime.Loader|4.3.0",
+                  "System.Runtime.Numerics|4.3.0",
+                  "System.Runtime.Serialization.Formatters|4.3.0",
+                  "System.Runtime.Serialization.Json|4.3.0",
+                  "System.Runtime.Serialization.Primitives|4.3.0",
+                  "System.Security.AccessControl|4.4.0",
+                  "System.Security.Claims|4.3.0",
+                  "System.Security.Cryptography.Algorithms|4.3.0",
+                  "System.Security.Cryptography.Csp|4.3.0",
+                  "System.Security.Cryptography.Encoding|4.3.0",
+                  "System.Security.Cryptography.Primitives|4.3.0",
+                  "System.Security.Cryptography.X509Certificates|4.3.0",
+                  "System.Security.Cryptography.Xml|4.4.0",
+                  "System.Security.Principal|4.3.0",
+                  "System.Security.Principal.Windows|4.4.0",
+                  "System.Text.Encoding|4.3.0",
+                  "System.Text.Encoding.Extensions|4.3.0",
+                  "System.Text.RegularExpressions|4.3.0",
+                  "System.Threading|4.3.0",
+                  "System.Threading.Overlapped|4.3.0",
+                  "System.Threading.Tasks|4.3.0",
+                  "System.Threading.Tasks.Extensions|4.3.0",
+                  "System.Threading.Tasks.Parallel|4.3.0",
+                  "System.Threading.Thread|4.3.0",
+                  "System.Threading.ThreadPool|4.3.0",
+                  "System.Threading.Timer|4.3.0",
+                  "System.ValueTuple|4.3.0",
+                  "System.Xml.ReaderWriter|4.3.0",
+                  "System.Xml.XDocument|4.3.0",
+                  "System.Xml.XmlDocument|4.3.0",
+                  "System.Xml.XmlSerializer|4.3.0",
+                  "System.Xml.XPath|4.3.0",
+                  "System.Xml.XPath.XDocument|4.3.0"
+                ],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.packaging.core": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "nunit": [],
+                "nunitlite": [],
+                "system.componentmodel.annotations": [],
+                "system.componentmodel.composition": [],
+                "system.formats.asn1": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.protecteddata": []
+              },
+              "framework_list": {
+                "mcmaster.extensions.commandlineutils": [],
+                "microsoft.netcore.app.ref": [
+                  "Microsoft.CSharp|6.0.0.0",
+                  "Microsoft.VisualBasic.Core|11.0.0.0",
+                  "Microsoft.VisualBasic|10.0.0.0",
+                  "Microsoft.Win32.Primitives|6.0.0.0",
+                  "Microsoft.Win32.Registry|6.0.0.0",
+                  "System.AppContext|6.0.0.0",
+                  "System.Buffers|6.0.0.0",
+                  "System.Collections.Concurrent|6.0.0.0",
+                  "System.Collections.Immutable|6.0.0.0",
+                  "System.Collections.NonGeneric|6.0.0.0",
+                  "System.Collections.Specialized|6.0.0.0",
+                  "System.Collections|6.0.0.0",
+                  "System.ComponentModel.Annotations|6.0.0.0",
+                  "System.ComponentModel.DataAnnotations|4.0.0.0",
+                  "System.ComponentModel.EventBasedAsync|6.0.0.0",
+                  "System.ComponentModel.Primitives|6.0.0.0",
+                  "System.ComponentModel.TypeConverter|6.0.0.0",
+                  "System.ComponentModel|6.0.0.0",
+                  "System.Configuration|4.0.0.0",
+                  "System.Console|6.0.0.0",
+                  "System.Core|4.0.0.0",
+                  "System.Data.Common|6.0.0.0",
+                  "System.Data.DataSetExtensions|4.0.0.0",
+                  "System.Data|4.0.0.0",
+                  "System.Diagnostics.Contracts|6.0.0.0",
+                  "System.Diagnostics.Debug|6.0.0.0",
+                  "System.Diagnostics.DiagnosticSource|6.0.0.0",
+                  "System.Diagnostics.FileVersionInfo|6.0.0.0",
+                  "System.Diagnostics.Process|6.0.0.0",
+                  "System.Diagnostics.StackTrace|6.0.0.0",
+                  "System.Diagnostics.TextWriterTraceListener|6.0.0.0",
+                  "System.Diagnostics.Tools|6.0.0.0",
+                  "System.Diagnostics.TraceSource|6.0.0.0",
+                  "System.Diagnostics.Tracing|6.0.0.0",
+                  "System.Drawing.Primitives|6.0.0.0",
+                  "System.Drawing|4.0.0.0",
+                  "System.Dynamic.Runtime|6.0.0.0",
+                  "System.Formats.Asn1|6.0.0.0",
+                  "System.Globalization.Calendars|6.0.0.0",
+                  "System.Globalization.Extensions|6.0.0.0",
+                  "System.Globalization|6.0.0.0",
+                  "System.IO.Compression.Brotli|6.0.0.0",
+                  "System.IO.Compression.FileSystem|4.0.0.0",
+                  "System.IO.Compression.ZipFile|6.0.0.0",
+                  "System.IO.Compression|6.0.0.0",
+                  "System.IO.FileSystem.AccessControl|6.0.0.0",
+                  "System.IO.FileSystem.DriveInfo|6.0.0.0",
+                  "System.IO.FileSystem.Primitives|6.0.0.0",
+                  "System.IO.FileSystem.Watcher|6.0.0.0",
+                  "System.IO.FileSystem|6.0.0.0",
+                  "System.IO.IsolatedStorage|6.0.0.0",
+                  "System.IO.MemoryMappedFiles|6.0.0.0",
+                  "System.IO.Pipes.AccessControl|6.0.0.0",
+                  "System.IO.Pipes|6.0.0.0",
+                  "System.IO.UnmanagedMemoryStream|6.0.0.0",
+                  "System.IO|6.0.0.0",
+                  "System.Linq.Expressions|6.0.0.0",
+                  "System.Linq.Parallel|6.0.0.0",
+                  "System.Linq.Queryable|6.0.0.0",
+                  "System.Linq|6.0.0.0",
+                  "System.Memory|6.0.0.0",
+                  "System.Net.Http.Json|6.0.0.0",
+                  "System.Net.Http|6.0.0.0",
+                  "System.Net.HttpListener|6.0.0.0",
+                  "System.Net.Mail|6.0.0.0",
+                  "System.Net.NameResolution|6.0.0.0",
+                  "System.Net.NetworkInformation|6.0.0.0",
+                  "System.Net.Ping|6.0.0.0",
+                  "System.Net.Primitives|6.0.0.0",
+                  "System.Net.Requests|6.0.0.0",
+                  "System.Net.Security|6.0.0.0",
+                  "System.Net.ServicePoint|6.0.0.0",
+                  "System.Net.Sockets|6.0.0.0",
+                  "System.Net.WebClient|6.0.0.0",
+                  "System.Net.WebHeaderCollection|6.0.0.0",
+                  "System.Net.WebProxy|6.0.0.0",
+                  "System.Net.WebSockets.Client|6.0.0.0",
+                  "System.Net.WebSockets|6.0.0.0",
+                  "System.Net|4.0.0.0",
+                  "System.Numerics.Vectors|6.0.0.0",
+                  "System.Numerics|4.0.0.0",
+                  "System.ObjectModel|6.0.0.0",
+                  "System.Reflection.DispatchProxy|6.0.0.0",
+                  "System.Reflection.Emit.ILGeneration|6.0.0.0",
+                  "System.Reflection.Emit.Lightweight|6.0.0.0",
+                  "System.Reflection.Emit|6.0.0.0",
+                  "System.Reflection.Extensions|6.0.0.0",
+                  "System.Reflection.Metadata|6.0.0.0",
+                  "System.Reflection.Primitives|6.0.0.0",
+                  "System.Reflection.TypeExtensions|6.0.0.0",
+                  "System.Reflection|6.0.0.0",
+                  "System.Resources.Reader|6.0.0.0",
+                  "System.Resources.ResourceManager|6.0.0.0",
+                  "System.Resources.Writer|6.0.0.0",
+                  "System.Runtime.CompilerServices.Unsafe|6.0.0.0",
+                  "System.Runtime.CompilerServices.VisualC|6.0.0.0",
+                  "System.Runtime.Extensions|6.0.0.0",
+                  "System.Runtime.Handles|6.0.0.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|6.0.0.0",
+                  "System.Runtime.InteropServices|6.0.0.0",
+                  "System.Runtime.Intrinsics|6.0.0.0",
+                  "System.Runtime.Loader|6.0.0.0",
+                  "System.Runtime.Numerics|6.0.0.0",
+                  "System.Runtime.Serialization.Formatters|6.0.0.0",
+                  "System.Runtime.Serialization.Json|6.0.0.0",
+                  "System.Runtime.Serialization.Primitives|6.0.0.0",
+                  "System.Runtime.Serialization.Xml|6.0.0.0",
+                  "System.Runtime.Serialization|4.0.0.0",
+                  "System.Runtime|6.0.0.0",
+                  "System.Security.AccessControl|6.0.0.0",
+                  "System.Security.Claims|6.0.0.0",
+                  "System.Security.Cryptography.Algorithms|6.0.0.0",
+                  "System.Security.Cryptography.Cng|6.0.0.0",
+                  "System.Security.Cryptography.Csp|6.0.0.0",
+                  "System.Security.Cryptography.Encoding|6.0.0.0",
+                  "System.Security.Cryptography.OpenSsl|6.0.0.0",
+                  "System.Security.Cryptography.Primitives|6.0.0.0",
+                  "System.Security.Cryptography.X509Certificates|6.0.0.0",
+                  "System.Security.Principal.Windows|6.0.0.0",
+                  "System.Security.Principal|6.0.0.0",
+                  "System.Security.SecureString|6.0.0.0",
+                  "System.Security|4.0.0.0",
+                  "System.ServiceModel.Web|4.0.0.0",
+                  "System.ServiceProcess|4.0.0.0",
+                  "System.Text.Encoding.CodePages|6.0.0.0",
+                  "System.Text.Encoding.Extensions|6.0.0.0",
+                  "System.Text.Encoding|6.0.0.0",
+                  "System.Text.Encodings.Web|6.0.0.0",
+                  "System.Text.Json|6.0.0.0",
+                  "System.Text.RegularExpressions|6.0.0.0",
+                  "System.Threading.Channels|6.0.0.0",
+                  "System.Threading.Overlapped|6.0.0.0",
+                  "System.Threading.Tasks.Dataflow|6.0.0.0",
+                  "System.Threading.Tasks.Extensions|6.0.0.0",
+                  "System.Threading.Tasks.Parallel|6.0.0.0",
+                  "System.Threading.Tasks|6.0.0.0",
+                  "System.Threading.Thread|6.0.0.0",
+                  "System.Threading.ThreadPool|6.0.0.0",
+                  "System.Threading.Timer|6.0.0.0",
+                  "System.Threading|6.0.0.0",
+                  "System.Transactions.Local|6.0.0.0",
+                  "System.Transactions|4.0.0.0",
+                  "System.ValueTuple|4.0.3.0",
+                  "System.Web.HttpUtility|6.0.0.0",
+                  "System.Web|4.0.0.0",
+                  "System.Windows|4.0.0.0",
+                  "System.Xml.Linq|4.0.0.0",
+                  "System.Xml.ReaderWriter|6.0.0.0",
+                  "System.Xml.Serialization|4.0.0.0",
+                  "System.Xml.XDocument|6.0.0.0",
+                  "System.Xml.XPath.XDocument|6.0.0.0",
+                  "System.Xml.XPath|6.0.0.0",
+                  "System.Xml.XmlDocument|6.0.0.0",
+                  "System.Xml.XmlSerializer|6.0.0.0",
+                  "System.Xml|4.0.0.0",
+                  "System|4.0.0.0",
+                  "WindowsBase|4.0.0.0",
+                  "mscorlib|4.0.0.0",
+                  "netstandard|2.1.0.0"
+                ],
+                "microsoft.netcore.platforms": [],
+                "microsoft.web.xdt": [],
+                "netstandard.library": [],
+                "netstandard.library.ref": [
+                  "Microsoft.Win32.Primitives|4.0.3.0",
+                  "System.AppContext|4.1.2.0",
+                  "System.Buffers|4.0.3.0",
+                  "System.Collections.Concurrent|4.0.11.0",
+                  "System.Collections.NonGeneric|4.0.3.0",
+                  "System.Collections.Specialized|4.0.3.0",
+                  "System.Collections|4.0.11.0",
+                  "System.ComponentModel.Composition|4.0.0.0",
+                  "System.ComponentModel.EventBasedAsync|4.0.11.0",
+                  "System.ComponentModel.Primitives|4.1.2.0",
+                  "System.ComponentModel.TypeConverter|4.1.2.0",
+                  "System.ComponentModel|4.0.1.0",
+                  "System.Console|4.0.2.0",
+                  "System.Core|4.0.0.0",
+                  "System.Data.Common|4.1.2.0",
+                  "System.Data|4.0.0.0",
+                  "System.Diagnostics.Contracts|4.0.1.0",
+                  "System.Diagnostics.Debug|4.0.11.0",
+                  "System.Diagnostics.FileVersionInfo|4.0.2.0",
+                  "System.Diagnostics.Process|4.1.2.0",
+                  "System.Diagnostics.StackTrace|4.0.4.0",
+                  "System.Diagnostics.TextWriterTraceListener|4.0.2.0",
+                  "System.Diagnostics.Tools|4.0.1.0",
+                  "System.Diagnostics.TraceSource|4.0.2.0",
+                  "System.Diagnostics.Tracing|4.1.2.0",
+                  "System.Drawing.Primitives|4.0.2.0",
+                  "System.Drawing|4.0.0.0",
+                  "System.Dynamic.Runtime|4.0.11.0",
+                  "System.Globalization.Calendars|4.0.3.0",
+                  "System.Globalization.Extensions|4.0.3.0",
+                  "System.Globalization|4.0.11.0",
+                  "System.IO.Compression.FileSystem|4.0.0.0",
+                  "System.IO.Compression.ZipFile|4.0.3.0",
+                  "System.IO.Compression|4.1.3.0",
+                  "System.IO.FileSystem.DriveInfo|4.0.2.0",
+                  "System.IO.FileSystem.Primitives|4.0.3.0",
+                  "System.IO.FileSystem.Watcher|4.0.2.0",
+                  "System.IO.FileSystem|4.0.3.0",
+                  "System.IO.IsolatedStorage|4.0.2.0",
+                  "System.IO.MemoryMappedFiles|4.0.2.0",
+                  "System.IO.Pipes|4.0.2.0",
+                  "System.IO.UnmanagedMemoryStream|4.0.3.0",
+                  "System.IO|4.1.2.0",
+                  "System.Linq.Expressions|4.1.2.0",
+                  "System.Linq.Parallel|4.0.1.0",
+                  "System.Linq.Queryable|4.0.1.0",
+                  "System.Linq|4.1.2.0",
+                  "System.Memory|4.0.2.0",
+                  "System.Net.Http|4.1.2.0",
+                  "System.Net.NameResolution|4.0.2.0",
+                  "System.Net.NetworkInformation|4.1.2.0",
+                  "System.Net.Ping|4.0.2.0",
+                  "System.Net.Primitives|4.0.11.0",
+                  "System.Net.Requests|4.0.11.0",
+                  "System.Net.Security|4.0.2.0",
+                  "System.Net.Sockets|4.1.2.0",
+                  "System.Net.WebHeaderCollection|4.0.1.0",
+                  "System.Net.WebSockets.Client|4.0.2.0",
+                  "System.Net.WebSockets|4.0.2.0",
+                  "System.Net|4.0.0.0",
+                  "System.Numerics.Vectors|4.1.5.0",
+                  "System.Numerics|4.0.0.0",
+                  "System.ObjectModel|4.0.11.0",
+                  "System.Reflection.DispatchProxy|4.0.5.0",
+                  "System.Reflection.Emit.ILGeneration|4.0.1.0",
+                  "System.Reflection.Emit.Lightweight|4.0.1.0",
+                  "System.Reflection.Emit|4.0.1.0",
+                  "System.Reflection.Extensions|4.0.1.0",
+                  "System.Reflection.Primitives|4.0.1.0",
+                  "System.Reflection|4.1.2.0",
+                  "System.Resources.Reader|4.0.2.0",
+                  "System.Resources.ResourceManager|4.0.1.0",
+                  "System.Resources.Writer|4.0.2.0",
+                  "System.Runtime.CompilerServices.VisualC|4.0.2.0",
+                  "System.Runtime.Extensions|4.1.2.0",
+                  "System.Runtime.Handles|4.0.1.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|4.0.2.0",
+                  "System.Runtime.InteropServices|4.1.2.0",
+                  "System.Runtime.Numerics|4.0.1.0",
+                  "System.Runtime.Serialization.Formatters|4.0.2.0",
+                  "System.Runtime.Serialization.Json|4.0.1.0",
+                  "System.Runtime.Serialization.Primitives|4.1.3.0",
+                  "System.Runtime.Serialization.Xml|4.1.3.0",
+                  "System.Runtime.Serialization|4.0.0.0",
+                  "System.Runtime|4.1.2.0",
+                  "System.Security.Claims|4.0.3.0",
+                  "System.Security.Cryptography.Algorithms|4.2.2.0",
+                  "System.Security.Cryptography.Csp|4.0.2.0",
+                  "System.Security.Cryptography.Encoding|4.0.2.0",
+                  "System.Security.Cryptography.Primitives|4.0.2.0",
+                  "System.Security.Cryptography.X509Certificates|4.1.2.0",
+                  "System.Security.Principal|4.0.1.0",
+                  "System.Security.SecureString|4.0.2.0",
+                  "System.ServiceModel.Web|4.0.0.0",
+                  "System.Text.Encoding.Extensions|4.0.11.0",
+                  "System.Text.Encoding|4.0.11.0",
+                  "System.Text.RegularExpressions|4.1.1.0",
+                  "System.Threading.Overlapped|4.0.3.0",
+                  "System.Threading.Tasks.Extensions|4.2.1.0",
+                  "System.Threading.Tasks.Parallel|4.0.1.0",
+                  "System.Threading.Tasks|4.0.11.0",
+                  "System.Threading.Thread|4.0.2.0",
+                  "System.Threading.ThreadPool|4.0.12.0",
+                  "System.Threading.Timer|4.0.1.0",
+                  "System.Threading|4.0.11.0",
+                  "System.Transactions|4.0.0.0",
+                  "System.ValueTuple|4.0.2.0",
+                  "System.Web|4.0.0.0",
+                  "System.Windows|4.0.0.0",
+                  "System.Xml.Linq|4.0.0.0",
+                  "System.Xml.ReaderWriter|4.1.1.0",
+                  "System.Xml.Serialization|4.0.0.0",
+                  "System.Xml.XDocument|4.0.11.0",
+                  "System.Xml.XPath.XDocument|4.0.3.0",
+                  "System.Xml.XPath|4.0.3.0",
+                  "System.Xml.XmlDocument|4.0.3.0",
+                  "System.Xml.XmlSerializer|4.0.11.0",
+                  "System.Xml|4.0.0.0",
+                  "System|4.0.0.0",
+                  "mscorlib|4.0.0.0",
+                  "netstandard|2.1.0.0"
+                ],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.packaging.core": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "nunit": [],
+                "nunitlite": [],
+                "system.componentmodel.annotations": [],
+                "system.componentmodel.composition": [],
+                "system.formats.asn1": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.protecteddata": []
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_dotnet+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_dotnet+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_dotnet+",
+            "rules_dotnet",
+            "rules_dotnet+"
           ]
         ]
       }
@@ -500,9 +3352,368 @@
         ]
       }
     },
+    "@@rules_rust+//crate_universe:extension.bzl%crate": {
+      "os:osx,arch:aarch64": {
+        "bzlTransitiveDigest": "eULI1IaqDOUe2uM7uXeQTzQn16av50dcWmvVTPwZ+qA=",
+        "usagesDigest": "1ZTRoTd2Ti8pWW4lP/M6QsvMQGl9cOTe9xdnzq8Pbls=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "crates": {
+            "repoRuleId": "@@rules_rust+//crate_universe:extensions.bzl%_generate_repo",
+            "attributes": {
+              "contents": {
+                "BUILD.bazel": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files(\n    [\n        \"cargo-bazel.json\",\n        \"crates.bzl\",\n        \"defs.bzl\",\n    ] + glob(\n        allow_empty = True,\n        include = [\"*.bazel\"],\n    ),\n)\n\nfilegroup(\n    name = \"srcs\",\n    srcs = glob(\n        allow_empty = True,\n        include = [\n            \"*.bazel\",\n            \"*.bzl\",\n        ],\n    ),\n)\n\n# Workspace Member Dependencies\nalias(\n    name = \"googletest\",\n    actual = \"@crates__googletest-0.14.3//:googletest\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"linkme\",\n    actual = \"@crates__linkme-0.3.36//:linkme\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"paste\",\n    actual = \"@crates__paste-1.0.15//:paste\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"quote\",\n    actual = \"@crates__quote-1.0.46//:quote\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"syn\",\n    actual = \"@crates__syn-2.0.118//:syn\",\n    tags = [\"manual\"],\n)\n",
+                "defs.bzl": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\"\"\"\n# `crates_repository` API\n\n- [aliases](#aliases)\n- [crate_deps](#crate_deps)\n- [all_crate_deps](#all_crate_deps)\n- [crate_repositories](#crate_repositories)\n\n\"\"\"\n\nload(\"@bazel_tools//tools/build_defs/repo:git.bzl\", \"new_git_repository\")\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_archive\")\nload(\"@bazel_tools//tools/build_defs/repo:utils.bzl\", \"maybe\")\nload(\"@bazel_skylib//lib:selects.bzl\", \"selects\")\nload(\"@rules_rust//crate_universe/private:local_crate_mirror.bzl\", \"local_crate_mirror\")\n\n###############################################################################\n# MACROS API\n###############################################################################\n\n# An identifier that represent common dependencies (unconditional).\n_COMMON_CONDITION = \"\"\n\ndef _flatten_dependency_maps(all_dependency_maps):\n    \"\"\"Flatten a list of dependency maps into one dictionary.\n\n    Dependency maps have the following structure:\n\n    ```python\n    DEPENDENCIES_MAP = {\n        # The first key in the map is a Bazel package\n        # name of the workspace this file is defined in.\n        \"workspace_member_package\": {\n\n            # Not all dependencies are supported for all platforms.\n            # the condition key is the condition required to be true\n            # on the host platform.\n            \"condition\": {\n\n                # An alias to a crate target.     # The label of the crate target the\n                # Aliases are only crate names.   # package name refers to.\n                \"package_name\":                   \"@full//:label\",\n            }\n        }\n    }\n    ```\n\n    Args:\n        all_dependency_maps (list): A list of dicts as described above\n\n    Returns:\n        dict: A dictionary as described above\n    \"\"\"\n    dependencies = {}\n\n    for workspace_deps_map in all_dependency_maps:\n        for pkg_name, conditional_deps_map in workspace_deps_map.items():\n            if pkg_name not in dependencies:\n                non_frozen_map = dict()\n                for key, values in conditional_deps_map.items():\n                    non_frozen_map.update({key: dict(values.items())})\n                dependencies.setdefault(pkg_name, non_frozen_map)\n                continue\n\n            for condition, deps_map in conditional_deps_map.items():\n                # If the condition has not been recorded, do so and continue\n                if condition not in dependencies[pkg_name]:\n                    dependencies[pkg_name].setdefault(condition, dict(deps_map.items()))\n                    continue\n\n                # Alert on any miss-matched dependencies\n                inconsistent_entries = []\n                for crate_name, crate_label in deps_map.items():\n                    existing = dependencies[pkg_name][condition].get(crate_name)\n                    if existing and existing != crate_label:\n                        inconsistent_entries.append((crate_name, existing, crate_label))\n                    dependencies[pkg_name][condition].update({crate_name: crate_label})\n\n    return dependencies\n\ndef crate_deps(deps, package_name = None):\n    \"\"\"Finds the fully qualified label of the requested crates for the package where this macro is called.\n\n    Args:\n        deps (list): The desired list of crate targets.\n        package_name (str, optional): The package name of the set of dependencies to look up.\n            Defaults to `native.package_name()`.\n\n    Returns:\n        list: A list of labels to generated rust targets (str)\n    \"\"\"\n\n    if not deps:\n        return []\n\n    if package_name == None:\n        package_name = native.package_name()\n\n    # Join both sets of dependencies\n    dependencies = _flatten_dependency_maps([\n        _NORMAL_DEPENDENCIES,\n        _NORMAL_DEV_DEPENDENCIES,\n        _PROC_MACRO_DEPENDENCIES,\n        _PROC_MACRO_DEV_DEPENDENCIES,\n        _BUILD_DEPENDENCIES,\n        _BUILD_PROC_MACRO_DEPENDENCIES,\n    ]).pop(package_name, {})\n\n    # Combine all conditional packages so we can easily index over a flat list\n    # TODO: Perhaps this should actually return select statements and maintain\n    # the conditionals of the dependencies\n    flat_deps = {}\n    for deps_set in dependencies.values():\n        for crate_name, crate_label in deps_set.items():\n            flat_deps.update({crate_name: crate_label})\n\n    missing_crates = []\n    crate_targets = []\n    for crate_target in deps:\n        if crate_target not in flat_deps:\n            missing_crates.append(crate_target)\n        else:\n            crate_targets.append(flat_deps[crate_target])\n\n    if missing_crates:\n        fail(\"Could not find crates `{}` among dependencies of `{}`. Available dependencies were `{}`\".format(\n            missing_crates,\n            package_name,\n            dependencies,\n        ))\n\n    return crate_targets\n\ndef all_crate_deps(\n        normal = False, \n        normal_dev = False, \n        proc_macro = False, \n        proc_macro_dev = False,\n        build = False,\n        build_proc_macro = False,\n        package_name = None):\n    \"\"\"Finds the fully qualified label of all requested direct crate dependencies \\\n    for the package where this macro is called.\n\n    If no parameters are set, all normal dependencies are returned. Setting any one flag will\n    otherwise impact the contents of the returned list.\n\n    Args:\n        normal (bool, optional): If True, normal dependencies are included in the\n            output list.\n        normal_dev (bool, optional): If True, normal dev dependencies will be\n            included in the output list..\n        proc_macro (bool, optional): If True, proc_macro dependencies are included\n            in the output list.\n        proc_macro_dev (bool, optional): If True, dev proc_macro dependencies are\n            included in the output list.\n        build (bool, optional): If True, build dependencies are included\n            in the output list.\n        build_proc_macro (bool, optional): If True, build proc_macro dependencies are\n            included in the output list.\n        package_name (str, optional): The package name of the set of dependencies to look up.\n            Defaults to `native.package_name()` when unset.\n\n    Returns:\n        list: A list of labels to generated rust targets (str)\n    \"\"\"\n\n    if package_name == None:\n        package_name = native.package_name()\n\n    # Determine the relevant maps to use\n    all_dependency_maps = []\n    if normal:\n        all_dependency_maps.append(_NORMAL_DEPENDENCIES)\n    if normal_dev:\n        all_dependency_maps.append(_NORMAL_DEV_DEPENDENCIES)\n    if proc_macro:\n        all_dependency_maps.append(_PROC_MACRO_DEPENDENCIES)\n    if proc_macro_dev:\n        all_dependency_maps.append(_PROC_MACRO_DEV_DEPENDENCIES)\n    if build:\n        all_dependency_maps.append(_BUILD_DEPENDENCIES)\n    if build_proc_macro:\n        all_dependency_maps.append(_BUILD_PROC_MACRO_DEPENDENCIES)\n\n    # Default to always using normal dependencies\n    if not all_dependency_maps:\n        all_dependency_maps.append(_NORMAL_DEPENDENCIES)\n\n    dependencies = _flatten_dependency_maps(all_dependency_maps).pop(package_name, None)\n\n    if not dependencies:\n        if dependencies == None:\n            fail(\"Tried to get all_crate_deps for package \" + package_name + \" but that package had no Cargo.toml file\")\n        else:\n            return []\n\n    crate_deps = list(dependencies.pop(_COMMON_CONDITION, {}).values())\n    for condition, deps in dependencies.items():\n        crate_deps += selects.with_or({\n            tuple(_CONDITIONS[condition]): deps.values(),\n            \"//conditions:default\": [],\n        })\n\n    return crate_deps\n\ndef aliases(\n        normal = False,\n        normal_dev = False,\n        proc_macro = False,\n        proc_macro_dev = False,\n        build = False,\n        build_proc_macro = False,\n        package_name = None):\n    \"\"\"Produces a map of Crate alias names to their original label\n\n    If no dependency kinds are specified, `normal` and `proc_macro` are used by default.\n    Setting any one flag will otherwise determine the contents of the returned dict.\n\n    Args:\n        normal (bool, optional): If True, normal dependencies are included in the\n            output list.\n        normal_dev (bool, optional): If True, normal dev dependencies will be\n            included in the output list..\n        proc_macro (bool, optional): If True, proc_macro dependencies are included\n            in the output list.\n        proc_macro_dev (bool, optional): If True, dev proc_macro dependencies are\n            included in the output list.\n        build (bool, optional): If True, build dependencies are included\n            in the output list.\n        build_proc_macro (bool, optional): If True, build proc_macro dependencies are\n            included in the output list.\n        package_name (str, optional): The package name of the set of dependencies to look up.\n            Defaults to `native.package_name()` when unset.\n\n    Returns:\n        dict: The aliases of all associated packages\n    \"\"\"\n    if package_name == None:\n        package_name = native.package_name()\n\n    # Determine the relevant maps to use\n    all_aliases_maps = []\n    if normal:\n        all_aliases_maps.append(_NORMAL_ALIASES)\n    if normal_dev:\n        all_aliases_maps.append(_NORMAL_DEV_ALIASES)\n    if proc_macro:\n        all_aliases_maps.append(_PROC_MACRO_ALIASES)\n    if proc_macro_dev:\n        all_aliases_maps.append(_PROC_MACRO_DEV_ALIASES)\n    if build:\n        all_aliases_maps.append(_BUILD_ALIASES)\n    if build_proc_macro:\n        all_aliases_maps.append(_BUILD_PROC_MACRO_ALIASES)\n\n    # Default to always using normal aliases\n    if not all_aliases_maps:\n        all_aliases_maps.append(_NORMAL_ALIASES)\n        all_aliases_maps.append(_PROC_MACRO_ALIASES)\n\n    aliases = _flatten_dependency_maps(all_aliases_maps).pop(package_name, None)\n\n    if not aliases:\n        return dict()\n\n    common_items = aliases.pop(_COMMON_CONDITION, {}).items()\n\n    # If there are only common items in the dictionary, immediately return them\n    if not len(aliases.keys()) == 1:\n        return dict(common_items)\n\n    # Build a single select statement where each conditional has accounted for the\n    # common set of aliases.\n    crate_aliases = {\"//conditions:default\": dict(common_items)}\n    for condition, deps in aliases.items():\n        condition_triples = _CONDITIONS[condition]\n        for triple in condition_triples:\n            if triple in crate_aliases:\n                crate_aliases[triple].update(deps)\n            else:\n                crate_aliases.update({triple: dict(deps.items() + common_items)})\n\n    return select(crate_aliases)\n\n###############################################################################\n# WORKSPACE MEMBER DEPS AND ALIASES\n###############################################################################\n\n_NORMAL_DEPENDENCIES = {\n    \"\": {\n        _COMMON_CONDITION: {\n            \"googletest\": Label(\"@crates__googletest-0.14.3//:googletest\"),\n            \"linkme\": Label(\"@crates__linkme-0.3.36//:linkme\"),\n            \"quote\": Label(\"@crates__quote-1.0.46//:quote\"),\n            \"syn\": Label(\"@crates__syn-2.0.118//:syn\"),\n        },\n    },\n}\n\n\n_NORMAL_ALIASES = {\n    \"\": {\n        _COMMON_CONDITION: {\n        },\n    },\n}\n\n\n_NORMAL_DEV_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_NORMAL_DEV_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_PROC_MACRO_DEPENDENCIES = {\n    \"\": {\n        _COMMON_CONDITION: {\n            \"paste\": Label(\"@crates__paste-1.0.15//:paste\"),\n        },\n    },\n}\n\n\n_PROC_MACRO_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_PROC_MACRO_DEV_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_PROC_MACRO_DEV_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_PROC_MACRO_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_PROC_MACRO_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_CONDITIONS = {\n    \"aarch64-apple-darwin\": [\"@rules_rust//rust/platform:aarch64-apple-darwin\"],\n    \"aarch64-apple-ios\": [\"@rules_rust//rust/platform:aarch64-apple-ios\"],\n    \"aarch64-apple-ios-sim\": [\"@rules_rust//rust/platform:aarch64-apple-ios-sim\"],\n    \"aarch64-linux-android\": [\"@rules_rust//rust/platform:aarch64-linux-android\"],\n    \"aarch64-pc-windows-msvc\": [\"@rules_rust//rust/platform:aarch64-pc-windows-msvc\"],\n    \"aarch64-unknown-fuchsia\": [\"@rules_rust//rust/platform:aarch64-unknown-fuchsia\"],\n    \"aarch64-unknown-linux-gnu\": [\"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\"],\n    \"aarch64-unknown-nixos-gnu\": [\"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\"],\n    \"aarch64-unknown-nto-qnx710\": [\"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\"],\n    \"arm-unknown-linux-gnueabi\": [\"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\"],\n    \"armv7-linux-androideabi\": [\"@rules_rust//rust/platform:armv7-linux-androideabi\"],\n    \"armv7-unknown-linux-gnueabi\": [\"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\"],\n    \"i686-apple-darwin\": [\"@rules_rust//rust/platform:i686-apple-darwin\"],\n    \"i686-linux-android\": [\"@rules_rust//rust/platform:i686-linux-android\"],\n    \"i686-pc-windows-msvc\": [\"@rules_rust//rust/platform:i686-pc-windows-msvc\"],\n    \"i686-unknown-freebsd\": [\"@rules_rust//rust/platform:i686-unknown-freebsd\"],\n    \"i686-unknown-linux-gnu\": [\"@rules_rust//rust/platform:i686-unknown-linux-gnu\"],\n    \"powerpc-unknown-linux-gnu\": [\"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\"],\n    \"riscv32imc-unknown-none-elf\": [\"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\"],\n    \"riscv64gc-unknown-none-elf\": [\"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\"],\n    \"s390x-unknown-linux-gnu\": [\"@rules_rust//rust/platform:s390x-unknown-linux-gnu\"],\n    \"thumbv7em-none-eabi\": [\"@rules_rust//rust/platform:thumbv7em-none-eabi\"],\n    \"thumbv8m.main-none-eabi\": [\"@rules_rust//rust/platform:thumbv8m.main-none-eabi\"],\n    \"wasm32-unknown-unknown\": [\"@rules_rust//rust/platform:wasm32-unknown-unknown\"],\n    \"wasm32-wasip1\": [\"@rules_rust//rust/platform:wasm32-wasip1\"],\n    \"x86_64-apple-darwin\": [\"@rules_rust//rust/platform:x86_64-apple-darwin\"],\n    \"x86_64-apple-ios\": [\"@rules_rust//rust/platform:x86_64-apple-ios\"],\n    \"x86_64-linux-android\": [\"@rules_rust//rust/platform:x86_64-linux-android\"],\n    \"x86_64-pc-windows-msvc\": [\"@rules_rust//rust/platform:x86_64-pc-windows-msvc\"],\n    \"x86_64-unknown-freebsd\": [\"@rules_rust//rust/platform:x86_64-unknown-freebsd\"],\n    \"x86_64-unknown-fuchsia\": [\"@rules_rust//rust/platform:x86_64-unknown-fuchsia\"],\n    \"x86_64-unknown-linux-gnu\": [\"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\"],\n    \"x86_64-unknown-nixos-gnu\": [\"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\"],\n    \"x86_64-unknown-none\": [\"@rules_rust//rust/platform:x86_64-unknown-none\"],\n}\n\n###############################################################################\n\ndef crate_repositories():\n    \"\"\"A macro for defining repositories for all generated crates.\n\n    Returns:\n      A list of repos visible to the module through the module extension.\n    \"\"\"\n    maybe(\n        http_archive,\n        name = \"crates__aho-corasick-1.1.4\",\n        sha256 = \"ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/aho-corasick/1.1.4/download\"],\n        strip_prefix = \"aho-corasick-1.1.4\",\n        build_file = Label(\"@crates//crates:BUILD.aho-corasick-1.1.4.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__autocfg-1.5.1\",\n        sha256 = \"f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/autocfg/1.5.1/download\"],\n        strip_prefix = \"autocfg-1.5.1\",\n        build_file = Label(\"@crates//crates:BUILD.autocfg-1.5.1.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__googletest-0.14.3\",\n        sha256 = \"f6b5e2f2b556b7b90297a5a35c8267dd43a537923d2b329beefdba2b4ec19d94\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/googletest/0.14.3/download\"],\n        strip_prefix = \"googletest-0.14.3\",\n        build_file = Label(\"@crates//crates:BUILD.googletest-0.14.3.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__googletest_macro-0.14.3\",\n        sha256 = \"2ae6abc96141edd26bf5aeec0f119c129c44de3ced09e5073711a02cb74725d0\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/googletest_macro/0.14.3/download\"],\n        strip_prefix = \"googletest_macro-0.14.3\",\n        build_file = Label(\"@crates//crates:BUILD.googletest_macro-0.14.3.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__linkme-0.3.36\",\n        sha256 = \"e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/linkme/0.3.36/download\"],\n        strip_prefix = \"linkme-0.3.36\",\n        build_file = Label(\"@crates//crates:BUILD.linkme-0.3.36.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__linkme-impl-0.3.36\",\n        sha256 = \"32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/linkme-impl/0.3.36/download\"],\n        strip_prefix = \"linkme-impl-0.3.36\",\n        build_file = Label(\"@crates//crates:BUILD.linkme-impl-0.3.36.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__memchr-2.8.3\",\n        sha256 = \"cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/memchr/2.8.3/download\"],\n        strip_prefix = \"memchr-2.8.3\",\n        build_file = Label(\"@crates//crates:BUILD.memchr-2.8.3.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__num-traits-0.2.19\",\n        sha256 = \"071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/num-traits/0.2.19/download\"],\n        strip_prefix = \"num-traits-0.2.19\",\n        build_file = Label(\"@crates//crates:BUILD.num-traits-0.2.19.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__paste-1.0.15\",\n        sha256 = \"57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/paste/1.0.15/download\"],\n        strip_prefix = \"paste-1.0.15\",\n        build_file = Label(\"@crates//crates:BUILD.paste-1.0.15.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__proc-macro2-1.0.106\",\n        sha256 = \"8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/proc-macro2/1.0.106/download\"],\n        strip_prefix = \"proc-macro2-1.0.106\",\n        build_file = Label(\"@crates//crates:BUILD.proc-macro2-1.0.106.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__quote-1.0.46\",\n        sha256 = \"dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/quote/1.0.46/download\"],\n        strip_prefix = \"quote-1.0.46\",\n        build_file = Label(\"@crates//crates:BUILD.quote-1.0.46.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__regex-1.13.0\",\n        sha256 = \"2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/regex/1.13.0/download\"],\n        strip_prefix = \"regex-1.13.0\",\n        build_file = Label(\"@crates//crates:BUILD.regex-1.13.0.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__regex-automata-0.4.15\",\n        sha256 = \"1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/regex-automata/0.4.15/download\"],\n        strip_prefix = \"regex-automata-0.4.15\",\n        build_file = Label(\"@crates//crates:BUILD.regex-automata-0.4.15.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__regex-syntax-0.8.11\",\n        sha256 = \"d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/regex-syntax/0.8.11/download\"],\n        strip_prefix = \"regex-syntax-0.8.11\",\n        build_file = Label(\"@crates//crates:BUILD.regex-syntax-0.8.11.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__rustversion-1.0.23\",\n        sha256 = \"cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/rustversion/1.0.23/download\"],\n        strip_prefix = \"rustversion-1.0.23\",\n        build_file = Label(\"@crates//crates:BUILD.rustversion-1.0.23.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__syn-2.0.118\",\n        sha256 = \"1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/syn/2.0.118/download\"],\n        strip_prefix = \"syn-2.0.118\",\n        build_file = Label(\"@crates//crates:BUILD.syn-2.0.118.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__unicode-ident-1.0.24\",\n        sha256 = \"e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/unicode-ident/1.0.24/download\"],\n        strip_prefix = \"unicode-ident-1.0.24\",\n        build_file = Label(\"@crates//crates:BUILD.unicode-ident-1.0.24.bazel\"),\n    )\n\n    return [\n       struct(repo=\"crates__googletest-0.14.3\", is_dev_dep = False),\n       struct(repo=\"crates__linkme-0.3.36\", is_dev_dep = False),\n       struct(repo=\"crates__paste-1.0.15\", is_dev_dep = False),\n       struct(repo=\"crates__quote-1.0.46\", is_dev_dep = False),\n       struct(repo=\"crates__syn-2.0.118\", is_dev_dep = False),\n    ]\n"
+              }
+            }
+          },
+          "crates__aho-corasick-1.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.1.4/download"
+              ],
+              "strip_prefix": "aho-corasick-1.1.4",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"aho_corasick\",\n    deps = [\n        \"@crates__memchr-2.8.3//:memchr\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"perf-literal\",\n        \"std\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=aho-corasick\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.1.4\",\n)\n"
+            }
+          },
+          "crates__autocfg-1.5.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.5.1/download"
+              ],
+              "strip_prefix": "autocfg-1.5.1",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"autocfg\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2015\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=autocfg\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.5.1\",\n)\n"
+            }
+          },
+          "crates__googletest-0.14.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "f6b5e2f2b556b7b90297a5a35c8267dd43a537923d2b329beefdba2b4ec19d94",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/googletest/0.14.3/download"
+              ],
+              "strip_prefix": "googletest-0.14.3",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"googletest\",\n    deps = [\n        \"@crates__num-traits-0.2.19//:num_traits\",\n        \"@crates__regex-1.13.0//:regex\",\n    ],\n    proc_macro_deps = [\n        \"@crates__googletest_macro-0.14.3//:googletest_macro\",\n        \"@crates__rustversion-1.0.23//:rustversion\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=googletest\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.14.3\",\n)\n"
+            }
+          },
+          "crates__googletest_macro-0.14.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "2ae6abc96141edd26bf5aeec0f119c129c44de3ced09e5073711a02cb74725d0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/googletest_macro/0.14.3/download"
+              ],
+              "strip_prefix": "googletest_macro-0.14.3",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_proc_macro(\n    name = \"googletest_macro\",\n    deps = [\n        \"@crates__proc-macro2-1.0.106//:proc_macro2\",\n        \"@crates__quote-1.0.46//:quote\",\n        \"@crates__syn-2.0.118//:syn\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=googletest_macro\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.14.3\",\n)\n"
+            }
+          },
+          "crates__linkme-0.3.36": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linkme/0.3.36/download"
+              ],
+              "strip_prefix": "linkme-0.3.36",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"linkme\",\n    deps = [\n        \"@crates__linkme-0.3.36//:build_script_build\",\n    ],\n    proc_macro_deps = [\n        \"@crates__linkme-impl-0.3.36//:linkme_impl\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.3.36\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"linkme\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.3.36\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__linkme-impl-0.3.36": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linkme-impl/0.3.36/download"
+              ],
+              "strip_prefix": "linkme-impl-0.3.36",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_proc_macro(\n    name = \"linkme_impl\",\n    deps = [\n        \"@crates__linkme-impl-0.3.36//:build_script_build\",\n        \"@crates__proc-macro2-1.0.106//:proc_macro2\",\n        \"@crates__quote-1.0.46//:quote\",\n        \"@crates__syn-2.0.118//:syn\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme-impl\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.3.36\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"linkme-impl\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme-impl\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.3.36\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__memchr-2.8.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.8.3/download"
+              ],
+              "strip_prefix": "memchr-2.8.3",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"memchr\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"alloc\",\n        \"std\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=memchr\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"2.8.3\",\n)\n"
+            }
+          },
+          "crates__num-traits-0.2.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-traits/0.2.19/download"
+              ],
+              "strip_prefix": "num-traits-0.2.19",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"num_traits\",\n    deps = [\n        \"@crates__num-traits-0.2.19//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"std\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=num-traits\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.2.19\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"std\",\n    ],\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    deps = [\n        \"@crates__autocfg-1.5.1//:autocfg\",\n    ],\n    edition = \"2021\",\n    pkg_name = \"num-traits\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=num-traits\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.2.19\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__paste-1.0.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/paste/1.0.15/download"
+              ],
+              "strip_prefix": "paste-1.0.15",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_proc_macro(\n    name = \"paste\",\n    deps = [\n        \"@crates__paste-1.0.15//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2018\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=paste\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.15\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2018\",\n    pkg_name = \"paste\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=paste\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.15\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__proc-macro2-1.0.106": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.106/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.106",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"proc_macro2\",\n    deps = [\n        \"@crates__proc-macro2-1.0.106//:build_script_build\",\n        \"@crates__unicode-ident-1.0.24//:unicode_ident\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"proc-macro\",\n    ] + select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [\n            \"default\",  # aarch64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [\n            \"default\",  # aarch64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [\n            \"default\",  # aarch64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [\n            \"default\",  # aarch64-unknown-nixos-gnu\n        ],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [\n            \"default\",  # arm-unknown-linux-gnueabi\n        ],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [\n            \"default\",  # i686-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [\n            \"default\",  # i686-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [\n            \"default\",  # powerpc-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [\n            \"default\",  # s390x-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [\n            \"default\",  # x86_64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [\n            \"default\",  # x86_64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [\n            \"default\",  # x86_64-unknown-freebsd\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [\n            \"default\",  # x86_64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [\n            \"default\",  # x86_64-unknown-nixos-gnu\n        ],\n        \"//conditions:default\": [],\n    }),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=proc-macro2\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.106\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"proc-macro\",\n    ] + select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [\n            \"default\",  # aarch64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [\n            \"default\",  # aarch64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [\n            \"default\",  # aarch64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [\n            \"default\",  # aarch64-unknown-nixos-gnu\n        ],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [\n            \"default\",  # arm-unknown-linux-gnueabi\n        ],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [\n            \"default\",  # i686-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [\n            \"default\",  # i686-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [\n            \"default\",  # powerpc-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [\n            \"default\",  # s390x-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [\n            \"default\",  # x86_64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [\n            \"default\",  # x86_64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [\n            \"default\",  # x86_64-unknown-freebsd\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [\n            \"default\",  # x86_64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [\n            \"default\",  # x86_64-unknown-nixos-gnu\n        ],\n        \"//conditions:default\": [],\n    }),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"proc-macro2\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=proc-macro2\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.106\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__quote-1.0.46": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.46/download"
+              ],
+              "strip_prefix": "quote-1.0.46",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"quote\",\n    deps = [\n        \"@crates__proc-macro2-1.0.106//:proc_macro2\",\n        \"@crates__quote-1.0.46//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"proc-macro\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=quote\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.46\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"proc-macro\",\n    ],\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"quote\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=quote\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.46\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__regex-1.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.13.0/download"
+              ],
+              "strip_prefix": "regex-1.13.0",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"regex\",\n    deps = [\n        \"@crates__aho-corasick-1.1.4//:aho_corasick\",\n        \"@crates__memchr-2.8.3//:memchr\",\n        \"@crates__regex-automata-0.4.15//:regex_automata\",\n        \"@crates__regex-syntax-0.8.11//:regex_syntax\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"perf\",\n        \"perf-backtrack\",\n        \"perf-cache\",\n        \"perf-dfa\",\n        \"perf-inline\",\n        \"perf-literal\",\n        \"perf-onepass\",\n        \"std\",\n        \"unicode\",\n        \"unicode-age\",\n        \"unicode-bool\",\n        \"unicode-case\",\n        \"unicode-gencat\",\n        \"unicode-perl\",\n        \"unicode-script\",\n        \"unicode-segment\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=regex\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.13.0\",\n)\n"
+            }
+          },
+          "crates__regex-automata-0.4.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.15/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.15",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"regex_automata\",\n    deps = [\n        \"@crates__aho-corasick-1.1.4//:aho_corasick\",\n        \"@crates__memchr-2.8.3//:memchr\",\n        \"@crates__regex-syntax-0.8.11//:regex_syntax\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"alloc\",\n        \"dfa-onepass\",\n        \"hybrid\",\n        \"meta\",\n        \"nfa-backtrack\",\n        \"nfa-pikevm\",\n        \"nfa-thompson\",\n        \"perf-inline\",\n        \"perf-literal\",\n        \"perf-literal-multisubstring\",\n        \"perf-literal-substring\",\n        \"std\",\n        \"syntax\",\n        \"unicode\",\n        \"unicode-age\",\n        \"unicode-bool\",\n        \"unicode-case\",\n        \"unicode-gencat\",\n        \"unicode-perl\",\n        \"unicode-script\",\n        \"unicode-segment\",\n        \"unicode-word-boundary\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=regex-automata\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.4.15\",\n)\n"
+            }
+          },
+          "crates__regex-syntax-0.8.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.11/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.11",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"regex_syntax\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"std\",\n        \"unicode\",\n        \"unicode-age\",\n        \"unicode-bool\",\n        \"unicode-case\",\n        \"unicode-gencat\",\n        \"unicode-perl\",\n        \"unicode-script\",\n        \"unicode-segment\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=regex-syntax\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.8.11\",\n)\n"
+            }
+          },
+          "crates__rustversion-1.0.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustversion/1.0.23/download"
+              ],
+              "strip_prefix": "rustversion-1.0.23",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_proc_macro(\n    name = \"rustversion\",\n    deps = [\n        \"@crates__rustversion-1.0.23//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2018\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=rustversion\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.23\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build/build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2018\",\n    pkg_name = \"rustversion\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=rustversion\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.23\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__syn-2.0.118": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.118/download"
+              ],
+              "strip_prefix": "syn-2.0.118",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"syn\",\n    deps = [\n        \"@crates__proc-macro2-1.0.106//:proc_macro2\",\n        \"@crates__quote-1.0.46//:quote\",\n        \"@crates__unicode-ident-1.0.24//:unicode_ident\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"clone-impls\",\n        \"default\",\n        \"derive\",\n        \"parsing\",\n        \"printing\",\n        \"proc-macro\",\n    ] + select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [\n            \"extra-traits\",  # aarch64-apple-darwin\n            \"full\",  # aarch64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [\n            \"extra-traits\",  # aarch64-pc-windows-msvc\n            \"full\",  # aarch64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [\n            \"extra-traits\",  # aarch64-unknown-linux-gnu\n            \"full\",  # aarch64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [\n            \"extra-traits\",  # aarch64-unknown-nixos-gnu\n            \"full\",  # aarch64-unknown-nixos-gnu\n        ],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [\n            \"extra-traits\",  # arm-unknown-linux-gnueabi\n            \"full\",  # arm-unknown-linux-gnueabi\n        ],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [\n            \"extra-traits\",  # i686-pc-windows-msvc\n            \"full\",  # i686-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [\n            \"extra-traits\",  # i686-unknown-linux-gnu\n            \"full\",  # i686-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [\n            \"extra-traits\",  # powerpc-unknown-linux-gnu\n            \"full\",  # powerpc-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [\n            \"extra-traits\",  # s390x-unknown-linux-gnu\n            \"full\",  # s390x-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [\n            \"extra-traits\",  # x86_64-apple-darwin\n            \"full\",  # x86_64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [\n            \"extra-traits\",  # x86_64-pc-windows-msvc\n            \"full\",  # x86_64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [\n            \"extra-traits\",  # x86_64-unknown-freebsd\n            \"full\",  # x86_64-unknown-freebsd\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [\n            \"extra-traits\",  # x86_64-unknown-linux-gnu\n            \"full\",  # x86_64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [\n            \"extra-traits\",  # x86_64-unknown-nixos-gnu\n            \"full\",  # x86_64-unknown-nixos-gnu\n        ],\n        \"//conditions:default\": [],\n    }),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=syn\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"2.0.118\",\n)\n"
+            }
+          },
+          "crates__unicode-ident-1.0.24": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.24/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.24",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"unicode_ident\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=unicode-ident\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.24\",\n)\n"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ],
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "cc_compatibility_proxy",
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "cargo_bazel_bootstrap",
+            "rules_rust++cu+cargo_bazel_bootstrap"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust",
+            "rules_rust+"
+          ],
+          [
+            "rules_rust+",
+            "rust_host_tools",
+            "rules_rust++rust_host_tools+rust_host_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu": {
       "general": {
-        "bzlTransitiveDigest": "TCqw0tqOBW3iq4m67WaWQyf971vcdWgvtc20+fYcfkA=",
+        "bzlTransitiveDigest": "XH8HAZa70v86XA5UWxDe/y5nwwtCwLSPWywsmY0i7Zw=",
         "usagesDigest": "cZ+ECJwGd7BJK/WUN0WIFhTQlfl/eawnUc90nVO6Ghc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -3588,6 +6799,16 @@
           ],
           [
             "rules_cc+",
+            "cc_compatibility_proxy",
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
             "rules_cc",
             "rules_cc+"
           ],
@@ -4946,6 +8167,1114 @@
           "go1.25.0.windows-arm64.zip",
           "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
         ]
+      }
+    },
+    "@@rules_python+//python/extensions:pip.bzl%pip": {
+      "dist_hashes": {
+        "https://pypi.org/simple": {
+          "alabaster": {
+            "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl": "b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92",
+            "https://files.pythonhosted.org/packages/64/88/c7083fc61120ab661c5d0b82cb77079fc1429d3f913a456c1c82cf4658f7/alabaster-0.7.13-py3-none-any.whl": "1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3",
+            "https://files.pythonhosted.org/packages/94/71/a8ee96d1fd95ca04a0d2e2d9c4081dac4c2d2b12f7ddb899c8cb9bfd1532/alabaster-0.7.13.tar.gz": "a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2",
+            "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz": "75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65"
+          },
+          "babel": {
+            "https://files.pythonhosted.org/packages/0d/35/4196b21041e29a42dc4f05866d0c94fa26c9da88ce12c38c2265e42c82fb/Babel-2.14.0-py3-none-any.whl": "efb1a25b7118e67ce3a259bed20545c29cb68be8ad2c784c83689981b7a57287",
+            "https://files.pythonhosted.org/packages/ba/42/54426ba5d7aeebde9f4aaba9884596eb2fe02b413ad77d62ef0b0422e205/Babel-2.12.1.tar.gz": "cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455",
+            "https://files.pythonhosted.org/packages/df/c4/1088865e0246d7ecf56d819a233ab2b72f7d6ab043965ef327d0731b5434/Babel-2.12.1-py3-none-any.whl": "b4246fb7677d3b98f501a39d43396d3cafdc8eadb045f4a31be01863f655c610",
+            "https://files.pythonhosted.org/packages/e2/80/cfbe44a9085d112e983282ee7ca4c00429bc4d1ce86ee5f4e60259ddff7f/Babel-2.14.0.tar.gz": "6919867db036398ba21eb5c7a0f6b28ab8cbc3ae7a73a44ebe34ae74a4e7d363"
+          },
+          "backports-tarfile": {
+            "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz": "d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991",
+            "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl": "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34"
+          },
+          "bleach": {
+            "https://files.pythonhosted.org/packages/7e/e6/d5f220ca638f6a25557a611860482cb6e54b2d97f0332966b1b005742e1f/bleach-6.0.0.tar.gz": "1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414",
+            "https://files.pythonhosted.org/packages/ac/e2/dfcab68c9b2e7800c8f06b85c76e5f978d05b195a958daa9b1dda54a1db6/bleach-6.0.0-py3-none-any.whl": "33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"
+          },
+          "certifi": {
+            "https://files.pythonhosted.org/packages/37/f7/2b1b0ec44fdc30a3d31dfebe52226be9ddc40cd6c0f34ffc8923ba423b69/certifi-2022.12.7.tar.gz": "35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+            "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz": "47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43",
+            "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl": "4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18",
+            "https://files.pythonhosted.org/packages/df/f7/04fee6ac349e915b82171f8e23cee63644d83663b34c539f7a09aed18f9e/certifi-2018.8.24-py2.py3-none-any.whl": "456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a",
+            "https://files.pythonhosted.org/packages/e1/0f/f8d5e939184547b3bdc6128551b831a62832713aa98c2ccdf8c47ecc7f17/certifi-2018.8.24.tar.gz": "376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
+            "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl": "0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de"
+          },
+          "cffi": {
+            "https://files.pythonhosted.org/packages/00/05/23a265a3db411b0bfb721bf7a116c7cecaf3eb37ebd48a6ea4dfb0a3244d/cffi-1.15.1-cp27-cp27m-win_amd64.whl": "e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e",
+            "https://files.pythonhosted.org/packages/03/7b/259d6e01a6083acef9d3c8c88990c97d313632bb28fa84d6ab2bb201140a/cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl": "173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405",
+            "https://files.pythonhosted.org/packages/04/a2/55f290ac034bd98c2a63e83be96925729cb2a70c8c42adc391ec5fbbaffd/cffi-1.16.0-cp39-cp39-win32.whl": "ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4",
+            "https://files.pythonhosted.org/packages/09/d4/8759cc3b2222c159add8ce3af0089912203a31610f4be4c36f98e320b4c6/cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969",
+            "https://files.pythonhosted.org/packages/0e/65/0d7b5dad821ced4dcd43f96a362905a68ce71e6b5f5cfd2fada867840582/cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl": "59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e",
+            "https://files.pythonhosted.org/packages/0e/e2/a23af3d81838c577571da4ff01b799b0c2bbde24bd924d97e228febae810/cffi-1.15.1-cp310-cp310-win_amd64.whl": "ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d",
+            "https://files.pythonhosted.org/packages/10/72/617ee266192223a38b67149c830bd9376b69cf3551e1477abc72ff23ef8e/cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9",
+            "https://files.pythonhosted.org/packages/18/6c/0406611f3d5aadf4c5b08f6c095d874aed8dfc2d3a19892707d72536d5dc/cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl": "1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417",
+            "https://files.pythonhosted.org/packages/18/8f/5ff70c7458d61fa8a9752e5ee9c9984c601b0060aae0c619316a1e1f1ee5/cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl": "54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585",
+            "https://files.pythonhosted.org/packages/1d/76/bcebbbab689f5f6fc8a91e361038a3001ee2e48c5f9dbad0a3b64a64cc9e/cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl": "9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914",
+            "https://files.pythonhosted.org/packages/20/18/76e26bcfa6a7a62f880791122261575b3048ac57dd72f300ba0827629ab8/cffi-1.16.0-cp310-cp310-win32.whl": "9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a",
+            "https://files.pythonhosted.org/packages/20/3b/f95e667064141843843df8ca79dd49ba57bb7a7615d6d7d538531e45f002/cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl": "b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2",
+            "https://files.pythonhosted.org/packages/20/f8/5931cfb7a8cc15d224099cead5e5432efe729bd61abce72d9b3e51e5800b/cffi-1.16.0-cp39-cp39-musllinux_1_1_i686.whl": "748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000",
+            "https://files.pythonhosted.org/packages/22/04/1d10d5baf3faaae9b35f6c49bcf25c1be81ea68cc7ee6923206d02be85b0/cffi-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl": "fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956",
+            "https://files.pythonhosted.org/packages/22/05/43cfda378da7bb0aa19b3cf34fe54f8867b0d581294216339d87deefd69c/cffi-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684",
+            "https://files.pythonhosted.org/packages/22/c6/df826563f55f7e9dd9a1d3617866282afa969fe0d57decffa1911f416ed8/cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a",
+            "https://files.pythonhosted.org/packages/23/8b/2e8c2469eaf89f7273ac685164949a7e644cdfe5daf1c036564208c3d26b/cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl": "3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac",
+            "https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz": "d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9",
+            "https://files.pythonhosted.org/packages/2d/86/3ca57cddfa0419f6a95d1c8478f8f622ba597e3581fd501bbb915b20eb75/cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27",
+            "https://files.pythonhosted.org/packages/2e/7a/68c35c151e5b7a12650ecc12fdfb85211aa1da43e9924598451c4a0a3839/cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl": "a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c",
+            "https://files.pythonhosted.org/packages/32/2a/63cb8c07d151de92ff9d897b2eb27ba6a0e78dda8e4c5f70d7b8c16cd6a2/cffi-1.15.1-cp37-cp37m-win_amd64.whl": "a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045",
+            "https://files.pythonhosted.org/packages/32/bd/d0809593f7976828f06a492716fbcbbfb62798bbf60ea1f65200b8d49901/cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl": "fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01",
+            "https://files.pythonhosted.org/packages/33/14/8398798ab001523f1abb2b4170a01bf2114588f3f1fa1f984b3f3bef107e/cffi-1.16.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872",
+            "https://files.pythonhosted.org/packages/36/44/124481b75d228467950b9e81d20ec963f33517ca551f08956f2838517ece/cffi-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d",
+            "https://files.pythonhosted.org/packages/37/5a/c37631a86be838bdd84cc0259130942bf7e6e32f70f4cab95f479847fb91/cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c",
+            "https://files.pythonhosted.org/packages/39/44/4381b8d26e9cfa3e220e3c5386f443a10c6313a6ade7acb314b2bcc0a6ce/cffi-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl": "0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc",
+            "https://files.pythonhosted.org/packages/3a/12/d6066828014b9ccb2bbb8e1d9dc28872d20669b65aeb4a86806a0757813f/cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl": "6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e",
+            "https://files.pythonhosted.org/packages/3a/75/a162315adeaf47e94a3b7f886a8e31d77b9e525a387eef2d6f0efc96a7c8/cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl": "fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0",
+            "https://files.pythonhosted.org/packages/3f/fa/dfc242febbff049509e5a35a065bdc10f90d8c8585361c2c66b9c2f97a01/cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl": "a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2",
+            "https://files.pythonhosted.org/packages/40/c9/cfba735d9ed117471e32d7bce435dd49721261ae294277c64aa929ec9c9d/cffi-1.16.0-cp38-cp38-win32.whl": "131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a",
+            "https://files.pythonhosted.org/packages/43/a0/cc7370ef72b6ee586369bacd3961089ab3d94ae712febf07a244f1448ffd/cffi-1.15.1-cp311-cp311-win_amd64.whl": "04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104",
+            "https://files.pythonhosted.org/packages/47/51/3049834f07cd89aceef27f9c56f5394ca6725ae6a15cff5fbdb2f06a24ad/cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d",
+            "https://files.pythonhosted.org/packages/47/97/137f0e3d2304df2060abb872a5830af809d7559a5a4b6a295afb02728e65/cffi-1.15.1-cp38-cp38-win32.whl": "8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314",
+            "https://files.pythonhosted.org/packages/47/e3/b6832b1b9a1b6170c585ee2c2d30baf64d0a497c17e6623f42cfeb59c114/cffi-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl": "e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb",
+            "https://files.pythonhosted.org/packages/4a/56/572f7f728b20e4d51766e63d7de811e45c7cae727dc1f769caad2973fb52/cffi-1.16.0-cp38-cp38-win_amd64.whl": "31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36",
+            "https://files.pythonhosted.org/packages/4a/ac/a4046ab3d72536eff8bc30b39d767f69bd8be715c5e395b71cfca26f03d9/cffi-1.16.0-cp311-cp311-win32.whl": "2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab",
+            "https://files.pythonhosted.org/packages/4c/00/e17e2a8df0ff5aca2edd9eeebd93e095dd2515f2dd8d591d84a3233518f6/cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl": "2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520",
+            "https://files.pythonhosted.org/packages/50/34/4cc590ad600869502c9838b4824982c122179089ed6791a8b1c95f0ff55e/cffi-1.15.1-cp37-cp37m-win32.whl": "e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9",
+            "https://files.pythonhosted.org/packages/50/bd/17a8f9ac569d328de304e7318d7707fcdb6f028bcc194d80cfc654902007/cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8",
+            "https://files.pythonhosted.org/packages/54/49/b8875986beef2e74fc668b95f2df010e354f78e009d33d95b375912810c3/cffi-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl": "7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7",
+            "https://files.pythonhosted.org/packages/57/3a/c263cf4d5b02880274866968fa2bf196a02c4486248bc164732319b4a4c0/cffi-1.16.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673",
+            "https://files.pythonhosted.org/packages/58/ac/2a3ea436a6cbaa8f75ddcab39010e5e0817a18f26fef5d2fe2e0c7df3425/cffi-1.16.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627",
+            "https://files.pythonhosted.org/packages/5a/c7/694814b3757878b29da39bc2f0cf9d20295f4c1e0a0bde7971708d5f23f8/cffi-1.16.0-cp311-cp311-win_amd64.whl": "db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba",
+            "https://files.pythonhosted.org/packages/5b/1a/e1ee5bed11d8b6540c05a8e3c32448832d775364d4461dd6497374533401/cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82",
+            "https://files.pythonhosted.org/packages/5d/4e/4e0bb5579b01fdbfd4388bd1eb9394a989e1336203a4b7f700d887b233c1/cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325",
+            "https://files.pythonhosted.org/packages/5d/6f/3a2e167113eabd46ed300ff3a6a1e9277a3ad8b020c4c682f83e9326fcf7/cffi-1.15.1-cp36-cp36m-win32.whl": "2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf",
+            "https://files.pythonhosted.org/packages/68/ce/95b0bae7968c65473e1298efb042e10cafc7bafc14d9e4f154008241c91d/cffi-1.16.0.tar.gz": "bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0",
+            "https://files.pythonhosted.org/packages/69/46/8882b0405be4ac7db3fefa5a201f221acb54f27c76e584e23e9c62b68819/cffi-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f",
+            "https://files.pythonhosted.org/packages/69/bf/335f8d95510b1a26d7c5220164dc739293a71d5540ecd54a2f66bac3ecb8/cffi-1.15.1-cp36-cp36m-win_amd64.whl": "30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497",
+            "https://files.pythonhosted.org/packages/71/d7/0fe0d91b0bbf610fb7254bb164fa8931596e660d62e90fb6289b7ee27b09/cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl": "03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef",
+            "https://files.pythonhosted.org/packages/73/dd/15c6f32166f0c8f97d8aadee9ac8f096557899f4f21448d2feb74cf4f210/cffi-1.16.0-cp39-cp39-win_amd64.whl": "3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8",
+            "https://files.pythonhosted.org/packages/77/b7/d3618d612be01e184033eab90006f8ca5b5edafd17bf247439ea4e167d8a/cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d",
+            "https://files.pythonhosted.org/packages/79/4b/33494eb0adbcd884656c48f6db0c98ad8a5c678fb8fb5ed41ab546b04d8c/cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl": "87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02",
+            "https://files.pythonhosted.org/packages/7c/3e/5d823e5bbe00285e479034bcad44177b7353ec9fdcd7795baac5ccf82950/cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl": "50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7",
+            "https://files.pythonhosted.org/packages/7f/5a/39e212f99aa73660a1c523f6b7ddeb4e26f906faaa5088e97b617a89c7ae/cffi-1.16.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0",
+            "https://files.pythonhosted.org/packages/85/1f/a3c533f8d377da5ca7edb4f580cc3edc1edbebc45fac8bb3ae60f1176629/cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415",
+            "https://files.pythonhosted.org/packages/85/3e/a4e4857c2aae635195459679ac9daea296630c1d76351259eb3de3c18ed0/cffi-1.16.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl": "a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b",
+            "https://files.pythonhosted.org/packages/87/4b/64e8bd9d15d6b22b6cb11997094fbe61edf453ea0a97c8675cb7d1c3f06f/cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl": "320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3",
+            "https://files.pythonhosted.org/packages/87/ee/ddc23981fc0f5e7b5356e98884226bcb899f95ebaefc3e8e8b8742dd7e22/cffi-1.15.1-cp311-cp311-win32.whl": "a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d",
+            "https://files.pythonhosted.org/packages/88/89/c34caf63029fb7628ec2ebd5c88ae0c9bd17db98c812e4065a4d020ca41f/cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4",
+            "https://files.pythonhosted.org/packages/8b/5c/7f9cd1fb80512c9e16c90b29b26fea52977e9ab268321f64b42f4c8488a3/cffi-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b",
+            "https://files.pythonhosted.org/packages/8c/54/82aa3c014760d5a6ddfde3253602f0ac1937dd504621d4139746f230a7b5/cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl": "8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe",
+            "https://files.pythonhosted.org/packages/91/bc/b7723c2fe7a22eee71d7edf2102cd43423d5f95ff3932ebaa2f82c7ec8d0/cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c",
+            "https://files.pythonhosted.org/packages/93/d0/2e2b27ea2f69b0ec9e481647822f8f77f5fc23faca2dd00d1ff009940eb7/cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426",
+            "https://files.pythonhosted.org/packages/95/c8/ce05a6cba2bec12d4b28285e66c53cc88dd7385b102dea7231da3b74cfef/cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl": "b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404",
+            "https://files.pythonhosted.org/packages/9b/1a/575200306a3dfd9102ce573e7158d459a1bd7e44637e4f22a999c4fd64b1/cffi-1.16.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e",
+            "https://files.pythonhosted.org/packages/9b/89/a31c81e36bbb793581d8bba4406a8aac4ba84b2559301c44eef81f4cf5df/cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e",
+            "https://files.pythonhosted.org/packages/9d/da/e6dbf22b66899419e66c501ae5f1cf3d69979d4c75ad30da683f60abba94/cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl": "582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed",
+            "https://files.pythonhosted.org/packages/9f/52/1e2b43cfdd7d9a39f48bc89fcaee8d8685b1295e205a4f1044909ac14d89/cffi-1.15.1-cp310-cp310-win32.whl": "cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2",
+            "https://files.pythonhosted.org/packages/a3/81/5f5d61338951afa82ce4f0f777518708893b9420a8b309cc037fbf114e63/cffi-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl": "b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6",
+            "https://files.pythonhosted.org/packages/a4/42/54bdf22cf6c8f95113af645d0bd7be7f9358ea5c2d57d634bb11c6b4d0b2/cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl": "ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b",
+            "https://files.pythonhosted.org/packages/a8/16/06b84a7063a4c0a2b081030fdd976022086da9c14e80a9ed4ba0183a98a9/cffi-1.15.1-cp39-cp39-win_amd64.whl": "70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c",
+            "https://files.pythonhosted.org/packages/a9/ba/e082df21ebaa9cb29f2c4e1d7e49a29b90fcd667d43632c6674a16d65382/cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984",
+            "https://files.pythonhosted.org/packages/aa/02/ab15b3aa572759df752491d5fa0f74128cd14e002e8e3257c1ab1587810b/cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl": "2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e",
+            "https://files.pythonhosted.org/packages/aa/aa/1c43e48a6f361d1529f9e4602d6992659a0107b5f21cae567e2eddcf8d66/cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl": "6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088",
+            "https://files.pythonhosted.org/packages/ad/26/7b3a73ab7d82a64664c7c4ea470e4ec4a3c73bb4f02575c543a41e272de5/cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl": "db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76",
+            "https://files.pythonhosted.org/packages/ae/00/831d01e63288d1654ed3084a6ac8b0940de6dc0ada4ba71b830fff7a0088/cffi-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl": "c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4",
+            "https://files.pythonhosted.org/packages/af/cb/53b7bba75a18372d57113ba934b27d0734206c283c1dfcc172347fbd9f76/cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl": "33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35",
+            "https://files.pythonhosted.org/packages/af/da/9441d56d7dd19d07dcc40a2a5031a1f51c82a27cee3705edf53dadcac398/cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f",
+            "https://files.pythonhosted.org/packages/b3/b8/89509b6357ded0cbacc4e430b21a4ea2c82c2cdeb4391c148b7c7b213bed/cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl": "4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a",
+            "https://files.pythonhosted.org/packages/b4/5f/c6e7e8d80fbf727909e4b1b5b9352082fc1604a14991b1d536bfaee5a36c/cffi-1.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357",
+            "https://files.pythonhosted.org/packages/b4/f6/b28d2bfb5fca9e8f9afc9d05eae245bed9f6ba5c2897fefee7a9abeaf091/cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl": "68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e",
+            "https://files.pythonhosted.org/packages/b5/23/ea84dd4985649fcc179ba3a6c9390412e924d20b0244dc71a6545788f5a2/cffi-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936",
+            "https://files.pythonhosted.org/packages/b5/7d/df6c088ef30e78a78b0c9cca6b904d5abb698afb5bc8f5191d529d83d667/cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl": "198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375",
+            "https://files.pythonhosted.org/packages/b5/80/ce5ba093c2475a73df530f643a61e2969a53366e372b24a32f08cd10172b/cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6",
+            "https://files.pythonhosted.org/packages/b7/8b/06f30caa03b5b3ac006de4f93478dbd0239e2a16566d81a106c322dc4f79/cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192",
+            "https://files.pythonhosted.org/packages/b9/4a/dde4d093a3084d0b0eadfb2703f71e31a5ced101a42c839ac5bbbd1710f2/cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl": "d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162",
+            "https://files.pythonhosted.org/packages/be/3e/0b197d1bfbf386a90786b251dbf2634a15f2ea3d4e4070e99c7d1c7689cf/cffi-1.16.0-cp310-cp310-win_amd64.whl": "e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1",
+            "https://files.pythonhosted.org/packages/c1/25/16a082701378170559bb1d0e9ef2d293cece8dc62913d79351beb34c5ddf/cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5",
+            "https://files.pythonhosted.org/packages/c2/0b/3b09a755ddb977c167e6d209a7536f6ade43bb0654bad42e08df1406b8e4/cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e",
+            "https://files.pythonhosted.org/packages/c4/01/f5116266fe80c04d4d1cc96c3d355606943f9fb604a810e0b02228a0ce19/cffi-1.16.0-cp310-cp310-macosx_11_0_arm64.whl": "ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9",
+            "https://files.pythonhosted.org/packages/c5/ff/3f9d73d480567a609e98beb0c64359f8e4f31cb6a407685da73e5347b067/cffi-1.15.1-cp27-cp27m-win32.whl": "b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3",
+            "https://files.pythonhosted.org/packages/c6/3d/dd085bb831b22ce4d0b7ba8550e6d78960f02f770bbd1314fea3580727f8/cffi-1.15.1-cp39-cp39-win32.whl": "40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee",
+            "https://files.pythonhosted.org/packages/c9/6e/751437067affe7ac0944b1ad4856ec11650da77f0dd8f305fae1117ef7bb/cffi-1.16.0-cp312-cp312-win32.whl": "b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b",
+            "https://files.pythonhosted.org/packages/c9/7c/43d81bdd5a915923c3bad5bb4bff401ea00ccc8e28433fb6083d2e3bf58e/cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614",
+            "https://files.pythonhosted.org/packages/c9/e3/0a52838832408cfbbf3a59cb19bcd17e64eb33795c9710ca7d29ae10b5b7/cffi-1.15.1-cp38-cp38-win_amd64.whl": "00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5",
+            "https://files.pythonhosted.org/packages/d3/56/3e94aa719ae96eeda8b68b3ec6e347e0a23168c6841dc276ccdcdadc9f32/cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl": "cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8",
+            "https://files.pythonhosted.org/packages/d3/e1/e55ca2e0dd446caa2cc8f73c2b98879c04a1f4064ac529e1836683ca58b8/cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b",
+            "https://files.pythonhosted.org/packages/da/ff/ab939e2c7b3f40d851c0f7192c876f1910f3442080c9c846532993ec3cef/cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl": "98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3",
+            "https://files.pythonhosted.org/packages/df/02/aef53d4aa43154b829e9707c8c60bab413cd21819c4a36b0d7aaa83e2a61/cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca",
+            "https://files.pythonhosted.org/packages/e0/80/52b71420d68c4be18873318f6735c742f1172bb3b18d23f0306e6444d410/cffi-1.16.0-cp311-cp311-musllinux_1_1_i686.whl": "c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc",
+            "https://files.pythonhosted.org/packages/e4/9a/7169ae3a67a7bb9caeb2249f0617ac1458df118305c53afa3dec4a9029cd/cffi-1.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl": "5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56",
+            "https://files.pythonhosted.org/packages/e4/c7/c09cc6fd1828ea950e60d44e0ef5ed0b7e3396fbfb856e49ca7d629b1408/cffi-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2",
+            "https://files.pythonhosted.org/packages/e8/ff/c4b7a358526f231efa46a375c959506c87622fb4a2c5726e827c55e6adf2/cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl": "39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21",
+            "https://files.pythonhosted.org/packages/e9/63/e285470a4880a4f36edabe4810057bd4b562c6ddcc165eacf9c3c7210b40/cffi-1.16.0-cp312-cp312-win_amd64.whl": "68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235",
+            "https://files.pythonhosted.org/packages/ea/ac/e9e77bc385729035143e54cc8c4785bd480eaca9df17565963556b0b7a93/cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098",
+            "https://files.pythonhosted.org/packages/ea/be/c4ad40ad441ac847b67c7a37284ae3c58f39f3e638c6b0f85fb662233825/cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl": "285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185",
+            "https://files.pythonhosted.org/packages/eb/de/4f644fc78a1144a897e1f908abfb2058f7be05a8e8e4fe90b7f41e9de36b/cffi-1.16.0-cp310-cp310-musllinux_1_1_i686.whl": "32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743",
+            "https://files.pythonhosted.org/packages/ed/a3/c5f01988ddb70a187c3e6112152e01696188c9f8a4fa4c68aa330adbb179/cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd",
+            "https://files.pythonhosted.org/packages/ee/68/74a2b9f9432b70d97d1184cdabf32d7803124c228adef9481d280864a4a7/cffi-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl": "673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d",
+            "https://files.pythonhosted.org/packages/ef/41/19da352d341963d29a33bdb28433ba94c05672fb16155f794fad3fd907b0/cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc",
+            "https://files.pythonhosted.org/packages/f0/31/a6503a5c4874fb4d4c2053f73f09a957cb427b6943fab5a43b8e156df397/cffi-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896",
+            "https://files.pythonhosted.org/packages/f1/c9/326611aa83e16b13b6db4dbb73b5455c668159a003c4c2f0c3bcb2ddabaf/cffi-1.16.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324",
+            "https://files.pythonhosted.org/packages/f9/6c/af5f40c66aac38aa70abfa6f26e8296947a79ef373cb81a14c791c3da91d/cffi-1.16.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c",
+            "https://files.pythonhosted.org/packages/f9/96/fc9e118c47b7adc45a0676f413b4a47554e5f3b6c99b8607ec9726466ef1/cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl": "3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83",
+            "https://files.pythonhosted.org/packages/ff/fe/ac46ca7b00e9e4f9c62e7928a11bc9227c86e2ff43526beee00cdfb4f0e8/cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl": "470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"
+          },
+          "chardet": {
+            "https://files.pythonhosted.org/packages/41/32/cdc91dcf83849c7385bf8e2a5693d87376536ed000807fa07f5eab33430d/chardet-5.1.0.tar.gz": "0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5",
+            "https://files.pythonhosted.org/packages/74/8f/8fc49109009e8d2169d94d72e6b1f4cd45c13d147ba7d6170fb41f22b08f/chardet-5.1.0-py3-none-any.whl": "362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9",
+            "https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl": "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+            "https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz": "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+          },
+          "charset-normalizer": {
+            "https://files.pythonhosted.org/packages/00/35/830c29e5dab61932224c7a6c89427090164a3e425cf03486ce7a3ce60623/charset_normalizer-3.0.1-cp37-cp37m-musllinux_1_1_i686.whl": "9d9153257a3f70d5f69edf2325357251ed20f772b12e593f3b3377b5f78e7ef8",
+            "https://files.pythonhosted.org/packages/00/47/f14533da238134f5067fb1d951eb03d5c4be895d6afb11c7ebd07d111acb/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28",
+            "https://files.pythonhosted.org/packages/00/bd/ef9c88464b126fa176f4ef4a317ad9b6f4d30b2cffbc43386062367c3e2c/charset_normalizer-3.4.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": "8999f965f922ae054125286faf9f11bc6932184b93011d138925a1773830bbe9",
+            "https://files.pythonhosted.org/packages/01/c7/0407de35b70525dba2a58a2724a525cf882ee76c3d2171d834463c5d2881/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb",
+            "https://files.pythonhosted.org/packages/01/ff/9ee4a44e8c32fe96dfc12daa42f29294608a55eadc88f327939327fb20fb/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_aarch64.whl": "72966d1b297c741541ca8cf1223ff262a6febe52481af742036a0b296e35fa5a",
+            "https://files.pythonhosted.org/packages/02/49/78b4c1bc8b1b0e0fc66fb31ce30d8302f10a1412ba75de72c57532f0beb0/charset_normalizer-3.0.1-cp311-cp311-macosx_11_0_arm64.whl": "87701167f2a5c930b403e9756fab1d31d4d4da52856143b609e30a1ce7160f3c",
+            "https://files.pythonhosted.org/packages/02/f7/3611b32318b30974131db62b4043f335861d4d9b49adc6d57c1149cc49d4/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_aarch64.whl": "ccf600859c183d70eb47e05a44cd80a4ce77394d1ac0f79dbd2dd90a69a3a049",
+            "https://files.pythonhosted.org/packages/03/5e/e81488c74e86eef85cf085417ed945da2dcca87ed22d76202680c16bd3c3/charset_normalizer-3.0.1-cp38-cp38-musllinux_1_1_x86_64.whl": "39049da0ffb96c8cbb65cbf5c5f3ca3168990adf3551bd1dee10c48fce8ae820",
+            "https://files.pythonhosted.org/packages/04/9a/914d294daa4809c57667b77470533e65def9c0be1ef8b4c1183a99170e9d/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl": "fb731e5deb0c7ef82d698b0f4c5bb724633ee2a489401594c5c88b02e6cb15f7",
+            "https://files.pythonhosted.org/packages/05/31/e1f51c76db7be1d4aef220d29fbfa5dbb4a99165d9833dcbf166753b6dc0/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl": "65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4",
+            "https://files.pythonhosted.org/packages/05/35/bb59b1cd012d7196fc81c2f5879113971efc226a63812c9cf7f89fe97c40/charset_normalizer-3.4.3-cp38-cp38-win_amd64.whl": "5d8d01eac18c423815ed4f4a2ec3b439d654e55ee4ad610e153cf02faf67ea40",
+            "https://files.pythonhosted.org/packages/05/6b/e2539a0a4be302b481e8cafb5af8792da8093b486885a1ae4d15d452bcec/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_ppc64le.whl": "42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491",
+            "https://files.pythonhosted.org/packages/05/8c/eb854996d5fef5e4f33ad56927ad053d04dc820e4a3d39023f35cad72617/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e",
+            "https://files.pythonhosted.org/packages/05/f3/86b5fcb5c8fe8b4231362918a7c4d8f549c56561c5fdb495a3c5b41c6862/charset_normalizer-3.1.0-cp310-cp310-win_amd64.whl": "65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8",
+            "https://files.pythonhosted.org/packages/06/57/84722eefdd338c04cf3030ada66889298eaedf3e7a30a624201e0cbe424a/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_s390x.whl": "30a96e1e1f865f78b030d65241c1ee850cdf422d869e9028e2fc1d5e4db73b92",
+            "https://files.pythonhosted.org/packages/07/07/7e554f2bbce3295e191f7e653ff15d55309a9ca40d0362fcdab36f01063c/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc",
+            "https://files.pythonhosted.org/packages/07/6b/98d41a0221991a806e88c95bfeecf8935fbf465b02eb4b469770d572183a/charset_normalizer-3.1.0-cp37-cp37m-win32.whl": "4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974",
+            "https://files.pythonhosted.org/packages/0a/67/8d3d162ec6641911879651cdef670c3c6136782b711d7f8e82e2fffe06e0/charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_x86_64.whl": "6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017",
+            "https://files.pythonhosted.org/packages/0b/8b/3cf0eff3c8b6734cd4336c23a3141846d579931a31e6476c8091961f1e25/charset_normalizer-3.0.1-cp36-cp36m-win_amd64.whl": "eaa379fcd227ca235d04152ca6704c7cb55564116f8bc52545ff357628e10602",
+            "https://files.pythonhosted.org/packages/0c/52/8b0c6c3e53f7e546a5e49b9edb876f379725914e1130297f3b423c7b71c5/charset_normalizer-3.4.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": "c60e092517a73c632ec38e290eba714e9627abe9d301c8c8a12ec32c314a2a4b",
+            "https://files.pythonhosted.org/packages/0e/d3/c5fa421dc69bb77c581ed561f1ec6656109c97731ad1128aa93d8bad3053/charset_normalizer-3.0.1-cp38-cp38-macosx_10_9_universal2.whl": "024e606be3ed92216e2b6952ed859d86b4cfa52cd5bc5f050e7dc28f9b43ec42",
+            "https://files.pythonhosted.org/packages/0e/fd/0d099502582af039ef8a8c954d69d7dadbe5f425cb1b24d175eb0034ea9e/charset_normalizer-3.0.1-cp37-cp37m-win32.whl": "0bf2dae5291758b6f84cf923bfaa285632816007db0330002fa1de38bfcb7154",
+            "https://files.pythonhosted.org/packages/0f/45/f462f534dd2853ebbc186ed859661db454665b1dc9ae6c690d982153cda9/charset_normalizer-3.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl": "503e65837c71b875ecdd733877d852adbc465bd82c768a067badd953bf1bc5a3",
+            "https://files.pythonhosted.org/packages/12/12/c5c39f5a149cd6788d2e40cea5618bae37380e2754fcdf53dc9e01bdd33a/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41",
+            "https://files.pythonhosted.org/packages/12/68/4812f9b05ac0a2b7619ac3dd7d7e3fc52c12006b84617021c615fc2fcf42/charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_universal2.whl": "38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e",
+            "https://files.pythonhosted.org/packages/12/e5/aa09a1c39c3e444dd223d63e2c816c18ed78d035cff954143b2a539bdc9e/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "0c0a590235ccd933d9892c627dec5bc7511ce6ad6c1011fdf5b11363022746c1",
+            "https://files.pythonhosted.org/packages/13/82/83c188028b6f38d39538442dd127dc794c602ae6d45d66c469f4063a4c30/charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl": "6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac",
+            "https://files.pythonhosted.org/packages/13/b7/21729a6d512246aa0bb872b90aea0d9fcd1b293762cdb1d1d33c01140074/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_aarch64.whl": "f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326",
+            "https://files.pythonhosted.org/packages/13/f8/eefae0629fa9260f83b826ee3363e311bb03cfdd518dad1bd10d57cb2d84/charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl": "bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8",
+            "https://files.pythonhosted.org/packages/16/58/19fd2f62e6ff44ba0db0cd44b584790555e2cde09293149f4409d654811b/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6",
+            "https://files.pythonhosted.org/packages/16/ab/0233c3231af734f5dfcf0844aa9582d5a1466c985bbed6cedab85af9bfe3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": "1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f",
+            "https://files.pythonhosted.org/packages/16/bd/671f11f920dfb46de848e9176d84ddb25b3bbdffac6751cbbf691c0b5b17/charset_normalizer-3.0.1-cp37-cp37m-macosx_10_9_x86_64.whl": "3e45867f1f2ab0711d60c6c71746ac53537f1684baa699f4f668d4c6f6ce8e14",
+            "https://files.pythonhosted.org/packages/16/ea/a9e284aa38cccea06b7056d4cbc7adf37670b1f8a668a312864abf1ff7c6/charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl": "37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a",
+            "https://files.pythonhosted.org/packages/17/67/4b25c0358a2e812312b551e734d58855d58f47d0e0e9d1573930003910cb/charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_universal2.whl": "8eade758719add78ec36dc13201483f8e9b5d940329285edcd5f70c0a9edbd7f",
+            "https://files.pythonhosted.org/packages/17/da/fdf8ffc33716c82cae06008159a55a581fa515e8dd02e3395dcad42ff83d/charset_normalizer-3.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "81d6741ab457d14fdedc215516665050f3822d3e56508921cc7239f8c8e66a58",
+            "https://files.pythonhosted.org/packages/17/e5/5e67ab85e6d22b04641acb5399c8684f4d37caf7558a53859f0283a650e9/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl": "2001a39612b241dae17b4687898843f254f8748b796a2e16f1051a17078d991d",
+            "https://files.pythonhosted.org/packages/18/36/7ae10a3dd7f9117b61180671f8d1e4802080cca88ad40aaabd3dad8bab0e/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62",
+            "https://files.pythonhosted.org/packages/19/28/573147271fd041d351b438a5665be8223f1dd92f273713cb882ddafe214c/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl": "eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887",
+            "https://files.pythonhosted.org/packages/1a/79/ae516e678d6e32df2e7e740a7be51dc80b700e2697cb70054a0f1ac2c955/charset_normalizer-3.4.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl": "3653fad4fe3ed447a596ae8638b437f827234f01a8cd801842e43f3d0a6b281b",
+            "https://files.pythonhosted.org/packages/1c/9b/de2adc43345623da8e7c958719528a42b6d87d2601017ce1187d43b8a2d7/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_i686.whl": "10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230",
+            "https://files.pythonhosted.org/packages/1e/49/7ab74d4ac537ece3bc3334ee08645e231f39f7d6df6347b29a74b0537103/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl": "4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce",
+            "https://files.pythonhosted.org/packages/1f/8d/33c860a7032da5b93382cbe2873261f81467e7b37f4ed91e25fed62fd49b/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185",
+            "https://files.pythonhosted.org/packages/1f/be/c6c76cf8fcf6918922223203c83ba8192eff1c6a709e8cfec7f5ca3e7d2d/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl": "d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854",
+            "https://files.pythonhosted.org/packages/20/30/5f64fe3981677fe63fa987b80e6c01042eb5ff653ff7cec1b7bd9268e54e/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_ppc64le.whl": "2c322db9c8c89009a990ef07c3bcc9f011a3269bc06782f916cd3d9eed7c9312",
+            "https://files.pythonhosted.org/packages/20/a2/16b2cbf5f73bdd10624b94647b85c008ba25059792a5c7b4fdb8358bceeb/charset_normalizer-3.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "e696f0dd336161fca9adbb846875d40752e6eba585843c768935ba5c9960722b",
+            "https://files.pythonhosted.org/packages/21/16/1b0d8fdcb81bbf180976af4f867ce0f2244d303ab10d452fde361dec3b5c/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_i686.whl": "11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be",
+            "https://files.pythonhosted.org/packages/21/40/5188be1e3118c82dcb7c2a5ba101b783822cfb413a0268ed3be0468532de/charset_normalizer-3.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": "cc9370a2da1ac13f0153780040f465839e6cccb4a1e44810124b4e22483c93fe",
+            "https://files.pythonhosted.org/packages/22/82/63a45bfc36f73efe46731a3a71cb84e2112f7e0b049507025ce477f0f052/charset_normalizer-3.4.3-cp38-cp38-macosx_10_9_universal2.whl": "0f2be7e0cf7754b9a30eb01f4295cc3d4358a479843b31f328afd210e2c7598c",
+            "https://files.pythonhosted.org/packages/23/13/cf5d7bb5bc95f120df64d6c470581189df51d7f011560b2a06a395b7a120/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_ppc64le.whl": "b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137",
+            "https://files.pythonhosted.org/packages/24/9d/2e3ef673dfd5be0154b20363c5cdcc5606f35666544381bee15af3778239/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl": "b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143",
+            "https://files.pythonhosted.org/packages/25/19/298089cef2eb82fd3810d982aa239d4226594f99e1fe78494cb9b47b03c9/charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_s390x.whl": "0f438ae3532723fb6ead77e7c604be7c8374094ef4ee2c5e03a3a17f1fca256c",
+            "https://files.pythonhosted.org/packages/25/b5/f477e419b06e49f3bae446cbdc1fd71d2599be8b12b4d45c641c5a4495b1/charset_normalizer-3.0.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "911d8a40b2bef5b8bbae2e36a0b103f142ac53557ab421dc16ac4aafee6f53dc",
+            "https://files.pythonhosted.org/packages/26/20/83e1804a62b25891c4e770c94d9fd80233bbb3f2a51c4fadee7a196e5a5b/charset_normalizer-3.1.0-cp38-cp38-win_amd64.whl": "3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59",
+            "https://files.pythonhosted.org/packages/27/b1/8dfcfa5d9978b845466cd41973b3d714eba3926fcb50f6fcddd45cfb75a2/charset_normalizer-3.0.1-cp36-cp36m-musllinux_1_1_ppc64le.whl": "083c8d17153ecb403e5e1eb76a7ef4babfc2c48d58899c98fcaa04833e7a2f9a",
+            "https://files.pythonhosted.org/packages/28/76/e6222113b83e3622caa4bb41032d0b1bf785250607392e1b778aca0b8a7d/charset_normalizer-3.3.2-py3-none-any.whl": "3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc",
+            "https://files.pythonhosted.org/packages/2a/91/26c3036e62dfe8de8061182d33be5025e2424002125c9500faff74a6735e/charset_normalizer-3.4.3-cp310-cp310-win32.whl": "d79c198e27580c8e958906f803e63cddb77653731be08851c7df0b1a14a8fc0f",
+            "https://files.pythonhosted.org/packages/2a/9d/a6d15bd1e3e2914af5955c8eb15f4071997e7078419328fee93dfd497eb7/charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl": "68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0",
+            "https://files.pythonhosted.org/packages/2b/61/095a0aa1a84d1481998b534177c8566fdc50bb1233ea9a0478cd3cc075bd/charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl": "25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3",
+            "https://files.pythonhosted.org/packages/2c/2f/ec805104098085728b7cb610deede7195c6fa59f51942422f02cc427b6f6/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649",
+            "https://files.pythonhosted.org/packages/2d/02/0f875eb6a1cf347bd3a6098f458f79796aafa3b51090fd7b2784736dc67d/charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_ppc64le.whl": "44ba614de5361b3e5278e1241fda3dc1838deed864b50a10d7ce92983797fa76",
+            "https://files.pythonhosted.org/packages/2d/dc/9dacba68c9ac0ae781d40e1a0c0058e26302ea0660e574ddf6797a0347f7/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl": "80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f",
+            "https://files.pythonhosted.org/packages/2e/25/3eab2b38fef9ae59f7b4e9c1e62eb50609d911867e5acabace95fe25c0b1/charset_normalizer-3.1.0-cp310-cp310-win32.whl": "12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448",
+            "https://files.pythonhosted.org/packages/2e/37/9223632af0872c86d8b851787f0edd3fe66be4a5378f51242b25212f8374/charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl": "3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6",
+            "https://files.pythonhosted.org/packages/2e/7b/5053a4a46fac017fd2aea3dc9abdd9983fd4cef153b6eb6aedcb0d7cb6e3/charset_normalizer-3.0.1-cp311-cp311-win_amd64.whl": "9ab77acb98eba3fd2a85cd160851816bfce6871d944d885febf012713f06659c",
+            "https://files.pythonhosted.org/packages/2e/7d/2259318c202f3d17f3fe6438149b3b9e706d1070fe3fcbb28049730bb25c/charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl": "ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b",
+            "https://files.pythonhosted.org/packages/2f/0e/d7303ccae9735ff8ff01e36705ad6233ad2002962e8668a970fc000c5e1b/charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl": "b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d",
+            "https://files.pythonhosted.org/packages/2f/36/77da9c6a328c54d17b960c89eccacfab8271fdaaa228305330915b88afa9/charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_x86_64.whl": "1e8ac75d72fa3775e0b7cb7e4629cec13b7514d928d15ef8ea06bca03ef01cae",
+            "https://files.pythonhosted.org/packages/31/06/f6330ee70c041a032ee1a5d32785d69748cfa41f64b6d327cc08cae51de9/charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_aarch64.whl": "ab5de034a886f616a5668aa5d098af2b5385ed70142090e2a31bcbd0af0fdb3d",
+            "https://files.pythonhosted.org/packages/31/8b/81c3515a69d06b501fcce69506af57a7a19bd9f42cabd1a667b1b40f2c55/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_ppc64le.whl": "80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b",
+            "https://files.pythonhosted.org/packages/31/af/67b7653a35dbd56f6bb9ff54652a551eae8420d1d0545f0042c5bdb15fb0/charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl": "f6f45710b4459401609ebebdbcfb34515da4fc2aa886f95107f556ac69a9147e",
+            "https://files.pythonhosted.org/packages/31/e7/883ee5676a2ef217a40ce0bffcc3d0dfbf9e64cbcfbdf822c52981c3304b/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_s390x.whl": "cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93",
+            "https://files.pythonhosted.org/packages/33/10/c87ba15f779f8251ae55fa147631339cd91e7af51c3c133d2687c6e41800/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_i686.whl": "ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11",
+            "https://files.pythonhosted.org/packages/33/95/ef68482e4a6adf781fae8d183fb48d6f2be8facb414f49c90ba6a5149cd1/charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl": "b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a",
+            "https://files.pythonhosted.org/packages/33/97/9967fb2d364a9da38557e4af323abcd58cc05bdd8f77e9fd5ae4882772cc/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706",
+            "https://files.pythonhosted.org/packages/33/9e/eca49d35867ca2db336b6ca27617deed4653b97ebf45dfc21311ce473c37/charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_x86_64.whl": "78deba4d8f9590fe4dae384aeff04082510a709957e968753ff3c48399f6f92a",
+            "https://files.pythonhosted.org/packages/33/c3/3b96a435c5109dd5b6adc8a59ba1d678b302a97938f032e3770cc84cd354/charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl": "beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c",
+            "https://files.pythonhosted.org/packages/34/2a/f392457d45e24a0c9bfc012887ed4f3c54bf5d4d05a5deb970ffec4b7fc0/charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33",
+            "https://files.pythonhosted.org/packages/35/86/d85885ed7ac236a297b0b8beab5f0703fc0516f803ddf7b1910f255b83f3/charset_normalizer-3.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl": "7eb33a30d75562222b64f569c642ff3dc6689e09adda43a082208397f016c39a",
+            "https://files.pythonhosted.org/packages/37/00/ca188e0a2b3cd3184cdd2521b8765cf579327d128caa8aedc3dc7614020a/charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_universal2.whl": "0298eafff88c99982a4cf66ba2efa1128e4ddaca0b05eec4c456bbc7db691d8d",
+            "https://files.pythonhosted.org/packages/37/60/5d0d74bc1e1380f0b72c327948d9c2aca14b46a9efd87604e724260f384c/charset_normalizer-3.4.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl": "07a0eae9e2787b586e129fdcbe1af6997f8d0e5abaa0bc98c0e20e124d67e601",
+            "https://files.pythonhosted.org/packages/37/60/7a01f3a129d1af1f26ab2c56aae89a72dbf33fd46a467c1aa994ec62b90b/charset_normalizer-3.0.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "8b8af03d2e37866d023ad0ddea594edefc31e827fee64f8de5611a1dbc373174",
+            "https://files.pythonhosted.org/packages/39/c6/99271dc37243a4f925b09090493fb96c9333d7992c6187f5cfe5312008d2/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": "23b6b24d74478dc833444cbd927c338349d6ae852ba53a0d02a2de1fce45b96e",
+            "https://files.pythonhosted.org/packages/39/f5/3b3836ca6064d0992c58c7561c6b6eee1b3892e9665d650c803bd5614522/charset_normalizer-3.4.3-cp312-cp312-win_amd64.whl": "86df271bf921c2ee3818f0522e9a5b8092ca2ad8b065ece5d7d9d0e9f4849bcc",
+            "https://files.pythonhosted.org/packages/3a/52/9f9d17c3b54dc238de384c4cb5a2ef0e27985b42a0e5cc8e8a31d918d48d/charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl": "55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6",
+            "https://files.pythonhosted.org/packages/3a/91/a233f06d33dc3ac90a9991d238fbc68c59615d9f71be1801e14ac4e42d7f/charset_normalizer-3.0.1-cp38-cp38-win32.whl": "4457ea6774b5611f4bed5eaa5df55f70abde42364d498c5134b7ef4c6958e20e",
+            "https://files.pythonhosted.org/packages/3a/a4/b3b6c76e7a635748c4421d2b92c7b8f90a432f98bda5082049af37ffc8e3/charset_normalizer-3.4.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl": "00237675befef519d9af72169d8604a067d92755e84fe76492fef5441db05b91",
+            "https://files.pythonhosted.org/packages/3b/38/20a1f44e4851aa1c9105d6e7110c9d020e093dfa5836d712a5f074a12bf7/charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_ppc64le.whl": "4ca4c094de7771a98d7fbd67d9e5dbf1eb73efa4f744a730437d8a3a5cf994f0",
+            "https://files.pythonhosted.org/packages/3d/09/d82fe4a34c5f0585f9ea1df090e2a71eb9bb1e469723053e1ee9f57c16f3/charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2",
+            "https://files.pythonhosted.org/packages/3d/85/5b7416b349609d20611a64718bed383b9251b5a601044550f0c8983b8900/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269",
+            "https://files.pythonhosted.org/packages/3e/33/21a875a61057165e92227466e54ee076b73af1e21fe1b31f1e292251aa1e/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl": "573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
+            "https://files.pythonhosted.org/packages/3f/ba/3f5e7be00b215fa10e13d64b1f6237eb6ebea66676a41b2bcdd09fe74323/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537",
+            "https://files.pythonhosted.org/packages/40/26/f35951c45070edc957ba40a5b1db3cf60a9dbb1b350c2d5bef03e01e61de/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8",
+            "https://files.pythonhosted.org/packages/43/05/3bf613e719efe68fb3a77f9c536a389f35b95d75424b96b426a47a45ef1d/charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl": "e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12",
+            "https://files.pythonhosted.org/packages/44/80/b339237b4ce635b4af1c73742459eee5f97201bd92b2371c53e11958392e/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl": "1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519",
+            "https://files.pythonhosted.org/packages/45/3d/fa2683f5604f99fba5098a7313e5d4846baaecbee754faf115907f21a85f/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f",
+            "https://files.pythonhosted.org/packages/45/59/3d27019d3b447a88fe7e7d004a1e04be220227760264cc41b405e863891b/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl": "7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26",
+            "https://files.pythonhosted.org/packages/45/8c/dcef87cfc2b3f002a6478f38906f9040302c68aebe21468090e39cde1445/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_x86_64.whl": "88ab34806dea0671532d3f82d82b85e8fc23d7b2dd12fa837978dad9bb392a34",
+            "https://files.pythonhosted.org/packages/46/69/9f42514a9f58c602ab89a2af89081a475dccd959f9bc01ba7e61372d31bd/charset_normalizer-3.0.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "c95a03c79bbe30eec3ec2b7f076074f4281526724c8685a42872974ef4d36b72",
+            "https://files.pythonhosted.org/packages/46/6a/d5c26c41c49b546860cc1acabdddf48b0b3fb2685f4f5617ac59261b44ae/charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl": "9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03",
+            "https://files.pythonhosted.org/packages/4c/92/27dbe365d34c68cfe0ca76f1edd70e8705d82b378cb54ebbaeabc2e3029d/charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_ppc64le.whl": "939578d9d8fd4299220161fdd76e86c6a251987476f5243e8864a7844476ba14",
+            "https://files.pythonhosted.org/packages/4e/11/f7077d78b18aca8ea3186a706c0221aa2bc34c442a3d3bdf3ad401a29052/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_aarch64.whl": "ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0",
+            "https://files.pythonhosted.org/packages/4f/18/92866f050f7114ba38aba4f4a69f83cc2a25dc2e5a8af4b44fd1bfd6d528/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl": "74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d",
+            "https://files.pythonhosted.org/packages/4f/7c/af43743567a7da2a069b4f9fa31874c3c02b963cd1fb84fe1e7568a567e6/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_ppc64le.whl": "6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7",
+            "https://files.pythonhosted.org/packages/4f/a2/9031ba4a008e11a21d7b7aa41751290d2f2035a2f14ecb6e589771a17c47/charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_universal2.whl": "e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b",
+            "https://files.pythonhosted.org/packages/4f/d1/d547cc26acdb0cc458b152f79b2679d7422f29d41581e6fa907861e88af1/charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl": "95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c",
+            "https://files.pythonhosted.org/packages/50/10/c117806094d2c956ba88958dab680574019abc0c02bcf57b32287afca544/charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_x86_64.whl": "a2d08ac246bb48479170408d6c19f6385fa743e7157d716e144cad849b2dd94b",
+            "https://files.pythonhosted.org/packages/50/ee/f4704bad8201de513fdc8aac1cabc87e38c5818c93857140e06e772b5892/charset_normalizer-3.4.3-cp312-cp312-win32.whl": "fb6fecfd65564f208cbf0fba07f107fb661bcd1a7c389edbced3f7a493f70e37",
+            "https://files.pythonhosted.org/packages/51/fd/0ee5b1c2860bb3c60236d05b6e4ac240cf702b67471138571dad91bcfed8/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl": "9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458",
+            "https://files.pythonhosted.org/packages/53/cd/aa4b8a4d82eeceb872f83237b2d27e43e637cac9ffaef19a1321c3bafb67/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl": "34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8",
+            "https://files.pythonhosted.org/packages/54/7f/cad0b328759630814fcf9d804bfabaf47776816ad4ef2e9938b7e1123d04/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl": "ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561",
+            "https://files.pythonhosted.org/packages/55/2b/35619e03725bfa4af4a902e1996c9ee8052d6bce005ff79c9bd988820cb4/charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_i686.whl": "31a9ddf4718d10ae04d9b18801bd776693487cbb57d74cc3458a7673f6f34639",
+            "https://files.pythonhosted.org/packages/56/24/5f2dedcf3d0673931b6200c410832ae44b376848bc899dbf1fa6c91c4ebe/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_x86_64.whl": "cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324",
+            "https://files.pythonhosted.org/packages/56/5d/275fb120957dfe5a2262d04f28bc742fd4bcc2bd270d19bb8757e09737ef/charset_normalizer-3.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl": "9cf4e8ad252f7c38dd1f676b46514f92dc0ebeb0db5552f5f403509705e24753",
+            "https://files.pythonhosted.org/packages/57/ec/80c8d48ac8b1741d5b963797b7c0c869335619e13d4744ca2f67fc11c6fc/charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl": "663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
+            "https://files.pythonhosted.org/packages/58/78/a0bc646900994df12e07b4ae5c713f2b3e5998f58b9d3720cce2aa45652f/charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl": "2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f",
+            "https://files.pythonhosted.org/packages/58/a2/0c63d5d7ffac3104b86631b7f2690058c97bf72d3145c0a9cd4fb90c58c2/charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985",
+            "https://files.pythonhosted.org/packages/59/c0/a74f3bd167d311365e7973990243f32c35e7a94e45103125275b9e6c479f/charset_normalizer-3.4.3-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl": "252098c8c7a873e17dd696ed98bbe91dbacd571da4b87df3736768efa7a792e4",
+            "https://files.pythonhosted.org/packages/5a/d8/9e76846e70e729de85ecc6af21edc584a2adfef202dc5f5ae00a02622e3d/charset_normalizer-3.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl": "11b53acf2411c3b09e6af37e4b9005cba376c872503c8f28218c7243582df45d",
+            "https://files.pythonhosted.org/packages/5b/ae/ce2c12fcac59cb3860b2e2d76dc405253a4475436b1861d95fe75bdea520/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl": "efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4",
+            "https://files.pythonhosted.org/packages/5b/e7/5527effca09d873e07e128d3daac7c531203b5105cb4e2956c2b7a8cc41c/charset_normalizer-3.0.1-cp38-cp38-musllinux_1_1_aarch64.whl": "109487860ef6a328f3eec66f2bf78b0b72400280d8f8ea05f69c51644ba6521a",
+            "https://files.pythonhosted.org/packages/5d/2b/4d8c80400c04ae3c8dbc847de092e282b5c7b17f8f9505d68bb3e5815c71/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_ppc64le.whl": "cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb",
+            "https://files.pythonhosted.org/packages/60/f5/4659a4cb3c4ec146bec80c32d8bb16033752574c20b1252ee842a95d1a1e/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl": "1bb60174149316da1c35fa5233681f7c0f9f514509b8e399ab70fea5f17e45c9",
+            "https://files.pythonhosted.org/packages/61/c5/dc3ba772489c453621ffc27e8978a98fe7e41a93e787e5e5bde797f1dddb/charset_normalizer-3.4.3-cp38-cp38-win32.whl": "ec557499516fc90fd374bf2e32349a2887a876fbf162c160e3c01b6849eaf557",
+            "https://files.pythonhosted.org/packages/61/e3/ad9ae58b28482d1069eba1edec2be87701f5dd6fd6024a665020d66677a0/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d",
+            "https://files.pythonhosted.org/packages/61/f1/190d9977e0084d3f1dc169acd060d479bbbc71b90bf3e7bf7b9927dec3eb/charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_aarch64.whl": "96b2b3d1a83ad55310de8c7b4a2d04d9277d5591f40761274856635acc5fcb30",
+            "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
+            "https://files.pythonhosted.org/packages/63/86/9cbd533bd37883d467fcd1bd491b3547a3532d0fbb46de2b99feeebf185e/charset_normalizer-3.4.3-cp39-cp39-win32.whl": "16a8770207946ac75703458e2c743631c79c59c5890c80011d536248f8eaa432",
+            "https://files.pythonhosted.org/packages/64/d1/f9d141c893ef5d4243bc75c130e95af8fd4bc355beff06e9b1e941daad6e/charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_ppc64le.whl": "5b413b0b1bfd94dbf4023ad6945889f374cd24e3f62de58d6bb102c4d9ae534a",
+            "https://files.pythonhosted.org/packages/64/d4/9eb4ff2c167edbbf08cdd28e19078bf195762e9bd63371689cab5ecd3d0d/charset_normalizer-3.4.3-cp311-cp311-win32.whl": "6cf8fd4c04756b6b60146d98cd8a77d0cdae0e1ca20329da2ac85eed779b6849",
+            "https://files.pythonhosted.org/packages/65/1a/7425c952944a6521a9cfa7e675343f83fd82085b8af2b1373a2409c683dc/charset_normalizer-3.4.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": "d0e909868420b7049dafd3a31d45125b31143eec59235311fc4c57ea26a4acd2",
+            "https://files.pythonhosted.org/packages/65/ca/2135ac97709b400c7654b4b764daf5c5567c2da45a30cdd20f9eefe2d658/charset_normalizer-3.4.3-cp313-cp313-macosx_10_13_universal2.whl": "14c2a87c65b351109f6abfc424cab3927b3bdece6f706e4d12faaf3d52ee5efe",
+            "https://files.pythonhosted.org/packages/66/fe/c7d3da40a66a6bf2920cce0f436fa1f62ee28aaf92f412f0bf3b84c8ad6c/charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl": "5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d",
+            "https://files.pythonhosted.org/packages/67/30/dbab1fe5ab2ce5d3d517ad9936170d896e9687f3860a092519f1fe359812/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1",
+            "https://files.pythonhosted.org/packages/67/c6/cf4e8a8f41201284bdf200f764b29a87f6f7d22fe3c9eddab602af489acc/charset_normalizer-3.0.1-cp36-cp36m-musllinux_1_1_i686.whl": "cd6056167405314a4dc3c173943f11249fa0f1b204f8b51ed4bde1a9cd1834dc",
+            "https://files.pythonhosted.org/packages/67/df/660e9665ace7ad711e275194a86cb757fb4d4e513fae5ff3d39573db4984/charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_x86_64.whl": "d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60",
+            "https://files.pythonhosted.org/packages/68/2b/02e9d6a98ddb73fa238d559a9edcc30b247b8dc4ee848b6184c936e99dc0/charset_normalizer-3.0.1-py3-none-any.whl": "7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24",
+            "https://files.pythonhosted.org/packages/68/77/02839016f6fbbf808e8b38601df6e0e66c17bbab76dff4613f7511413597/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl": "802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
+            "https://files.pythonhosted.org/packages/68/77/af702eba147ba963b27eb00832cef6b8c4cb9fcf7404a476993876434b93/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_s390x.whl": "73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd",
+            "https://files.pythonhosted.org/packages/69/22/66351781e668158feef71c5e3b059a79ecc9efc3ef84a45888b0f3a933d5/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f",
+            "https://files.pythonhosted.org/packages/6a/ab/3a00ecbddabe25132c20c1bd45e6f90c537b5f7a0b5bcaba094c4922928c/charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_x86_64.whl": "8499ca8f4502af841f68135133d8258f7b32a53a1d594aa98cc52013fff55678",
+            "https://files.pythonhosted.org/packages/6c/c2/4a583f800c0708dd22096298e49f887b49d9746d0e78bfc1d7e29816614c/charset_normalizer-3.3.2-cp311-cp311-win32.whl": "7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab",
+            "https://files.pythonhosted.org/packages/6d/59/59a3f4d8a59ee270da77f9e954a0e284c9d6884d39ec69d696d9aa5ff2f2/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0",
+            "https://files.pythonhosted.org/packages/6e/a3/997ff79260f76210b1d73463b9081ae7edbf16ff3d611b67f5e72c685cab/charset_normalizer-3.0.1-cp39-cp39-win32.whl": "39cf9ed17fe3b1bc81f33c9ceb6ce67683ee7526e65fde1447c772afc54a1bb8",
+            "https://files.pythonhosted.org/packages/6e/d7/1d4035fcbf7d0f2e89588a142628355d8d1cd652a227acefb9ec85908cd4/charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl": "772b87914ff1152b92a197ef4ea40efe27a378606c39446ded52c8f80f79702e",
+            "https://files.pythonhosted.org/packages/70/99/f1c3bdcfaa9c45b3ce96f70b14f070411366fa19549c1d4832c935d8e2c3/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_x86_64.whl": "18343b2d246dc6761a249ba1fb13f9ee9a2bcd95decc767319506056ea4ad4dc",
+            "https://files.pythonhosted.org/packages/71/11/98a04c3c97dd34e49c7d247083af03645ca3730809a5509443f3c37f7c99/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": "41d1fc408ff5fdfb910200ec0e74abc40387bccb3252f3f27c0676731df2b2c8",
+            "https://files.pythonhosted.org/packages/71/67/79be03bf7ab4198d994c2e8da869ca354487bfa25656b95cf289cf6338a2/charset_normalizer-3.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "16a8663d6e281208d78806dbe14ee9903715361cf81f6d4309944e4d1e59ac5b",
+            "https://files.pythonhosted.org/packages/72/1a/641d5c9f59e6af4c7b53da463d07600a695b9824e20849cb6eea8a627761/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl": "8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa",
+            "https://files.pythonhosted.org/packages/72/2a/aff5dd112b2f14bcc3462c312dce5445806bfc8ab3a7328555da95330e4b/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl": "d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16",
+            "https://files.pythonhosted.org/packages/72/90/667a6bc6abe42fc10adf4cd2c1e1c399d78e653dbac4c8018350843d4ab7/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl": "c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0",
+            "https://files.pythonhosted.org/packages/74/20/8923a06f15eb3d7f6a306729360bd58f9ead1dc39bc7ea8831f4b407e4ae/charset_normalizer-3.3.2-cp38-cp38-win32.whl": "6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25",
+            "https://files.pythonhosted.org/packages/74/5f/361202de730532028458b729781b8435f320e31a622c27f30e25eec80513/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0",
+            "https://files.pythonhosted.org/packages/74/f1/0d9fe69ac441467b737ba7f48c68241487df2f4522dd7246d9426e7c690e/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574",
+            "https://files.pythonhosted.org/packages/74/f1/d0b8385b574f7e086fb6709e104b696707bd3742d54a6caf0cebbb7e975b/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_s390x.whl": "49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce",
+            "https://files.pythonhosted.org/packages/76/ad/516fed8ffaf02e7a01cd6f6e9d101a6dec64d4db53bec89d30802bf30a96/charset_normalizer-3.1.0-cp38-cp38-win32.whl": "12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0",
+            "https://files.pythonhosted.org/packages/77/d9/cbcf1a2a5c7d7856f11e7ac2d782aec12bdfea60d104e60e0aa1c97849dc/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl": "fdabf8315679312cfa71302f9bd509ded4f2f263fb5b765cf1433b39106c3cc9",
+            "https://files.pythonhosted.org/packages/79/66/8946baa705c588521afe10b2d7967300e49380ded089a62d38537264aece/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c",
+            "https://files.pythonhosted.org/packages/7a/03/cbb6fac9d3e57f7e07ce062712ee80d80a5ab46614684078461917426279/charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_aarch64.whl": "d95bfb53c211b57198bb91c46dd5a2d8018b3af446583aab40074bf7988401cb",
+            "https://files.pythonhosted.org/packages/7b/ef/5eb105530b4da8ae37d506ccfa25057961b7b63d581def6f99165ea89c7e/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl": "8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d",
+            "https://files.pythonhosted.org/packages/7d/a8/c6ec5d389672521f644505a257f50544c074cf5fc292d5390331cd6fc9c3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": "0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884",
+            "https://files.pythonhosted.org/packages/7e/61/19b36f4bd67f2793ab6a99b979b4e4f3d8fc754cbdffb805335df4337126/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_ppc64le.whl": "53cd68b185d98dde4ad8990e56a58dea83a4162161b1ea9272e5c9182ce415e0",
+            "https://files.pythonhosted.org/packages/7e/95/42aa2156235cbc8fa61208aded06ef46111c4d3f0de233107b3f38631803/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": "416175faf02e4b0810f1f38bcb54682878a4af94059a1cd63b8747244420801f",
+            "https://files.pythonhosted.org/packages/7f/b5/991245018615474a60965a7c9cd2b4efbaabd16d582a5547c47ee1c7730b/charset_normalizer-3.4.3-cp311-cp311-macosx_10_9_universal2.whl": "b256ee2e749283ef3ddcff51a675ff43798d92d746d1a6e4631bf8c707d22d0b",
+            "https://files.pythonhosted.org/packages/80/54/183163f9910936e57a60ee618f4f5cc91c2f8333ee2d4ebc6c50f6c8684d/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_s390x.whl": "4a8fcf28c05c1f6d7e177a9a46a1c52798bfe2ad80681d275b10dcf317deaf0b",
+            "https://files.pythonhosted.org/packages/81/b2/160893421adfa3c45554fb418e321ed342bb10c0a4549e855b2b2a3699cb/charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8",
+            "https://files.pythonhosted.org/packages/82/10/0fd19f20c624b278dddaf83b8464dcddc2456cb4b02bb902a6da126b87a1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl": "3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392",
+            "https://files.pythonhosted.org/packages/82/49/ab81421d5aa25bc8535896a017c93204cb4051f2a4e72b1ad8f3b594e072/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_x86_64.whl": "761e8904c07ad053d285670f36dd94e1b6ab7f16ce62b9805c475b7aa1cffde6",
+            "https://files.pythonhosted.org/packages/82/b9/51b66a647be8685dee75b7807e0f750edf5c1e4f29bc562ad285c501e3c7/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl": "d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c",
+            "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz": "6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14",
+            "https://files.pythonhosted.org/packages/84/0e/5965dd90991e4f2588718b865115a78c8b040193ac3676f757b7fb6af9d0/charset_normalizer-3.0.1-cp311-cp311-win32.whl": "71140351489970dfe5e60fc621ada3e0f41104a5eddaca47a7acb3c1b851d6d3",
+            "https://files.pythonhosted.org/packages/84/23/f60cda6c70ae922ad78368982f06e7fef258fba833212f26275fe4727dc4/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_s390x.whl": "dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84",
+            "https://files.pythonhosted.org/packages/84/ff/78a4942ef1ea4d1c464cc9a132122b36c5390c5cf6301ed0f9e3e6e24bd9/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "8ac7b6a045b814cf0c47f3623d21ebd88b3e8cf216a14790b455ea7ff0135d18",
+            "https://files.pythonhosted.org/packages/85/9a/d891f63722d9158688de58d050c59dc3da560ea7f04f4c53e769de5140f5/charset_normalizer-3.4.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl": "74d77e25adda8581ffc1c720f1c81ca082921329452eba58b16233ab1842141c",
+            "https://files.pythonhosted.org/packages/85/e8/18d408d8fe29a56012c10d6b15960940b83f06620e9d7481581cdc6d9901/charset_normalizer-3.1.0-cp311-cp311-macosx_11_0_arm64.whl": "f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
+            "https://files.pythonhosted.org/packages/86/9e/f552f7a00611f168b9a5865a1414179b2c6de8235a4fa40189f6f79a1753/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl": "30d006f98569de3459c2fc1f2acde170b7b2bd265dc1943e87e1a4efe1b67c31",
+            "https://files.pythonhosted.org/packages/86/eb/31c9025b4ed7eddd930c5f2ac269efb953de33140608c7539675d74a2081/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_ppc64le.whl": "5995f0164fa7df59db4746112fec3f49c461dd6b31b841873443bdb077c13cfc",
+            "https://files.pythonhosted.org/packages/87/5d/0ebaee2249a04fd20bb4baeb9ea2c29dee17317175d9d67b4f5f34cf048d/charset_normalizer-3.0.1-cp38-cp38-win_amd64.whl": "e62164b50f84e20601c1ff8eb55620d2ad25fb81b59e3cd776a1902527a788af",
+            "https://files.pythonhosted.org/packages/87/df/b7737ff046c974b183ea9aa111b74185ac8c3a326c6262d413bd5a1b8c69/charset_normalizer-3.4.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": "0e78314bdc32fa80696f72fa16dc61168fda4d6a0c014e0380f9d02f0e5d8a07",
+            "https://files.pythonhosted.org/packages/89/87/c237a299a658b35d19fd531eeb8247480627fc2fb4b7a471334b48850f45/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_i686.whl": "f9d0c5c045a3ca9bedfc35dca8526798eb91a07aa7a2c0fee134c6c6f321cbd7",
+            "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl": "ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a",
+            "https://files.pythonhosted.org/packages/8d/b7/9e95102e9a8cce6654b85770794b582dda2921ec1fd924c10fbcf215ad31/charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl": "87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c",
+            "https://files.pythonhosted.org/packages/8e/91/b5a06ad970ddc7a0e513112d40113e834638f4ca1120eb727a249fb2715e/charset_normalizer-3.4.3-cp314-cp314-macosx_10_13_universal2.whl": "3cd35b7e8aedeb9e34c41385fda4f73ba609e561faedfae0a9e75e44ac558a15",
+            "https://files.pythonhosted.org/packages/8f/e2/73ea48d2608f71a879588b607e093d550b8eaa177eb31bbdf1c01e515818/charset_normalizer-3.0.1-cp36-cp36m-musllinux_1_1_s390x.whl": "f5057856d21e7586765171eac8b9fc3f7d44ef39425f85dbcccb13b3ebea806c",
+            "https://files.pythonhosted.org/packages/90/2c/bb5e4f7e2e9871793b5c0fb5c6c4056458a148a05143143320f2d4a410a9/charset_normalizer-3.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl": "59e5686dd847347e55dffcc191a96622f016bc0ad89105e24c14e0d6305acbc6",
+            "https://files.pythonhosted.org/packages/90/59/941e2e5ae6828a688c6437ad16e026eb3606d0cfdd13ea5c9090980f3ffd/charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl": "a8d0fc946c784ff7f7c3742310cc8a57c5c6dc31631269876a88b809dbeff3d3",
+            "https://files.pythonhosted.org/packages/91/33/749df346e93d7a30cdcb90cbfdd41a06026317bfbfb62cd68307c1a3c543/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389",
+            "https://files.pythonhosted.org/packages/91/95/e2cfa7ce962e6c4b59a44a6e19e541c3a0317e543f0e0923f844e8d7d21d/charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl": "c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711",
+            "https://files.pythonhosted.org/packages/92/00/b8dc8dd725297b05f1ab4929c9d7e879f31746131534221c5c8948bc7563/charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_s390x.whl": "12db3b2c533c23ab812c2b25934f60383361f8a376ae272665f8e48b88e8e1c6",
+            "https://files.pythonhosted.org/packages/93/d1/569445a704414e150f198737c245ab96b40d28d5b68045a62c414a5157de/charset_normalizer-3.0.1-cp37-cp37m-musllinux_1_1_ppc64le.whl": "02a51034802cbf38db3f89c66fb5d2ec57e6fe7ef2f4a44d070a593c3688667b",
+            "https://files.pythonhosted.org/packages/94/70/23981e7bf098efbc4037e7c66d28a10e950d9296c08c6dea8ef290f9c79e/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e",
+            "https://files.pythonhosted.org/packages/96/d7/1675d9089a1f4677df5eb29c3f8b064aa1e70c1251a0a8a127803158942d/charset-normalizer-3.0.1.tar.gz": "ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f",
+            "https://files.pythonhosted.org/packages/96/fc/0cae31c0f150cd1205a2a208079de865f69a8fd052a98856c40c99e36b3c/charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl": "86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99",
+            "https://files.pythonhosted.org/packages/97/f9/366db2d2cf69d641159d6448b813ac9b1b5f9807a46fde6c50b36c1387f8/charset_normalizer-3.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "93ad6d87ac18e2a90b0fe89df7c65263b9a99a0eb98f0a3d2e079f12a0735837",
+            "https://files.pythonhosted.org/packages/98/69/5d8751b4b670d623aa7a47bef061d69c279e9f922f6705147983aa76c3ce/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796",
+            "https://files.pythonhosted.org/packages/98/e4/d4685870fda1cc7c5e29899ec329500460418e54f4f5df76ee520e30689a/charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_x86_64.whl": "c512accbd6ff0270939b9ac214b84fb5ada5f0409c44298361b2f5e13f9aed9e",
+            "https://files.pythonhosted.org/packages/98/f4/5ca33ee1e0b3412cbd13eae230321a9fe819acf1a99ad6482420fb97cc6b/charset_normalizer-3.0.1-cp310-cp310-win_amd64.whl": "601f36512f9e28f029d9481bdaf8e89e5148ac5d89cffd3b05cd533eeb423b59",
+            "https://files.pythonhosted.org/packages/99/04/baae2a1ea1893a01635d475b9261c889a18fd48393634b6270827869fa34/charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_s390x.whl": "fd10de089bcdcd1be95a2f73dbe6254798ec1bda9f450d5828c96f93e2536b9c",
+            "https://files.pythonhosted.org/packages/99/24/eb846dc9a797da58e6e5b3b5a71d3ff17264de3f424fb29aaa5d27173b55/charset_normalizer-3.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "3b590df687e3c5ee0deef9fc8c547d81986d9a1b56073d82de008744452d6541",
+            "https://files.pythonhosted.org/packages/99/b0/9c365f6d79a9f0f3c379ddb40a256a67aa69c59609608fe7feb6235896e1/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a",
+            "https://files.pythonhosted.org/packages/9a/8f/ae790790c7b64f925e5c953b924aaa42a243fb778fed9e41f147b2a5715a/charset_normalizer-3.4.3-cp313-cp313-win_amd64.whl": "cf1ebb7d78e1ad8ec2a8c4732c7be2e736f6e5123a4146c5b89c9d1f585f8cef",
+            "https://files.pythonhosted.org/packages/9a/bf/c9fa15ccf216a69aaaa735c961d7fac2a2801a1b01023fe05d194bf076b4/charset_normalizer-3.0.1-cp36-cp36m-win32.whl": "95dea361dd73757c6f1c0a1480ac499952c16ac83f7f5f4f84f0658a01b8ef41",
+            "https://files.pythonhosted.org/packages/9a/f1/ff81439aa09070fee64173e6ca6ce1342f2b1cca997bcaae89e443812684/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl": "c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f",
+            "https://files.pythonhosted.org/packages/9c/42/c1ebc736c57459aab28bfb8aa28c6a047796f2ea46050a3b129b4920dbe4/charset_normalizer-3.0.1-cp38-cp38-macosx_10_9_x86_64.whl": "4b0d02d7102dd0f997580b51edc4cebcf2ab6397a7edf89f1c73b586c614272c",
+            "https://files.pythonhosted.org/packages/9c/94/1725fc3e0dbe8918a4ec6dd317ec1ef388e701bdfb5053e1f34f5c6d5a8e/charset_normalizer-3.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "df2c707231459e8a4028eabcd3cfc827befd635b3ef72eada84ab13b52e1574d",
+            "https://files.pythonhosted.org/packages/9e/62/a1e0a8f8830c92014602c8a88a1a20b8a68d636378077381f671e6e1cec9/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a",
+            "https://files.pythonhosted.org/packages/9e/ef/cd47a63d3200b232792e361cd67530173a09eb011813478b1c0fb8aa7226/charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl": "2127566c664442652f024c837091890cb1942c30937add288223dc895793f898",
+            "https://files.pythonhosted.org/packages/9f/5a/9dc8932d1e5f8eeaa502e3c3fce91c86be20c04eb3ec202d2b7d74b567e5/charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_aarch64.whl": "2edb64ee7bf1ed524a1da60cdcd2e1f6e2b4f66ef7c077680739f1641f62f555",
+            "https://files.pythonhosted.org/packages/a0/98/7b0d3a853af59e092cdd77c7e1c67ca92fd6acc126285240dbb552b4162f/charset_normalizer-3.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "74292fc76c905c0ef095fe11e188a32ebd03bc38f3f3e9bcb85e4e6db177b7ea",
+            "https://files.pythonhosted.org/packages/a0/b1/4e72ef73d68ebdd4748f2df97130e8428c4625785f2b6ece31f555590c2d/charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl": "8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811",
+            "https://files.pythonhosted.org/packages/a0/e4/5a075de8daa3ec0745a9a3b54467e0c2967daaaf2cec04c845f73493e9a1/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": "18b97b8404387b96cdbd30ad660f6407799126d26a39ca65729162fd810a99aa",
+            "https://files.pythonhosted.org/packages/a2/51/e5023f937d7f307c948ed3e5c29c4b7a3e42ed2ee0b8cdf8f3a706089bf0/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl": "6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068",
+            "https://files.pythonhosted.org/packages/a2/6c/5167f08da5298f383036c33cb749ab5b3405fd07853edc8314c6882c01b8/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_s390x.whl": "0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e",
+            "https://files.pythonhosted.org/packages/a2/93/0b1aa4dbc0ae2aa2e1b2e6d037ab8984dc09912d6b26d63ced14da07e3a7/charset_normalizer-3.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl": "a16418ecf1329f71df119e8a65f3aa68004a3f9383821edcb20f0702934d8087",
+            "https://files.pythonhosted.org/packages/a2/a0/4af29e22cb5942488cf45630cbdd7cefd908768e69bdd90280842e4e8529/charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl": "10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09",
+            "https://files.pythonhosted.org/packages/a2/a7/adc963ad8f8fddadd6be088e636972705ec9d1d92d1b45e6119eb02b7e9e/charset_normalizer-3.0.1-cp38-cp38-macosx_11_0_arm64.whl": "358a7c4cb8ba9b46c453b1dd8d9e431452d5249072e4f56cfda3149f6ab1405e",
+            "https://files.pythonhosted.org/packages/a3/09/a837b27b122e710dfad15b0b5df04cd0623c8d8d3382e4298f50798fb84a/charset_normalizer-3.0.1-cp37-cp37m-musllinux_1_1_s390x.whl": "2e396d70bc4ef5325b72b593a72c8979999aa52fb8bcf03f701c1b03e1166918",
+            "https://files.pythonhosted.org/packages/a3/4b/f565c852163312a0991c30598f403fd06796a12e408d7839cc46ca8d7f4a/charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "62595ab75873d50d57323a91dd03e6966eb79c41fa834b7a1661ed043b2d404d",
+            "https://files.pythonhosted.org/packages/a3/ad/b0081f2f99a4b194bcbb1934ef3b12aa4d9702ced80a37026b7607c72e58/charset_normalizer-3.4.3-cp313-cp313-win32.whl": "6fb70de56f1859a3f71261cbe41005f56a7842cc348d3aeb26237560bfa5e0ce",
+            "https://files.pythonhosted.org/packages/a4/03/355281b62c26712a50c6a9dd75339d8cdd58488fd7bf2556ba1320ebd315/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_i686.whl": "1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d",
+            "https://files.pythonhosted.org/packages/a4/fa/384d2c0f57edad03d7bec3ebefb462090d8905b4ff5a2d2525f3bb711fac/charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_s390x.whl": "02425242e96bcf29a49711b0ca9f37e451da7c70562bc10e8ed992a5a7a25cc0",
+            "https://files.pythonhosted.org/packages/a8/31/47d018ef89f95b8aded95c589a77c072c55e94b50a41aa99c0a2008a45a4/charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl": "fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519",
+            "https://files.pythonhosted.org/packages/a8/6f/4ff299b97da2ed6358154b6eb3a2db67da2ae204e53d205aacb18a7e4f34/charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl": "a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99",
+            "https://files.pythonhosted.org/packages/a9/83/138d2624fdbcb62b7e14715eb721d44347e41a1b4c16544661e940793f49/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_x86_64.whl": "53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f",
+            "https://files.pythonhosted.org/packages/aa/a4/2d6255d4db5d4558a92458fd8dacddfdda2fb4ad9c0a87db6f6034aded34/charset_normalizer-3.0.1-cp38-cp38-musllinux_1_1_ppc64le.whl": "f97e83fa6c25693c7a35de154681fcc257c1c41b38beb0304b9c4d2d9e164479",
+            "https://files.pythonhosted.org/packages/ac/7f/62d5dff4e9cb993e4b0d4ea78a74cc84d7d92120879529e0ce0965765936/charset_normalizer-3.1.0-cp39-cp39-macosx_11_0_arm64.whl": "8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f",
+            "https://files.pythonhosted.org/packages/ac/c5/990bc41a98b7fa2677c665737fdf278bb74ad4b199c56b6b564b3d4cbfc5/charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_x86_64.whl": "3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c",
+            "https://files.pythonhosted.org/packages/ad/83/994bfca99e29f1bab66b9248e739360ee70b5aae0a5ee488cd776501edbc/charset_normalizer-3.1.0-cp311-cp311-win_amd64.whl": "cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755",
+            "https://files.pythonhosted.org/packages/ae/02/e29e22b4e02839a0e4a06557b1999d0a47db3567e82989b5bb21f3fbbd9f/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_aarch64.whl": "027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154",
+            "https://files.pythonhosted.org/packages/ae/d5/4fecf1d58bedb1340a50f165ba1c7ddc0400252d6832ff619c4568b36cc0/charset_normalizer-3.3.2-cp310-cp310-win32.whl": "3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73",
+            "https://files.pythonhosted.org/packages/af/63/2c00ff4e657fb9bb76306ffbc7878fd52067e39716f5e8b0dd5582caf1fa/charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "70990b9c51340e4044cfc394a81f614f3f90d41397104d226f21e66de668730d",
+            "https://files.pythonhosted.org/packages/b0/55/d8ef4c8c7d2a8b3a16e7d9b03c59475c2ee96a0e0c90b14c99faaac0ee3b/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_x86_64.whl": "6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8",
+            "https://files.pythonhosted.org/packages/b0/a8/6f5bcf1bcf63cb45625f7c5cadca026121ff8a6c8a3256d8d8cd59302663/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl": "257f26fed7d7ff59921b78244f3cd93ed2af1800ff048c33f624c87475819dd7",
+            "https://files.pythonhosted.org/packages/b2/4c/9a4f30042bfee22d34d80daf75f51817cdd23180d718e0160aab235c4faf/charset_normalizer-3.0.1-cp310-cp310-macosx_10_9_universal2.whl": "88600c72ef7587fe1708fd242b385b6ed4b8904976d5da0893e31df8b3480cb6",
+            "https://files.pythonhosted.org/packages/b2/62/5a5dcb9a71390a9511a253bde19c9c89e0b20118e41080185ea69fb2c209/charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786",
+            "https://files.pythonhosted.org/packages/b3/c1/ebca8e87c714a6a561cfee063f0655f742e54b8ae6e78151f60ba8708b3a/charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl": "06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087",
+            "https://files.pythonhosted.org/packages/b5/1a/932d86fde86bb0d2992c74552c9a422883fe0890132bbc9a5e2211f03318/charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "00d3ffdaafe92a5dc603cb9bd5111aaa36dfa187c8285c543be562e61b755f6b",
+            "https://files.pythonhosted.org/packages/b6/7c/8debebb4f90174074b827c63242c23851bdf00a532489fba57fef3416e40/charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl": "96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001",
+            "https://files.pythonhosted.org/packages/b6/c2/da108d835354b49aa5c738906e9b6a197b071bc5d77d223f6cd98119172a/charset_normalizer-3.0.1-cp310-cp310-win32.whl": "502218f52498a36d6bf5ea77081844017bf7982cdbe521ad85e64cabee1b608b",
+            "https://files.pythonhosted.org/packages/b7/8c/9839225320046ed279c6e839d51f028342eb77c91c89b8ef2549f951f3ec/charset_normalizer-3.4.3-cp314-cp314-win32.whl": "c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce",
+            "https://files.pythonhosted.org/packages/b8/60/e2f67915a51be59d4539ed189eb0a2b0d292bf79270410746becb32bc2c3/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d",
+            "https://files.pythonhosted.org/packages/bb/dc/58fdef3ab85e8e7953a8b89ef1d2c06938b8ad88d9617f22967e1a90e6b8/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c",
+            "https://files.pythonhosted.org/packages/bc/08/7e7c97399806366ca515a049c3a1e4b644a6a2048bed16e5e67bfaafd0aa/charset_normalizer-3.1.0-cp311-cp311-win32.whl": "c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909",
+            "https://files.pythonhosted.org/packages/bc/92/ac692a303e53cdc8852ce72b1ac364b493ca5c9206a5c8db5b30a7f3019c/charset_normalizer-3.1.0-cp39-cp39-win32.whl": "a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1",
+            "https://files.pythonhosted.org/packages/bd/28/7ea29e73eea52c7e15b4b9108d0743fc9e4cc2cdb00d275af1df3d46d360/charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl": "923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04",
+            "https://files.pythonhosted.org/packages/be/4d/9e370f8281cec2fcc9452c4d1ac513324c32957c5f70c73dd2fa8442a21a/charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238",
+            "https://files.pythonhosted.org/packages/c0/4d/6b82099e3f25a9ed87431e2f51156c14f3a9ce8fad73880a3856cd95f1d5/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "14e76c0f23218b8f46c4d87018ca2e441535aed3632ca134b10239dfb6dadd6b",
+            "https://files.pythonhosted.org/packages/c1/06/b7b1d3d186e0f288500b8a1161ede6b38a0abbf878c2033d667e815e6bd7/charset_normalizer-3.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "292d5e8ba896bbfd6334b096e34bffb56161c81408d6d036a7dfa6929cff8783",
+            "https://files.pythonhosted.org/packages/c1/35/6525b21aa0db614cf8b5792d232021dca3df7f90a1944db934efa5d20bb1/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_x86_64.whl": "320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f",
+            "https://files.pythonhosted.org/packages/c1/9d/254a2f1bcb0ce9acad838e94ed05ba71a7cb1e27affaa4d9e1ca3958cdb6/charset_normalizer-3.3.2-cp39-cp39-win32.whl": "aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f",
+            "https://files.pythonhosted.org/packages/c1/b2/d81606aebeb7e9a33dc877ff3a206c9946f5bb374c99d22d4a28825aa270/charset_normalizer-3.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "a60332922359f920193b1d4826953c507a877b523b2395ad7bc716ddd386d866",
+            "https://files.pythonhosted.org/packages/c2/35/dfb4032f5712747d3dcfdd19d0768f6d8f60910ae24ed066ecbf442be013/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_aarch64.whl": "891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203",
+            "https://files.pythonhosted.org/packages/c2/65/52aaf47b3dd616c11a19b1052ce7fa6321250a7a0b975f48d8c366733b9f/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl": "d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c",
+            "https://files.pythonhosted.org/packages/c2/a9/3865b02c56f300a6f94fc631ef54f0a8a29da74fb45a773dfd3dcd380af7/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_aarch64.whl": "6aab0f181c486f973bc7262a97f5aca3ee7e1437011ef0c2ec04b5a11d16c927",
+            "https://files.pythonhosted.org/packages/c2/ca/9a0983dd5c8e9733565cf3db4df2b0a2e9a82659fd8aa2a868ac6e4a991f/charset_normalizer-3.4.3-cp39-cp39-macosx_10_9_universal2.whl": "70bfc5f2c318afece2f5838ea5e4c3febada0be750fcf4775641052bbba14d05",
+            "https://files.pythonhosted.org/packages/c4/72/d3d0e9592f4e504f9dea08b8db270821c909558c353dc3b457ed2509f2fb/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_aarch64.whl": "1ef99f0456d3d46a50945c98de1774da86f8e992ab5c77865ea8b8195341fc19",
+            "https://files.pythonhosted.org/packages/c4/d4/94f1ea460cce04483d2460efba6fd4d66e6f60ad6fc6075dba13e3501e48/charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_i686.whl": "9cb3032517f1627cc012dbc80a8ec976ae76d93ea2b5feaa9d2a5b8882597579",
+            "https://files.pythonhosted.org/packages/c5/35/9c99739250742375167bc1b1319cd1cec2bf67438a70d84b2e1ec4c9daa3/charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_s390x.whl": "b5e3b2d152e74e100a9e9573837aba24aab611d39428ded46f4e4022ea7d1942",
+            "https://files.pythonhosted.org/packages/c6/ab/43ea052756b2f2dcb6a131897811c0e2704b0288f090336217d3346cd682/charset_normalizer-3.1.0-cp310-cp310-macosx_11_0_arm64.whl": "04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1",
+            "https://files.pythonhosted.org/packages/c7/2a/ae245c41c06299ec18262825c1569c5d3298fc920e4ddf56ab011b417efd/charset_normalizer-3.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": "13faeacfe61784e2559e690fc53fa4c5ae97c6fcedb8eb6fb8d0a15b475d2c64",
+            "https://files.pythonhosted.org/packages/c8/a2/8f873138c99423de3b402daf8ccd7a538632c83d0c129444a6a18ef34e03/charset_normalizer-3.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "c22d3fe05ce11d3671297dc8973267daa0f938b93ec716e12e0f6dee81591dc1",
+            "https://files.pythonhosted.org/packages/c8/ce/09d6845504246d95c7443b8c17d0d3911ec5fdc838c3213e16c5e47dee44/charset_normalizer-3.3.2-cp37-cp37m-win32.whl": "db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4",
+            "https://files.pythonhosted.org/packages/c9/7a/6d8767fac16f2c80c7fa9f14e0f53d4638271635c306921844dc0b5fd8a6/charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714",
+            "https://files.pythonhosted.org/packages/c9/8c/a76dd9f2c8803eb147e1e715727f5c3ba0ef39adaadf66a7b3698c113180/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_aarch64.whl": "bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5",
+            "https://files.pythonhosted.org/packages/c9/dd/80a5e8c080b7e1cc2b0ca35f0d6aeedafd7bbd06d25031ac20868b1366d6/charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_ppc64le.whl": "608862a7bf6957f2333fc54ab4399e405baad0163dc9f8d99cb236816db169d4",
+            "https://files.pythonhosted.org/packages/cc/94/f7cf5e5134175de79ad2059edf2adce18e0685ebdb9227ff0139975d0e93/charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl": "06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027",
+            "https://files.pythonhosted.org/packages/cc/f6/21a66e524658bd1dd7b89ac9d1ee8f7823f2d9701a2fbc458ab9ede53c63/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795",
+            "https://files.pythonhosted.org/packages/ce/d6/7e805c8e5c46ff9729c49950acc4ee0aeb55efb8b3a56687658ad10c3216/charset_normalizer-3.4.3-cp39-cp39-win_amd64.whl": "d22dbedd33326a4a5190dd4fe9e9e693ef12160c77382d9e87919bce54f3d4ca",
+            "https://files.pythonhosted.org/packages/ce/ec/1edc30a377f0a02689342f214455c3f6c2fbedd896a1d2f856c002fc3062/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl": "b89bc04de1d83006373429975f8ef9e7932534b8cc9ca582e4db7d20d91816db",
+            "https://files.pythonhosted.org/packages/cf/7c/f3b682fa053cc21373c9a839e6beba7705857075686a05c72e0f8c4980ca/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl": "deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae",
+            "https://files.pythonhosted.org/packages/d1/2f/0d1efd07c74c52b6886c32a3b906fb8afd2fecf448650e73ecb90a5a27f1/charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl": "4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d",
+            "https://files.pythonhosted.org/packages/d1/b2/fcedc8255ec42afee97f9e6f0145c734bbe104aac28300214593eb326f1d/charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl": "0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8",
+            "https://files.pythonhosted.org/packages/d1/ff/51fe7e6446415f143b159740c727850172bc35622b2a06dde3354bdebaf3/charset_normalizer-3.1.0-cp39-cp39-win_amd64.whl": "830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b",
+            "https://files.pythonhosted.org/packages/d2/7f/3c8a6db3eda16ce79a01552ec85ac8fd0ea6265976eb4db250a60b7416ab/charset_normalizer-3.0.1-cp36-cp36m-macosx_10_9_x86_64.whl": "84c3990934bae40ea69a82034912ffe5a62c60bbf6ec5bc9691419641d7d5c9a",
+            "https://files.pythonhosted.org/packages/d3/5b/4031145fcfb9ceaf49dad2fbf9a44e062eb2c08aff36f71d8aafbecf4567/charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "ff6f3db31555657f3163b15a6b7c6938d08df7adbfc9dd13d9d19edad678f1e8",
+            "https://files.pythonhosted.org/packages/d5/92/86c0f0e66e897f6818c46dadef328a5b345d061688f9960fc6ca1fd03dbe/charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl": "6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31",
+            "https://files.pythonhosted.org/packages/d6/98/f3b8013223728a99b908c9344da3aa04ee6e3fa235f19409033eda92fb78/charset_normalizer-3.4.3-cp310-cp310-macosx_10_9_universal2.whl": "fb7f67a1bfa6e40b438170ebdc8158b78dc465a5a67b6dde178a46987b244a72",
+            "https://files.pythonhosted.org/packages/d7/4c/37ad75674e8c6bc22ab01bef673d2d6e46ee44203498c9a26aa23959afe5/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl": "e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1",
+            "https://files.pythonhosted.org/packages/d8/b5/eb705c313100defa57da79277d9207dc8d8e45931035862fa64b625bfead/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl": "e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae",
+            "https://files.pythonhosted.org/packages/d8/ca/a7ff600781bf1e5f702ba26bb82f2ba1d3a873a3f8ad73cc44c79dfaefa9/charset_normalizer-3.1.0-cp38-cp38-macosx_11_0_arm64.whl": "7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14",
+            "https://files.pythonhosted.org/packages/d9/7a/60d45c9453212b30eebbf8b5cddbdef330eebddfcf335bce7920c43fb72e/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "79909e27e8e4fcc9db4addea88aa63f6423ebb171db091fb4373e3312cb6d603",
+            "https://files.pythonhosted.org/packages/da/f1/3702ba2a7470666a62fd81c58a4c40be00670e5006a67f4d626e57f013ae/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5",
+            "https://files.pythonhosted.org/packages/db/fb/d29e343e7c57bbf1231275939f6e75eb740cd47a9d7cb2c52ffeb62ef869/charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl": "eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b",
+            "https://files.pythonhosted.org/packages/dc/ff/2c7655d83b1d6d6a0e132d50d54131fcb8da763b417ccc6c4a506aa0e08c/charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "c2ac1b08635a8cd4e0cbeaf6f5e922085908d48eb05d44c5ae9eabab148512ca",
+            "https://files.pythonhosted.org/packages/dd/39/6276cf5a395ffd39b77dadf0e2fcbfca8dbfe48c56ada250c40086055143/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9",
+            "https://files.pythonhosted.org/packages/dd/51/68b61b90b24ca35495956b718f35a9756ef7d3dd4b3c1508056fa98d1a1b/charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl": "549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
+            "https://files.pythonhosted.org/packages/df/2f/4806e155191f75e720aca98a969581c6b2676f0379dd315c34c388bbf8b5/charset_normalizer-3.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "cadaeaba78750d58d3cc6ac4d1fd867da6fc73c88156b7a3212a3cd4819d679d",
+            "https://files.pythonhosted.org/packages/df/3e/a06b18788ca2eb6695c9b22325b6fde7dde0f1d1838b1792a0076f58fe9d/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed",
+            "https://files.pythonhosted.org/packages/df/c5/dd3a17a615775d0ffc3e12b0e47833d8b7e0a4871431dad87a3f92382a19/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl": "8c7fe7afa480e3e82eed58e0ca89f751cd14d767638e2550c77a92a9e749c317",
+            "https://files.pythonhosted.org/packages/e1/7c/398600268fc98b7e007f5a716bd60903fff1ecff75e45f5700212df5cd76/charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_universal2.whl": "9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19",
+            "https://files.pythonhosted.org/packages/e1/7f/64b51f144fa9e74da63fa690d9563eae627f4df6cc6ae5185a781e1912e5/charset_normalizer-3.0.1-cp310-cp310-macosx_10_9_x86_64.whl": "c75ffc45f25324e68ab238cb4b5c0a38cd1c3d7f1fb1f72b5541de469e2247db",
+            "https://files.pythonhosted.org/packages/e1/9c/60729bf15dc82e3aaf5f71e81686e42e50715a1399770bcde1a9e43d09db/charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl": "7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2",
+            "https://files.pythonhosted.org/packages/e1/b4/53678b2a14e0496fc167fe9b9e726ad33d670cfd2011031aa5caeee6b784/charset_normalizer-3.1.0-cp37-cp37m-macosx_10_9_x86_64.whl": "0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373",
+            "https://files.pythonhosted.org/packages/e1/ef/dd08b2cac9284fd59e70f7d97382c33a3d0a926e45b15fc21b3308324ffd/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_s390x.whl": "511729f456829ef86ac41ca78c63a5cb55240ed23b4b737faca0eb1abb1c41bc",
+            "https://files.pythonhosted.org/packages/e2/c6/f05db471f81af1fa01839d44ae2a8bfeec8d2a8b4590f16c4e7393afd323/charset_normalizer-3.4.3-cp310-cp310-win_amd64.whl": "c6e490913a46fa054e03699c70019ab869e990270597018cef1d8562132c2669",
+            "https://files.pythonhosted.org/packages/e2/e6/63bb0e10f90a8243c5def74b5b105b3bbbfb3e7bb753915fe333fb0c11ea/charset_normalizer-3.4.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl": "585f3b2a80fbd26b048a0be90c5aae8f06605d3c92615911c3a2b03a8a3b796f",
+            "https://files.pythonhosted.org/packages/e3/96/8cdbce165c96cce5f2c9c7748f7ed8e0cf0c5d03e213bbc90b7c3e918bf5/charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "3ae1de54a77dc0d6d5fcf623290af4266412a7c4be0b1ff7444394f03f5c54e3",
+            "https://files.pythonhosted.org/packages/e4/69/132eab043356bba06eb333cc2cc60c6340857d0a2e4ca6dc2b51312886b3/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl": "34a7f768e3f985abdb42841e20e17b330ad3aaf4bb7e7aeeb73db2e70f077b99",
+            "https://files.pythonhosted.org/packages/e4/a6/7ee57823d46331ddc37dd00749c95b0edec2c79b15fc0d6e6efb532e89ac/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f",
+            "https://files.pythonhosted.org/packages/e5/aa/9d2d60d6a566423da96c15cd11cbb88a70f9aff9a4db096094ee19179cab/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_s390x.whl": "abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac",
+            "https://files.pythonhosted.org/packages/e6/98/a3f65f57651da1cecaed91d6f75291995d56c97442fa2a43d2a421139adf/charset_normalizer-3.1.0-cp37-cp37m-win_amd64.whl": "322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23",
+            "https://files.pythonhosted.org/packages/e7/0d/5eaceb5abfc000cca204af9f50e9839462dc0bb1c4e0f4b14ed370e3febd/charset_normalizer-3.0.1-cp39-cp39-win_amd64.whl": "0a11e971ed097d24c534c037d298ad32c6ce81a45736d31e0ff0ad37ab437d59",
+            "https://files.pythonhosted.org/packages/e8/80/141f6af05332cbb811ab469f64deb1e1d4cc9e8b0c003aa8a38d689ce84a/charset_normalizer-3.0.1-cp38-cp38-musllinux_1_1_i686.whl": "37f8febc8ec50c14f3ec9637505f28e58d4f66752207ea177c1d67df25da5aed",
+            "https://files.pythonhosted.org/packages/e9/5e/14c94999e418d9b87682734589404a25854d5f5d0408df68bc15b6ff54bb/charset_normalizer-3.4.3-cp312-cp312-macosx_10_13_universal2.whl": "e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1",
+            "https://files.pythonhosted.org/packages/ea/38/d31c7906c4be13060c1a5034087966774ef33ab57ff2eee76d71265173c3/charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_universal2.whl": "e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531",
+            "https://files.pythonhosted.org/packages/eb/5c/97d97248af4920bc68687d9c3b3c0f47c910e21a8ff80af4565a576bd2f0/charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl": "572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269",
+            "https://files.pythonhosted.org/packages/ed/3a/a448bf035dce5da359daf9ae8a16b8a39623cc395a2ffb1620aa1bce62b0/charset_normalizer-3.3.2-cp312-cp312-win32.whl": "d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7",
+            "https://files.pythonhosted.org/packages/ee/7a/36fbcf646e41f710ce0a563c1c9a343c6edf9be80786edeb15b6f62e17db/charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl": "73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c",
+            "https://files.pythonhosted.org/packages/ee/fb/14d30eb4956408ee3ae09ad34299131fb383c47df355ddb428a7331cfa1e/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b",
+            "https://files.pythonhosted.org/packages/ef/81/14b3b8f01ddaddad6cdec97f2f599aa2fa466bd5ee9af99b08b7713ccd29/charset_normalizer-3.1.0-py3-none-any.whl": "3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d",
+            "https://files.pythonhosted.org/packages/ef/d4/a1d72a8f6aa754fdebe91b848912025d30ab7dced61e9ed8aabbf791ed65/charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl": "6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a",
+            "https://files.pythonhosted.org/packages/f0/78/30d853a3073c866b47abede6d86b5532aa99ac67a95e86077d20be1ce481/charset_normalizer-3.0.1-cp310-cp310-macosx_11_0_arm64.whl": "db72b07027db150f468fbada4d85b3b2729a3db39178abf5c543b784c1254539",
+            "https://files.pythonhosted.org/packages/f0/c9/a2c9c2a355a8594ce2446085e2ec97fd44d323c684ff32042e2a6b718e1d/charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_aarch64.whl": "c6f162aabe9a91a309510d74eeb6507fab5fff92337a15acbe77753d88d9dcf0",
+            "https://files.pythonhosted.org/packages/f1/14/ed5990189a6a25ae9f8d63e74cd0336189f9ad7e51f066ba2f6cb73e8126/charset_normalizer-3.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl": "f4c39b0e3eac288fedc2b43055cfc2ca7a60362d0e5e87a637beac5d801ef478",
+            "https://files.pythonhosted.org/packages/f1/e5/38421987f6c697ee3722981289d554957c4be652f963d71c5e46a262e135/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl": "8dcfc373f888e4fb39a7bc57e93e3b845e7f462dacc008d9749568b1c4ece096",
+            "https://files.pythonhosted.org/packages/f1/ff/9a1c65d8c44958f45ae40cd558ab63bd499a35198a2014e13c0887c07ed1/charset_normalizer-3.0.1-cp38-cp38-musllinux_1_1_s390x.whl": "a152f5f33d64a6be73f1d30c9cc82dfc73cec6477ec268e7c6e4c7d23c2d2291",
+            "https://files.pythonhosted.org/packages/f2/0e/e06bc07ef4673e4d24dc461333c254586bb759fdd075031539bab6514d07/charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl": "c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5",
+            "https://files.pythonhosted.org/packages/f2/b7/e21e16c98575616f4ce09dc766dbccdac0ca119c176b184d46105e971a84/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab",
+            "https://files.pythonhosted.org/packages/f2/d7/6ee92c11eda3f3c9cac1e059901092bfdf07388be7d2e60ac627527eee62/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_i686.whl": "5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1",
+            "https://files.pythonhosted.org/packages/f4/0a/8c03913ed1eca9d831db0c28759edb6ce87af22bb55dbc005a52525a75b6/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_x86_64.whl": "22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a",
+            "https://files.pythonhosted.org/packages/f4/9c/996a4a028222e7761a96634d1820de8a744ff4327a00ada9c8942033089b/charset_normalizer-3.4.3-cp311-cp311-win_amd64.whl": "31a9a6f775f9bcd865d88ee350f0ffb0e25936a7f930ca98995c05abf1faf21c",
+            "https://files.pythonhosted.org/packages/f5/84/cac681144a28114bd9e40d3cdbfd961c14ecc2b56f1baec2094afd6744c7/charset_normalizer-3.0.1-cp39-cp39-macosx_11_0_arm64.whl": "3fc1c4a2ffd64890aebdb3f97e1278b0cc72579a08ca4de8cd2c04799a3a22be",
+            "https://files.pythonhosted.org/packages/f5/ec/a9bed59079bd0267d34ada58a4048c96a59b3621e7f586ea85840d41831d/charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_x86_64.whl": "356541bf4381fa35856dafa6a965916e54bed415ad8a24ee6de6e37deccf2786",
+            "https://files.pythonhosted.org/packages/f6/0f/de1c4030fd669e6719277043e3b0f152a83c118dd1020cf85b51d443d04a/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e",
+            "https://files.pythonhosted.org/packages/f6/42/6f45efee8697b89fda4d50580f292b8f7f9306cb2971d4b53f8914e4d890/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl": "bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5",
+            "https://files.pythonhosted.org/packages/f6/93/bb6cbeec3bf9da9b2eba458c15966658d1daa8b982c642f81c93ad9b40e1/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl": "cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6",
+            "https://files.pythonhosted.org/packages/f6/d3/bfc699ab2c4f9245867060744e8136d359412ff1e5ad93be38a46d160f9d/charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5",
+            "https://files.pythonhosted.org/packages/f7/9d/bcf4a449a438ed6f19790eee543a86a740c77508fbc5ddab210ab3ba3a9a/charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl": "c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4",
+            "https://files.pythonhosted.org/packages/f8/ed/500609cb2457b002242b090c814549997424d72690ef3058cfdfca91f68b/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl": "78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b",
+            "https://files.pythonhosted.org/packages/fa/8e/2e5c742c3082bce3eea2ddd5b331d08050cda458bc362d71c48e07a44719/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_ppc64le.whl": "04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6",
+            "https://files.pythonhosted.org/packages/fc/64/443267b7824283b3e0e33cee4240c079939a970c2c9a5a3164fc988d690b/charset_normalizer-3.0.1-cp37-cp37m-win_amd64.whl": "2c03cc56021a4bd59be889c2b9257dae13bf55041a3372d3295416f86b295fb5",
+            "https://files.pythonhosted.org/packages/fc/eb/a2ffb08547f4e1e5415fb69eb7db25932c52a52bed371429648db4d84fb1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl": "c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018",
+            "https://files.pythonhosted.org/packages/ff/d7/8d757f8bd45be079d76309248845a04f09619a7b17d6dfc8c9ff6433cac2/charset-normalizer-3.1.0.tar.gz": "34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5"
+          },
+          "colorama": {
+            "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+            "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+          },
+          "cryptography": {
+            "https://files.pythonhosted.org/packages/06/b1/6b6f8dccd1432a6a998e92f75ff235b0f69e8a8c509b5739d673ea2ba548/cryptography-39.0.0-cp36-abi3-win32.whl": "f671c1bb0d6088e94d61d80c606d65baacc0d374e67bf895148883461cd848de",
+            "https://files.pythonhosted.org/packages/0d/5c/b83623ce6e7d6653d858d5c85916217bb1e66a4c7a2da7051588fd5d9e0a/cryptography-39.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "6f97109336df5c178ee7c9c711b264c502b905c2d2a29ace99ed761533a3460f",
+            "https://files.pythonhosted.org/packages/0d/bf/e7a1382034c4feaa77b35147138ff2bc8ae47a2fa7e2838fcdd41d2d0f2e/cryptography-41.0.7-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl": "c7f3201ec47d5207841402594f1d7950879ef890c0c495052fa62f58283fde1a",
+            "https://files.pythonhosted.org/packages/12/e3/c46c274cf466b24e5d44df5d5cd31a31ff23e57f074a2bb30931a8c9b01a/cryptography-39.0.0.tar.gz": "f964c7dcf7802d133e8dbd1565914fa0194f9d683d82411989889ecd701e8adf",
+            "https://files.pythonhosted.org/packages/13/56/7ebf13cfd85f2948480a45937bcc43d6f01edfde99dab47443e72aed564a/cryptography-39.0.0-cp36-abi3-macosx_10_12_x86_64.whl": "80ee674c08aaef194bc4627b7f2956e5ba7ef29c3cc3ca488cf15854838a8f72",
+            "https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "841df4caa01008bad253bce2a6f7b47f86dc9f08df4b433c404def869f590a15",
+            "https://files.pythonhosted.org/packages/26/ab/59f271c8f027b8068bbf4dfd6e3ad4c6fc20df0b108ee29c64a1036ba4ce/cryptography-41.0.7-pp310-pypy310_pp73-macosx_10_12_x86_64.whl": "079b85658ea2f59c4f43b70f8119a52414cdb7be34da5d019a77bf96d473b960",
+            "https://files.pythonhosted.org/packages/2c/5d/f9ae5e819dcd2618b2d3e671b22c26b5db1da30414af399e4f624b3fe6cd/cryptography-41.0.7-pp38-pypy38_pp73-macosx_10_12_x86_64.whl": "7a698cb1dac82c35fcf8fe3417a3aaba97de16a01ac914b89a0889d364d2f6be",
+            "https://files.pythonhosted.org/packages/2d/62/7c62efcb4a1b1905ad16476f9dcb55a2913bf4dd0049a083390a622901c8/cryptography-39.0.0-cp36-abi3-musllinux_1_1_x86_64.whl": "f3ed2d864a2fa1666e749fe52fb8e23d8e06b8012e8bd8147c73797c506e86f1",
+            "https://files.pythonhosted.org/packages/2e/90/1fffa1dd2e0894cdd8ef33b7d95de7c4d6de5fb77fb23cd21b24b069047e/cryptography-39.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl": "887cbc1ea60786e534b00ba8b04d1095f4272d380ebd5f7a7eb4cc274710fad9",
+            "https://files.pythonhosted.org/packages/31/9e/30f98ba184be2792f77437607e23b08975ba7876f6a0a0d101df9ff5d180/cryptography-41.0.7-pp310-pypy310_pp73-win_amd64.whl": "d5ec85080cce7b0513cfd233914eb8b7bbd0633f1d1703aa28d1dd5a72f678ec",
+            "https://files.pythonhosted.org/packages/34/b3/3011b5f6c5cc935113fc58f8b07d42fcdd03e7a76b1c3c8ba27d276e8833/cryptography-39.0.0-cp36-abi3-manylinux_2_28_x86_64.whl": "875aea1039d78557c7c6b4db2fe0e9d2413439f4676310a5f269dd342ca7a717",
+            "https://files.pythonhosted.org/packages/3b/37/da734cab133cc0b873d3caa31d73bba2c3cdc8423dc3d443095a87b3b036/cryptography-41.0.7-pp38-pypy38_pp73-win_amd64.whl": "09616eeaef406f99046553b8a40fbf8b1e70795a91885ba4c96a70793de5504a",
+            "https://files.pythonhosted.org/packages/3c/8f/9f5f4d9c00f030e81eda69e689c9777fe665bf34045cec2fd5e71b4859b6/cryptography-41.0.7-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl": "68a2dec79deebc5d26d617bfdf6e8aab065a4f34934b22d3b5010df3ba36612c",
+            "https://files.pythonhosted.org/packages/3e/81/ae2c51ea2b80d57d5756a12df67816230124faea0a762a7a6304fe3c819c/cryptography-41.0.7-cp37-abi3-manylinux_2_28_aarch64.whl": "5429ec739a29df2e29e15d082f1d9ad683701f0ec7709ca479b3ff2708dae65a",
+            "https://files.pythonhosted.org/packages/41/3f/8b3676edb61a9d2dc0e78ba9d450ebb75d958f70ed3dea9cb143262c8406/cryptography-39.0.0-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl": "e5d71c5d5bd5b5c3eebcf7c5c2bb332d62ec68921a8c593bea8c394911a005ce",
+            "https://files.pythonhosted.org/packages/43/7d/0d0756853ad357b7f12d63595a8aac66d255ea68061e3c1983f4cfebc73b/cryptography-39.0.0-pp39-pypy39_pp73-win_amd64.whl": "e0a05aee6a82d944f9b4edd6a001178787d1546ec7c6223ee9a848a7ade92e39",
+            "https://files.pythonhosted.org/packages/44/0a/4170788974aef7baf5eab77947246887c64a0a2c371f769f79259835af89/cryptography-39.0.0-cp36-abi3-win_amd64.whl": "e324de6972b151f99dc078defe8fb1b0a82c6498e37bff335f5bc6b1e3ab5a1e",
+            "https://files.pythonhosted.org/packages/4e/9e/102aae84e2f1c4733ab76fd311d0b4612699daaba04a3a872567274dc211/cryptography-39.0.0-cp36-abi3-manylinux_2_28_aarch64.whl": "bae6c7f4a36a25291b619ad064a30a07110a805d08dc89984f4f441f6c1f3f96",
+            "https://files.pythonhosted.org/packages/54/34/5669347a730ba5f02b89499f03acf4563123fb98b27546d1fadcccf34564/cryptography-39.0.0-pp38-pypy38_pp73-win_amd64.whl": "7dacfdeee048814563eaaec7c4743c8aea529fe3dd53127313a792f0dadc1773",
+            "https://files.pythonhosted.org/packages/54/f4/3eec29ab2fdd673de8f44af3876b32248eb79550ced822363e35da1644d1/cryptography-41.0.7-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl": "b640981bf64a3e978a56167594a0e97db71c89a479da8e175d8bb5be5178c003",
+            "https://files.pythonhosted.org/packages/59/2d/6a6700968097ed41e48bc61405f862ef4e8924d0ab53a40b0e0fec4f0008/cryptography-41.0.7-pp39-pypy39_pp73-win_amd64.whl": "d6c391c021ab1f7a82da5d8d0b3cee2f4b2c455ec86c8aebbc84837a631ff309",
+            "https://files.pythonhosted.org/packages/62/bd/69628ab50368b1beb900eb1de5c46f8137169b75b2458affe95f2f470501/cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl": "43f2552a2378b44869fe8827aa19e69512e3245a219104438692385b0ee119d1",
+            "https://files.pythonhosted.org/packages/68/bb/475658ea92653a894589e657d6cea9ae01354db73405d62126ac5e74e2f8/cryptography-41.0.7-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "5a1b41bc97f1ad230a41657d9155113c7521953869ae57ac39ac7f1bb471469a",
+            "https://files.pythonhosted.org/packages/78/23/ca3a4d7cb681fb4b7f9a088e7392f0aa2c1a51017a8a23fff377bb155af7/cryptography-39.0.0-cp36-abi3-macosx_10_12_universal2.whl": "c52a1a6f81e738d07f43dab57831c29e57d21c81a942f4602fac7ee21b27f288",
+            "https://files.pythonhosted.org/packages/79/68/9767a3fb985515d3c34221c3671043cda57b1f691046ad8aae355fb2a8a5/cryptography-41.0.7-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl": "c5ca78485a255e03c32b513f8c2bc39fedb7f5c5f8535545bdc223a03b24f248",
+            "https://files.pythonhosted.org/packages/7a/46/8b58d6b8244ff613ecb983b9428d1168dd0b014a34e13fb19737b9ba1fc1/cryptography-39.0.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "1a6915075c6d3a5e1215eab5d99bcec0da26036ff2102a1038401d6ef5bef25b",
+            "https://files.pythonhosted.org/packages/a9/76/d705397d076fcbf5671544eb72a70b5a5ac83462d23dbd2a365a3bf3692a/cryptography-41.0.7-cp37-abi3-macosx_10_12_x86_64.whl": "928258ba5d6f8ae644e764d0f996d61a8777559f72dfeb2eea7e2fe0ad6e782d",
+            "https://files.pythonhosted.org/packages/b3/f6/ee2cd6c13d62ecd4f93722327b5f79808d4a243d6d86e6c1058fe361dc68/cryptography-39.0.0-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl": "407cec680e811b4fc829de966f88a7c62a596faa250fc1a4b520a0355b9bc190",
+            "https://files.pythonhosted.org/packages/b4/68/1857c44826171a995e65a11d4b507cd0aa0bace926c2842d7252d8b1dcca/cryptography-39.0.0-cp36-abi3-musllinux_1_1_aarch64.whl": "f6c0db08d81ead9576c4d94bbb27aed8d7a430fa27890f39084c2d0e2ec6b0df",
+            "https://files.pythonhosted.org/packages/b6/4a/1808333c5ea79cb6d51102036cbcf698704b1fc7a5ccd139957aeadd2311/cryptography-41.0.7-cp37-abi3-musllinux_1_1_aarch64.whl": "af03b32695b24d85a75d40e1ba39ffe7db7ffcb099fe507b39fd41a565f1b157",
+            "https://files.pythonhosted.org/packages/b9/19/75d3e8b9b814c09eef76899fea542473273311ab9bfaa1ca4e22c112e660/cryptography-41.0.7-pp39-pypy39_pp73-macosx_10_12_x86_64.whl": "48a0476626da912a44cc078f9893f292f0b3e4c739caf289268168d8f4702a39",
+            "https://files.pythonhosted.org/packages/c5/07/826d66b6b03c5bfde8b451bea22c41e68d60aafff0ffa02c5f0819844319/cryptography-41.0.7-cp37-abi3-musllinux_1_1_x86_64.whl": "49f0805fc0b2ac8d4882dd52f4a3b935b210935d500b6b805f321addc8177406",
+            "https://files.pythonhosted.org/packages/c9/46/c488acbc62aedb14c1082c31bd5062caf8881530e97d2443ce33589f2053/cryptography-41.0.7-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl": "37a138589b12069efb424220bf78eac59ca68b95696fc622b6ccc1c0a197204a",
+            "https://files.pythonhosted.org/packages/ce/b3/13a12ea7edb068de0f62bac88a8ffd92cc2901881b391839851846b84a81/cryptography-41.0.7.tar.gz": "13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc",
+            "https://files.pythonhosted.org/packages/d0/8a/5c567f8a6f12966c46d6f884d259ddf4f8ae908272e8c7c0807a53cdc255/cryptography-39.0.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "1ee1fd0de9851ff32dbbb9362a4d833b579b4a6cc96883e8e6d2ff2a6bc7104f",
+            "https://files.pythonhosted.org/packages/dc/05/2cee803d6b83fef95229f9864646ba399f1ebda03333e34c2ddee210aaa1/cryptography-39.0.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl": "844ad4d7c3850081dffba91cdd91950038ee4ac525c575509a42d3fc806b83c8",
+            "https://files.pythonhosted.org/packages/e4/73/5461318abd2fe426855a2f66775c063bbefd377729ece3c3ee048ddf19a5/cryptography-41.0.7-cp37-abi3-macosx_10_12_universal2.whl": "3c78451b78313fa81607fa1b3f1ae0a5ddd8014c38a02d9db0616133987b9cdf",
+            "https://files.pythonhosted.org/packages/e5/9e/ed757a5244649d3400d62967d247af10e85d804882ba56fdf164c3f0c575/cryptography-39.0.0-pp38-pypy38_pp73-macosx_10_12_x86_64.whl": "754978da4d0457e7ca176f58c57b1f9de6556591c19b25b8bcce3c77d314f5eb",
+            "https://files.pythonhosted.org/packages/ee/9f/f9f4e4410e1945550883bc07afc32986dc1e5d59bc327aff88f0ddbf0fb7/cryptography-39.0.0-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl": "fec8b932f51ae245121c4671b4bbc030880f363354b2f0e0bd1366017d891458",
+            "https://files.pythonhosted.org/packages/f3/4f/11b739e95598db236013cc9efb4e3d02b51dd0861c85470c3fe42720ef5b/cryptography-41.0.7-cp37-abi3-win32.whl": "f983596065a18a2183e7f79ab3fd4c475205b839e02cbc0efbbf9666c4b3083d",
+            "https://files.pythonhosted.org/packages/f4/2b/96fd47dff43cdeb3e24e962fec9ed6ffa1369320146eb95524088265fa00/cryptography-41.0.7-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl": "e3114da6d7f95d2dee7d3f4eec16dacff819740bbab931aff8648cb13c5ff5e7",
+            "https://files.pythonhosted.org/packages/f6/23/b28f4a03650512efff13a8fcbb977bac178a765c5a887a6720bee13fa85b/cryptography-41.0.7-cp37-abi3-win_amd64.whl": "90452ba79b8788fa380dfb587cca692976ef4e757b194b093d845e8d99f612f2",
+            "https://files.pythonhosted.org/packages/fa/31/52ccfb7147564fefe83fdbbebc9dbd4c6749663c019a053ab2c83469c47a/cryptography-39.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "50386acb40fbabbceeb2986332f0287f50f29ccf1497bae31cf5c3e7b4f4b34f",
+            "https://files.pythonhosted.org/packages/fc/b2/3b946e24de214fc49adeefeea6214bcbc4bce2bd745877f074d1dd13c9a2/cryptography-39.0.0-cp36-abi3-manylinux_2_24_x86_64.whl": "76c24dd4fd196a80f9f2f5405a778a8ca132f16b10af113474005635fe7e066c",
+            "https://files.pythonhosted.org/packages/fd/59/bacaaed27787b87b660b7de016e1034a9bf2aaf5031d2b7d085cd83413f3/cryptography-39.0.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl": "ad04f413436b0781f20c52a661660f1e23bcd89a0e9bb1d6d20822d048cf2856"
+          },
+          "deprecated": {
+            "https://files.pythonhosted.org/packages/20/8d/778b7d51b981a96554f29136cd59ca7880bf58094338085bcf2a979a0e6a/Deprecated-1.2.14-py2.py3-none-any.whl": "6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c",
+            "https://files.pythonhosted.org/packages/92/14/1e41f504a246fc224d2ac264c227975427a85caf37c3979979edb9b1b232/Deprecated-1.2.14.tar.gz": "e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"
+          },
+          "docutils": {
+            "https://files.pythonhosted.org/packages/1f/53/a5da4f2c5739cf66290fac1431ee52aff6851c7c8ffd8264f13affd7bcdd/docutils-0.20.1.tar.gz": "f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b",
+            "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl": "96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
+            "https://files.pythonhosted.org/packages/4a/c0/89fe6215b443b919cb98a5002e107cb5026854ed1ccb6b5833e0768419d1/docutils-0.22.2.tar.gz": "9fdb771707c8784c8f2728b67cb2c691305933d68137ef95a75db5f4dfbc213d",
+            "https://files.pythonhosted.org/packages/57/b1/b880503681ea1b64df05106fc7e3c4e3801736cf63deffc6fa7fc5404cf5/docutils-0.18.1.tar.gz": "679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06",
+            "https://files.pythonhosted.org/packages/66/dd/f95350e853a4468ec37478414fc04ae2d61dad7a947b3015c3dcc51a09b9/docutils-0.22.2-py3-none-any.whl": "b0e98d679283fc3bb0ead8a5da7f501baa632654e7056e9c5846842213d674d8",
+            "https://files.pythonhosted.org/packages/6b/5c/330ea8d383eb2ce973df34d1239b3b21e91cd8c865d21ff82902d952f91f/docutils-0.19.tar.gz": "33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
+            "https://files.pythonhosted.org/packages/8d/14/69b4bad34e3f250afe29a854da03acb6747711f3df06c359fa053fae4e76/docutils-0.18.1-py2.py3-none-any.whl": "23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c",
+            "https://files.pythonhosted.org/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl": "5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"
+          },
+          "idna": {
+            "https://files.pythonhosted.org/packages/4b/2a/0276479a4b3caeb8a8c1af2f8e4355746a97fab05a372e4a2c6a6b876165/idna-2.7-py2.py3-none-any.whl": "156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+            "https://files.pythonhosted.org/packages/65/c4/80f97e9c9628f3cac9b98bfca0402ede54e0563b56482e3e6e45c43c4935/idna-2.7.tar.gz": "684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16",
+            "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+            "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz": "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+            "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+            "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+          },
+          "imagesize": {
+            "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz": "69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a",
+            "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl": "0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"
+          },
+          "importlib-metadata": {
+            "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl": "e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd",
+            "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+            "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz": "d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000",
+            "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
+            "https://files.pythonhosted.org/packages/e2/d8/3d431bade4598ad9e33be9da41d15e6607b878008e922d122659ab01b077/importlib_metadata-6.1.0.tar.gz": "43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20",
+            "https://files.pythonhosted.org/packages/f8/7d/e3adad613703c86d62aa991b45d6f090cf59975078a8c8100b50a0c86948/importlib_metadata-6.1.0-py3-none-any.whl": "ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09"
+          },
+          "importlib-resources": {
+            "https://files.pythonhosted.org/packages/2e/f8/be5c59ff2545362397cbc989f5cd3835326fc4092433d50dfaf21616bc71/importlib_resources-5.10.2.tar.gz": "e4a96c8cc0339647ff9a5e0550d9f276fc5a01ffa276012b58ec108cfd7b8484",
+            "https://files.pythonhosted.org/packages/be/0f/bd3e7fa47cc43276051c557d3b2fe946664781d2ecf08b05d074e1a3ee59/importlib_resources-5.10.2-py3-none-any.whl": "7d543798b0beca10b6a01ac7cafda9f822c54db9e8376a6bf57e0cbd74d486b6"
+          },
+          "jaraco-classes": {
+            "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz": "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd",
+            "https://files.pythonhosted.org/packages/60/28/220d3ae0829171c11e50dded4355d17824d60895285631d7eb9dee0ab5e5/jaraco.classes-3.2.3-py3-none-any.whl": "2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158",
+            "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl": "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790",
+            "https://files.pythonhosted.org/packages/bf/02/a956c9bfd2dfe60b30c065ed8e28df7fcf72b292b861dca97e951c145ef6/jaraco.classes-3.2.3.tar.gz": "89559fa5c1d3c34eff6f631ad80bb21f378dbcbb35dd161fd2c6b93f5be2f98a"
+          },
+          "jaraco-context": {
+            "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz": "9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3",
+            "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl": "f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4"
+          },
+          "jaraco-functools": {
+            "https://files.pythonhosted.org/packages/b4/09/726f168acad366b11e420df31bf1c702a54d373a83f968d94141a8c3fde0/jaraco_functools-4.3.0-py3-none-any.whl": "227ff8ed6f7b8f62c56deff101545fa7543cf2c8e7b82a7c2116e672f29c26e8",
+            "https://files.pythonhosted.org/packages/f7/ed/1aa2d585304ec07262e1a83a9889880701079dde796ac7b1d1826f40c63d/jaraco_functools-4.3.0.tar.gz": "cfd13ad0dd2c47a3600b439ef72d8615d482cedcff1632930d6f28924d92f294"
+          },
+          "jeepney": {
+            "https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl": "c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755",
+            "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz": "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806"
+          },
+          "jinja2": {
+            "https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl": "7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa",
+            "https://files.pythonhosted.org/packages/7a/ff/75c28576a1d900e87eb6335b063fab47a8ef3c8b4d88524c4bf78f670cce/Jinja2-3.1.2.tar.gz": "31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
+            "https://files.pythonhosted.org/packages/b2/5e/3a21abf3cd467d7876045335e681d276ac32492febe6d98ad89562d1a7e1/Jinja2-3.1.3.tar.gz": "ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90",
+            "https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl": "6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
+          },
+          "keyring": {
+            "https://files.pythonhosted.org/packages/55/fe/282f4c205add8e8bb3a1635cbbac59d6def2e0891b145aa553a0e40dd2d0/keyring-23.13.1.tar.gz": "ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678",
+            "https://files.pythonhosted.org/packages/62/db/0e9a09b2b95986dcd73ac78be6ed2bd73ebe8bac65cba7add5b83eb9d899/keyring-23.13.1-py3-none-any.whl": "771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd",
+            "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz": "0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66",
+            "https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl": "552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd"
+          },
+          "markdown-it-py": {
+            "https://files.pythonhosted.org/packages/33/e9/ac8a93e9eda3891ecdfecf5e01c060bbd2c44d4e3e77efc83b9c7ce9db32/markdown-it-py-2.1.0.tar.gz": "cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da",
+            "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz": "cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3",
+            "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl": "87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147",
+            "https://files.pythonhosted.org/packages/f9/3f/ecd1b708973b9a3e4574b43cffc1ce8eb98696da34f1a1c44a68c3c0d737/markdown_it_py-2.1.0-py3-none-any.whl": "93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27"
+          },
+          "markupsafe": {
+            "https://files.pythonhosted.org/packages/02/2c/18d55e5df6a9ea33709d6c33e08cb2e07d39e20ad05d8c6fbf9c9bcafd54/MarkupSafe-2.1.2-cp310-cp310-win_amd64.whl": "835fb5e38fd89328e9c81067fd642b3593c33e1e17e2fdbf77f5676abb14a156",
+            "https://files.pythonhosted.org/packages/03/06/e72e88f81f8c91d4f488d21712d2d403fd644e3172eaadc302094377bc22/MarkupSafe-2.1.3-cp38-cp38-macosx_10_9_universal2.whl": "2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
+            "https://files.pythonhosted.org/packages/03/65/3473d2cb84bb2cda08be95b97fc4f53e6bcd701a2d50ba7b7c905e1e9273/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl": "ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
+            "https://files.pythonhosted.org/packages/04/cf/9464c3c41b7cdb8df660cda75676697e7fb49ce1be7691a1162fc88da078/MarkupSafe-2.1.2-cp311-cp311-musllinux_1_1_i686.whl": "085fd3201e7b12809f9e6e9bc1e5c96a368c8523fad5afb02afe3c051ae4afcc",
+            "https://files.pythonhosted.org/packages/06/3b/d026c21cd1dbee89f41127e93113dcf5fa85c6660d108847760b59b3a66d/MarkupSafe-2.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "40dfd3fefbef579ee058f139733ac336312663c6706d1163b82b3003fb1925c4",
+            "https://files.pythonhosted.org/packages/0a/88/78cb3d95afebd183d8b04442685ab4c70cfc1138b850ba20e2a07aff2f53/MarkupSafe-2.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "65608c35bfb8a76763f37036547f7adfd09270fbdbf96608be2bead319728fcd",
+            "https://files.pythonhosted.org/packages/0d/15/82b108c697bec4c26c00aed6975b778cf0eac6cbb77598862b10550b7fcc/MarkupSafe-2.1.2-cp38-cp38-musllinux_1_1_x86_64.whl": "2298c859cfc5463f1b64bd55cb3e602528db6fa0f3cfd568d3605c50678f8f03",
+            "https://files.pythonhosted.org/packages/10/b3/c2b0a61cc0e1d50dd8a1b663ba4866c667cb58fb35f12475001705001680/MarkupSafe-2.1.3-cp38-cp38-win32.whl": "ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5",
+            "https://files.pythonhosted.org/packages/11/40/ea7f85e2681d29bc9301c757257de561923924f24de1802d9c3baa396bb4/MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl": "14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c",
+            "https://files.pythonhosted.org/packages/12/b3/d9ed2c0971e1435b8a62354b18d3060b66c8cb1d368399ec0b9baa7c0ee5/MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52",
+            "https://files.pythonhosted.org/packages/19/00/3b8eb0093c885576a1ce7f2263e7b8c01e55b9977433f8246f57cd81b0be/MarkupSafe-2.1.2-cp311-cp311-win32.whl": "7df70907e00c970c60b9ef2938d894a9381f38e6b9db73c5be35e59d92e06625",
+            "https://files.pythonhosted.org/packages/1f/20/76f6337f1e7238a626ab34405ddd634636011b2ff947dcbd8995f16a7776/MarkupSafe-2.1.2-cp311-cp311-musllinux_1_1_x86_64.whl": "1bea30e9bf331f3fef67e0a3877b2288593c98a21ccb2cf29b74c581a4eb3af0",
+            "https://files.pythonhosted.org/packages/20/1d/713d443799d935f4d26a4f1510c9e61b1d288592fb869845e5cc92a1e055/MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_universal2.whl": "cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa",
+            "https://files.pythonhosted.org/packages/22/81/b5659e2b6ae1516495a22f87370419c1d79c8d853315e6cbe5172fc01a06/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_i686.whl": "7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
+            "https://files.pythonhosted.org/packages/22/88/9c0cae2f5ada778182f2842b377dd273d6be689953345c10b165478831eb/MarkupSafe-2.1.2-cp39-cp39-win32.whl": "137678c63c977754abe9086a3ec011e8fd985ab90631145dfb9294ad09c102a7",
+            "https://files.pythonhosted.org/packages/29/d2/243e6b860d97c18d848fc2bee2f39d102755a2b04a5ce4d018d839711b46/MarkupSafe-2.1.2-cp38-cp38-musllinux_1_1_i686.whl": "8db032bf0ce9022a8e41a22598eefc802314e81b879ae093f36ce9ddf39ab1ba",
+            "https://files.pythonhosted.org/packages/30/3e/0a69a24adb38df83e2f6989c38d68627a5f27181c82ecaa1fd03d1236dca/MarkupSafe-2.1.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "ca244fa73f50a800cf8c3ebf7fd93149ec37f5cb9596aa8873ae2c1d23498601",
+            "https://files.pythonhosted.org/packages/32/d4/ce98c4ca713d91c4a17c1a184785cc00b9e9c25699d618956c2b9999500a/MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_i686.whl": "df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
+            "https://files.pythonhosted.org/packages/34/19/64b0abc021b22766e86efee32b0e2af684c4b731ce8ac1d519c791800c13/MarkupSafe-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl": "340bea174e9761308703ae988e982005aedf427de816d1afe98147668cc03036",
+            "https://files.pythonhosted.org/packages/37/b2/6f4d5cac75ba6fe9f17671304fe339ea45a73c5609b5f5e652aa79c915c8/MarkupSafe-2.1.2-cp310-cp310-macosx_10_9_universal2.whl": "665a36ae6f8f20a4676b53224e33d456a6f5a72657d9c83c2aa00765072f31f7",
+            "https://files.pythonhosted.org/packages/39/8d/5c5ce72deb8567ab48a18fbd99dc0af3dd651b6691b8570947e54a28e0f3/MarkupSafe-2.1.2-cp37-cp37m-win_amd64.whl": "6d6607f98fcf17e534162f0709aaad3ab7a96032723d8ac8750ffe17ae5a0666",
+            "https://files.pythonhosted.org/packages/3a/72/9f683a059bde096776e8acf9aa34cbbba21ddc399861fe3953790d4f2cde/MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl": "aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823",
+            "https://files.pythonhosted.org/packages/3c/c8/74d13c999cbb49e3460bf769025659a37ef4a8e884de629720ab4e42dcdb/MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_x86_64.whl": "c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7",
+            "https://files.pythonhosted.org/packages/3d/66/2f636ba803fd6eb4cee7b3106ae02538d1e84a7fb7f4f8775c6528a87d31/MarkupSafe-2.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "28057e985dace2f478e042eaa15606c7efccb700797660629da387eb289b9323",
+            "https://files.pythonhosted.org/packages/41/54/6e88795c64ab5dcda31b06406c062c2740d1a64db18219d4e21fc90928c1/MarkupSafe-2.1.2-cp39-cp39-musllinux_1_1_i686.whl": "c0a33bc9f02c2b17c3ea382f91b4db0e6cde90b63b296422a939886a7a80de1c",
+            "https://files.pythonhosted.org/packages/41/f1/bc770c37ecd58638c18f8ec85df205dacb818ccf933692082fd93010a4bc/MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl": "8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1",
+            "https://files.pythonhosted.org/packages/43/70/f24470f33b2035b035ef0c0ffebf57006beb2272cf3df068fc5154e04ead/MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_aarch64.whl": "e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
+            "https://files.pythonhosted.org/packages/43/ad/7246ae594aac948b17408c0ff0f9ff0bc470bdbe9c672a754310db64b237/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
+            "https://files.pythonhosted.org/packages/44/44/dbaf65876e258facd65f586dde158387ab89963e7f2235551afc9c2e24c2/MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl": "1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb",
+            "https://files.pythonhosted.org/packages/44/53/93405d37bb04a10c43b1bdd6f548097478d494d7eadb4b364e3e1337f0cc/MarkupSafe-2.1.3-cp311-cp311-win32.whl": "dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb",
+            "https://files.pythonhosted.org/packages/46/0c/10ee33673c5e36fa3809cf136971f81d951ca38516188ee11a965d9b2fe9/MarkupSafe-2.1.2-cp39-cp39-win_amd64.whl": "0576fe974b40a400449768941d5d0858cc624e3249dfd1e0c33674e5c7ca7aed",
+            "https://files.pythonhosted.org/packages/47/26/932140621773bfd4df3223fbdd9e78de3477f424f0d2987c313b1cb655ff/MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_i686.whl": "aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
+            "https://files.pythonhosted.org/packages/48/cc/d027612e17b56088cfccd2c8e083518995fcb25a7b4f17fc146362a0499d/MarkupSafe-2.1.2-cp38-cp38-musllinux_1_1_aarch64.whl": "f8ffb705ffcf5ddd0e80b65ddf7bed7ee4f5a441ea7d3419e861a12eaf41af58",
+            "https://files.pythonhosted.org/packages/49/74/bf95630aab0a9ed6a67556cd4e54f6aeb0e74f4cb0fd2f229154873a4be4/MarkupSafe-2.1.3-cp312-cp312-win32.whl": "715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007",
+            "https://files.pythonhosted.org/packages/4b/34/dc837e5ad9e14634aac4342eb8b12a9be20a4f74f50cc0d765f7aa2fc1e3/MarkupSafe-2.1.2-cp38-cp38-macosx_10_9_x86_64.whl": "a4abaec6ca3ad8660690236d11bfe28dfd707778e2442b45addd2f086d6ef094",
+            "https://files.pythonhosted.org/packages/4d/e4/77bb622d6a37aeb51ee55857100986528b7f47d6dbddc35f9b404622ed50/MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_aarch64.whl": "b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc",
+            "https://files.pythonhosted.org/packages/4f/13/cf36eff21600fb21d5bd8c4c1b6ff0b7cc0ff37b955017210cfc6f367972/MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b",
+            "https://files.pythonhosted.org/packages/50/41/1442b693a40eb76d835ca2016e86a01479f17d7fd8288f9830f6790e366a/MarkupSafe-2.1.2-cp39-cp39-musllinux_1_1_x86_64.whl": "b8526c6d437855442cdd3d87eede9c425c4445ea011ca38d937db299382e6fa3",
+            "https://files.pythonhosted.org/packages/51/94/9a04085114ff2c24f7424dbc890a281d73c5a74ea935dc2e69c66a3bd558/MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd",
+            "https://files.pythonhosted.org/packages/52/36/b35c577c884ea352fc0c1eaed9ca4946ffc22cc9c3527a70408bfa9e9496/MarkupSafe-2.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "40627dcf047dadb22cd25ea7ecfe9cbf3bbbad0482ee5920b582f3809c97654f",
+            "https://files.pythonhosted.org/packages/56/0d/c9818629672a3368b773fa94597d79da77bdacc3186f097bb85023f785f6/MarkupSafe-2.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl": "0b462104ba25f1ac006fdab8b6a01ebbfbce9ed37fd37fd4acd70c67c973e460",
+            "https://files.pythonhosted.org/packages/5a/94/d056bf5dbadf7f4b193ee2a132b3d49ffa1602371e3847518b2982045425/MarkupSafe-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "f2bfb563d0211ce16b63c7cb9395d2c682a23187f54c3d79bfec33e6705473c6",
+            "https://files.pythonhosted.org/packages/5e/f6/8eb8a5692c1986b6e863877b0b8a83628aff14e5fbfaf11d9522b532bd9d/MarkupSafe-2.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "22152d00bf4a9c7c83960521fc558f55a1adbc0631fbb00a9471e097b19d72e1",
+            "https://files.pythonhosted.org/packages/62/9b/4908a57acf39d8811836bc6776b309c2e07d63791485589acf0b6d7bc0c6/MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl": "6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+            "https://files.pythonhosted.org/packages/66/21/dadb671aade8eb67ef96e0d8f90b1bd5e8cfb6ad9d8c7fa2c870ec0c257b/MarkupSafe-2.1.2-cp37-cp37m-musllinux_1_1_aarch64.whl": "55f44b440d491028addb3b88f72207d71eeebfb7b5dbf0643f7c023ae1fba619",
+            "https://files.pythonhosted.org/packages/68/8d/c33c43c499c19f4b51181e196c9a497010908fc22c5de33551e298aa6a21/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+            "https://files.pythonhosted.org/packages/6a/86/654dc431513cd4417dfcead8102f22bece2d6abf2f584f0e1cc1524f7b94/MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl": "8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
+            "https://files.pythonhosted.org/packages/6d/7c/59a3248f411813f8ccba92a55feaac4bf360d29e2ff05ee7d8e1ef2d7dbf/MarkupSafe-2.1.3.tar.gz": "af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
+            "https://files.pythonhosted.org/packages/71/61/f5673d7aac2cf7f203859008bb3fc2b25187aa330067c5e9955e5c5ebbab/MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_aarch64.whl": "962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
+            "https://files.pythonhosted.org/packages/74/a3/54fc60ee2da3ab6d68b1b2daf4897297c597840212ee126e68a4eb89fcd7/MarkupSafe-2.1.3-cp38-cp38-win_amd64.whl": "1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
+            "https://files.pythonhosted.org/packages/76/b5/05ce70a3e31ecebcd3628cd180dc4761293aa496db85170fdc085ed2d79a/MarkupSafe-2.1.2-cp38-cp38-win32.whl": "50c42830a633fa0cf9e7d27664637532791bfc31c731a87b202d2d8ac40c3ea2",
+            "https://files.pythonhosted.org/packages/77/26/af46880038c6eac3832e751298f1965f3a550f38d1e9ddaabd674860076b/MarkupSafe-2.1.2-cp39-cp39-macosx_10_9_x86_64.whl": "8bca7e26c1dd751236cfb0c6c72d4ad61d986e9a41bbf76cb445f69488b2a2bd",
+            "https://files.pythonhosted.org/packages/78/e6/91c9a20a943ea231c59024e181c4c5480097daf132428f2272670974637f/MarkupSafe-2.1.2-cp310-cp310-win32.whl": "c4a549890a45f57f1ebf99c067a4ad0cb423a05544accaf2b065246827ed9603",
+            "https://files.pythonhosted.org/packages/79/e2/b818bf277fa6b01244943498cb2127372c01dde5eff7682837cc72740618/MarkupSafe-2.1.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "da25303d91526aac3672ee6d49a2f3db2d9502a4a60b55519feb1a4c7714e07d",
+            "https://files.pythonhosted.org/packages/7b/0f/0e99c2f342933c43af69849a6ba63f2eef54e14c6d0e10a26470fb6b40a9/MarkupSafe-2.1.2-cp37-cp37m-macosx_10_9_x86_64.whl": "a6e40afa7f45939ca356f348c8e23048e02cb109ced1eb8420961b2f40fb373a",
+            "https://files.pythonhosted.org/packages/7c/e6/454df09f18e0ea34d189b447a9e1a9f66c2aa332b77fd5577ebc7ca14d42/MarkupSafe-2.1.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "090376d812fb6ac5f171e5938e82e7f2d7adc2b629101cec0db8b267815c85e2",
+            "https://files.pythonhosted.org/packages/7d/48/6ba4db436924698ca22109325969e00be459d417830dafec3c1001878b57/MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e",
+            "https://files.pythonhosted.org/packages/80/64/ccb65aadd71e7685caa69a885885a673e8748525a243fb26acea37201b44/MarkupSafe-2.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "f03a532d7dee1bed20bc4884194a16160a2de9ffc6354b3878ec9682bb623c54",
+            "https://files.pythonhosted.org/packages/82/70/b3978786c7b576c25d84b009d2a20a11b5300d252fc3ce984e37b932e97c/MarkupSafe-2.1.2-cp39-cp39-musllinux_1_1_aarch64.whl": "2e7821bffe00aa6bd07a23913b7f4e01328c3d5cc0b40b36c0bd81d362faeb65",
+            "https://files.pythonhosted.org/packages/82/e3/4efcd74f10a7999783955aec36386f71082e6d7dafcc06b77b9df72b325a/MarkupSafe-2.1.2-cp39-cp39-macosx_10_9_universal2.whl": "99625a92da8229df6d44335e6fcc558a5037dd0a760e11d84be2260e6f37002f",
+            "https://files.pythonhosted.org/packages/84/a8/c4aebb8a14a1d39d5135eb8233a0b95831cdc42c4088358449c3ed657044/MarkupSafe-2.1.3-cp310-cp310-win_amd64.whl": "1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
+            "https://files.pythonhosted.org/packages/87/a1/d0f05a09c6c1aef89d1eea0ab0ff1ea897d4117d27f1571034a7e3ff515b/MarkupSafe-2.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "cf877ab4ed6e302ec1d04952ca358b381a882fbd9d1b07cccbfd61783561f98a",
+            "https://files.pythonhosted.org/packages/89/5a/ee546f2aa73a1d6fcfa24272f356fe06d29acca81e76b8d32ca53e429a2e/MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl": "f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc",
+            "https://files.pythonhosted.org/packages/8b/bb/72ca339b012054a84753accabe3258e0baf6e34bd0ab6e3670b9a65f679d/MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_aarch64.whl": "69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
+            "https://files.pythonhosted.org/packages/8d/66/4a46c7f1402e0377a8b220fd4b53cc4f1b2337ab0d97f06e23acd1f579d1/MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
+            "https://files.pythonhosted.org/packages/93/ca/1c3ae0c6a5712d4ba98610cada03781ea0448436b17d1dcd4759115b15a1/MarkupSafe-2.1.2-cp310-cp310-musllinux_1_1_aarch64.whl": "d9d971ec1e79906046aa3ca266de79eac42f1dbf3612a05dc9368125952bd1a1",
+            "https://files.pythonhosted.org/packages/93/fa/d72f68f84f8537ee8aa3e0764d1eb11e5e025a5ca90c16e94a40f894c2fc/MarkupSafe-2.1.2-cp38-cp38-win_amd64.whl": "bb06feb762bade6bf3c8b844462274db0c76acc95c52abe8dbed28ae3d44a147",
+            "https://files.pythonhosted.org/packages/95/7e/68018b70268fb4a2a605e2be44ab7b4dd7ce7808adae6c5ef32e34f4b55a/MarkupSafe-2.1.2.tar.gz": "abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d",
+            "https://files.pythonhosted.org/packages/95/88/8c8cce021ac1b1eedde349c6a41f6c256da60babf95e572071361ff3f66b/MarkupSafe-2.1.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "63ba06c9941e46fa389d389644e2d8225e0e3e5ebcc4ff1ea8506dce646f8c8a",
+            "https://files.pythonhosted.org/packages/96/92/a873b4a7fa20c2e30bffe883bb560330f3b6ce03aaf278f75f96d161935b/MarkupSafe-2.1.2-cp310-cp310-musllinux_1_1_i686.whl": "7e007132af78ea9df29495dbf7b5824cb71648d7133cf7848a2a5dd00d36f9ff",
+            "https://files.pythonhosted.org/packages/96/e4/4db3b1abc5a1fe7295aa0683eafd13832084509c3b8236f3faf8dd4eff75/MarkupSafe-2.1.3-cp310-cp310-win32.whl": "10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
+            "https://files.pythonhosted.org/packages/9b/c1/9f44da5ca74f95116c644892152ca6514ecdc34c8297a3f40d886147863d/MarkupSafe-2.1.3-cp37-cp37m-win_amd64.whl": "787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
+            "https://files.pythonhosted.org/packages/9d/78/92f15eb9b1e8f1668a9787ba103cf6f8d19a9efed8150245404836145c24/MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11",
+            "https://files.pythonhosted.org/packages/9d/80/8320f182d06a9b289b1a9f266f593feb91d3781c7e104bbe09e0c4c11439/MarkupSafe-2.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "4cf06cdc1dda95223e9d2d3c58d3b178aa5dacb35ee7e3bbac10e4e1faacb419",
+            "https://files.pythonhosted.org/packages/a2/b2/624042cb58cc6b3529a6c3a7b7d230766e3ecb768cba118ba7befd18ed6f/MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl": "3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
+            "https://files.pythonhosted.org/packages/a2/f7/9175ad1b8152092f7c3b78c513c1bdfe9287e0564447d1c2d3d1a2471540/MarkupSafe-2.1.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee",
+            "https://files.pythonhosted.org/packages/a6/56/f1d4ee39e898a9e63470cbb7fae1c58cce6874f25f54220b89213a47f273/MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
+            "https://files.pythonhosted.org/packages/a8/12/fd9ef3e09a7312d60467c71037283553ff2acfcd950159cd4c3ca9558af4/MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl": "8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
+            "https://files.pythonhosted.org/packages/ab/20/f59423543a8422cb8c69a579ebd0ef2c9dafa70cc8142b7372b5b4073caa/MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl": "0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
+            "https://files.pythonhosted.org/packages/b2/0d/cbaade3ee8efbd5ce2fb72b48cc51479ebf3d4ce2c54dcb6557d3ea6a950/MarkupSafe-2.1.3-cp37-cp37m-win32.whl": "8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0",
+            "https://files.pythonhosted.org/packages/b2/27/07e5aa9f93314dc65ad2ad9b899656dee79b70a9425ee199dd5a4c4cf2cd/MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_i686.whl": "504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
+            "https://files.pythonhosted.org/packages/bb/82/f88ccb3ca6204a4536cf7af5abdad7c3657adac06ab33699aa67279e0744/MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl": "5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac",
+            "https://files.pythonhosted.org/packages/be/18/988e1913a40cc8eb725b1e073eacc130f7803a061577bdc0b9343eb3c696/MarkupSafe-2.1.2-cp37-cp37m-win32.whl": "7668b52e102d0ed87cb082380a7e2e1e78737ddecdde129acadb0eccc5423859",
+            "https://files.pythonhosted.org/packages/be/bb/08b85bc194034efbf572e70c3951549c8eca0ada25363afc154386b5390a/MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl": "134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
+            "https://files.pythonhosted.org/packages/bf/b7/c5ba9b7ad9ad21fc4a60df226615cf43ead185d328b77b0327d603d00cc5/MarkupSafe-2.1.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
+            "https://files.pythonhosted.org/packages/c0/c7/171f5ac6b065e1425e8fabf4a4dfbeca76fd8070072c6a41bd5c07d90d8b/MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_x86_64.whl": "3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
+            "https://files.pythonhosted.org/packages/c3/e5/42842a44bfd9ba2955c562b1139334a2f64cedb687e8969777fd07de42a9/MarkupSafe-2.1.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "f1cd098434e83e656abf198f103a8207a8187c0fc110306691a2e94a78d0abb2",
+            "https://files.pythonhosted.org/packages/c7/0e/22d0c8e6ee84414e251bd1bc555b2705af6b3fb99f0ba1ead2a0f51d423b/MarkupSafe-2.1.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "22731d79ed2eb25059ae3df1dfc9cb1546691cc41f4e3130fe6bfbc3ecbbecfa",
+            "https://files.pythonhosted.org/packages/c9/80/f08e782943ee7ae6e9438851396d00a869f5b50ea8c6e1f40385f3e95771/MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_x86_64.whl": "42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
+            "https://files.pythonhosted.org/packages/cf/c1/d7596976a868fe3487212a382cc121358a53dc8e8d85ff2ee2c3d3b40f04/MarkupSafe-2.1.2-cp311-cp311-musllinux_1_1_aarch64.whl": "9cad97ab29dfc3f0249b483412c85c8ef4766d96cdf9dcf5a1e3caa3f3661cf1",
+            "https://files.pythonhosted.org/packages/d1/10/ff89b23d4a24051c4e4f689b79ee06f230d7e9431445e24f5dd9d9a89730/MarkupSafe-2.1.2-cp38-cp38-macosx_10_9_universal2.whl": "a806db027852538d2ad7555b203300173dd1b77ba116de92da9afbc3a3be3eed",
+            "https://files.pythonhosted.org/packages/d2/a1/4ae49dd1520c7b891ea4963258aab08fb2554c564781ecb2a9c4afdf9cb1/MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_i686.whl": "c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48",
+            "https://files.pythonhosted.org/packages/d5/c1/1177f712d4ab91eb67f79d763a7b5f9c5851ee3077d6b4eee15e23b6b93e/MarkupSafe-2.1.3-cp39-cp39-win32.whl": "fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2",
+            "https://files.pythonhosted.org/packages/de/63/cb7e71984e9159ec5f45b5e81e896c8bdd0e45fe3fc6ce02ab497f0d790e/MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
+            "https://files.pythonhosted.org/packages/de/e2/32c14301bb023986dff527a49325b6259cab4ebb4633f69de54af312fc45/MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
+            "https://files.pythonhosted.org/packages/e3/a9/e366665c7eae59c9c9d34b747cd5a3994847719a2304e0c8dec8b604dd98/MarkupSafe-2.1.2-cp311-cp311-macosx_10_9_universal2.whl": "2ec4f2d48ae59bbb9d1f9d7efb9236ab81429a764dedca114f5fdabbc3788013",
+            "https://files.pythonhosted.org/packages/e5/dd/49576e803c0d974671e44fa78049217fcc68af3662a24f831525ed30e6c7/MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
+            "https://files.pythonhosted.org/packages/e6/5c/8ab8f67bbbbf90fe88f887f4fa68123435c5415531442e8aefef1e118d5c/MarkupSafe-2.1.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e",
+            "https://files.pythonhosted.org/packages/e6/ff/d2378ca3cb3ac4a37af767b820b0f0bf3f5e9193a6acce0eefc379425c1c/MarkupSafe-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl": "608e7073dfa9e38a85d38474c082d4281f4ce276ac0010224eaba11e929dd53a",
+            "https://files.pythonhosted.org/packages/e7/33/54d29854716725d7826079b8984dd235fac76dab1c32321e555d493e61f5/MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl": "9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c",
+            "https://files.pythonhosted.org/packages/e9/c6/2da36728c1310f141395176556500aeedfdea8c2b02a3b72ba61b69280e8/MarkupSafe-2.1.2-cp37-cp37m-musllinux_1_1_i686.whl": "a6f2fcca746e8d5910e18782f976489939d54a91f9411c32051b4aab2bd7c513",
+            "https://files.pythonhosted.org/packages/ea/60/2400ba59cf2465fa136487ee7299f52121a9d04b2cf8539ad43ad10e70e8/MarkupSafe-2.1.2-cp311-cp311-win_amd64.whl": "e55e40ff0cc8cc5c07996915ad367fa47da6b3fc091fdadca7f5403239c5fec3",
+            "https://files.pythonhosted.org/packages/ec/53/fcb3214bd370185e223b209ce6bb010fb887ea57173ca4f75bd211b24e10/MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939",
+            "https://files.pythonhosted.org/packages/f4/a0/103f94793c3bf829a18d2415117334ece115aeca56f2df1c47fa02c6dbd6/MarkupSafe-2.1.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9",
+            "https://files.pythonhosted.org/packages/f7/9c/86cbd8e0e1d81f0ba420f20539dd459c50537c7751e28102dbfee2b6f28c/MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_x86_64.whl": "e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
+            "https://files.pythonhosted.org/packages/f8/33/e9e83b214b5f8d9a60b26e60051734e7657a416e5bce7d7f1c34e26badad/MarkupSafe-2.1.3-cp38-cp38-macosx_10_9_x86_64.whl": "2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
+            "https://files.pythonhosted.org/packages/f9/aa/ebcd114deab08f892b1d70badda4436dbad1747f9e5b72cffb3de4c7129d/MarkupSafe-2.1.2-cp310-cp310-musllinux_1_1_x86_64.whl": "7313ce6a199651c4ed9d7e4cfb4aa56fe923b1adf9af3b420ee14e6d9a73df65",
+            "https://files.pythonhosted.org/packages/fa/bb/12fb5964c4a766eb98155dd31ec070adc8a69a395564ffc1e7b34d91335a/MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_x86_64.whl": "56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
+            "https://files.pythonhosted.org/packages/fe/09/c31503cb8150cf688c1534a7135cc39bb9092f8e0e6369ec73494d16ee0e/MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_universal2.whl": "ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
+            "https://files.pythonhosted.org/packages/fe/21/2eff1de472ca6c99ec3993eab11308787b9879af9ca8bbceb4868cf4f2ca/MarkupSafe-2.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2"
+          },
+          "mdurl": {
+            "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+            "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+          },
+          "more-itertools": {
+            "https://files.pythonhosted.org/packages/13/b3/397aa9668da8b1f0c307bc474608653d46122ae0563d1d32f60e24fa0cbd/more-itertools-9.0.0.tar.gz": "5a6257e40878ef0520b1803990e3e22303a41b5714006c32a3fd8304b26ea1ab",
+            "https://files.pythonhosted.org/packages/5d/87/1ec3fcc09d2c04b977eabf8a1083222f82eaa2f46d5a4f85f403bf8e7b30/more_itertools-9.0.0-py3-none-any.whl": "250e83d7e81d0c87ca6bd942e6aeab8cc9daa6096d12c5308f3f92fa5e5c1f41",
+            "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl": "52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b",
+            "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz": "f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd"
+          },
+          "nh3": {
+            "https://files.pythonhosted.org/packages/0c/e0/cf1543e798ba86d838952e8be4cb8d18e22999be2a24b112a671f1c04fd6/nh3-0.3.0-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl": "ec6cfdd2e0399cb79ba4dcffb2332b94d9696c52272ff9d48a630c5dca5e325a",
+            "https://files.pythonhosted.org/packages/10/71/2fb1834c10fab6d9291d62c95192ea2f4c7518bd32ad6c46aab5d095cb87/nh3-0.3.0-cp313-cp313t-musllinux_1_2_i686.whl": "0649464ac8eee018644aacbc103874ccbfac80e3035643c3acaab4287e36e7f5",
+            "https://files.pythonhosted.org/packages/23/1e/80a8c517655dd40bb13363fc4d9e66b2f13245763faab1a20f1df67165a7/nh3-0.3.0-cp313-cp313t-win_amd64.whl": "423201bbdf3164a9e09aa01e540adbb94c9962cc177d5b1cbb385f5e1e79216e",
+            "https://files.pythonhosted.org/packages/2f/d6/f1c6e091cbe8700401c736c2bc3980c46dca770a2cf6a3b48a175114058e/nh3-0.3.0-cp313-cp313t-win32.whl": "7275fdffaab10cc5801bf026e3c089d8de40a997afc9e41b981f7ac48c5aa7d5",
+            "https://files.pythonhosted.org/packages/33/c1/8f8ccc2492a000b6156dce68a43253fcff8b4ce70ab4216d08f90a2ac998/nh3-0.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl": "1adeb1062a1c2974bc75b8d1ecb014c5fd4daf2df646bbe2831f7c23659793f9",
+            "https://files.pythonhosted.org/packages/39/2c/6394301428b2017a9d5644af25f487fa557d06bc8a491769accec7524d9a/nh3-0.3.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "f416c35efee3e6a6c9ab7716d9e57aa0a49981be915963a82697952cba1353e1",
+            "https://files.pythonhosted.org/packages/4c/3c/cba7b26ccc0ef150c81646478aa32f9c9535234f54845603c838a1dc955c/nh3-0.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl": "80fe20171c6da69c7978ecba33b638e951b85fb92059259edd285ff108b82a6d",
+            "https://files.pythonhosted.org/packages/4e/9a/344b9f9c4bd1c2413a397f38ee6a3d5db30f1a507d4976e046226f12b297/nh3-0.3.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl": "37d3003d98dedca6cd762bf88f2e70b67f05100f6b949ffe540e189cc06887f9",
+            "https://files.pythonhosted.org/packages/5b/76/3165e84e5266d146d967a6cc784ff2fbf6ddd00985a55ec006b72bc39d5d/nh3-0.3.0-cp38-abi3-win_arm64.whl": "d97d3efd61404af7e5721a0e74d81cdbfc6e5f97e11e731bb6d090e30a7b62b2",
+            "https://files.pythonhosted.org/packages/5c/86/a96b1453c107b815f9ab8fac5412407c33cc5c7580a4daf57aabeb41b774/nh3-0.3.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "ce5e7185599f89b0e391e2f29cc12dc2e206167380cea49b33beda4891be2fe1",
+            "https://files.pythonhosted.org/packages/63/da/c5fd472b700ba37d2df630a9e0d8cc156033551ceb8b4c49cc8a5f606b68/nh3-0.3.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl": "ba0caa8aa184196daa6e574d997a33867d6d10234018012d35f86d46024a2a95",
+            "https://files.pythonhosted.org/packages/66/3f/cd37f76c8ca277b02a84aa20d7bd60fbac85b4e2cbdae77cb759b22de58b/nh3-0.3.0-cp38-abi3-musllinux_1_2_aarch64.whl": "634e34e6162e0408e14fb61d5e69dbaea32f59e847cfcfa41b66100a6b796f62",
+            "https://files.pythonhosted.org/packages/6a/1b/b15bd1ce201a1a610aeb44afd478d55ac018b4475920a3118ffd806e2483/nh3-0.3.0-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl": "e9e6a7e4d38f7e8dda9edd1433af5170c597336c1a74b4693c5cb75ab2b30f2a",
+            "https://files.pythonhosted.org/packages/8c/ae/324b165d904dc1672eee5f5661c0a68d4bab5b59fbb07afb6d8d19a30b45/nh3-0.3.0-cp38-abi3-win_amd64.whl": "bae63772408fd63ad836ec569a7c8f444dd32863d0c67f6e0b25ebbd606afa95",
+            "https://files.pythonhosted.org/packages/8f/14/079670fb2e848c4ba2476c5a7a2d1319826053f4f0368f61fca9bb4227ae/nh3-0.3.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "7852f038a054e0096dac12b8141191e02e93e0b4608c4b993ec7d4ffafea4e49",
+            "https://files.pythonhosted.org/packages/97/03/03f79f7e5178eb1ad5083af84faff471e866801beb980cc72943a4397368/nh3-0.3.0-cp38-abi3-musllinux_1_2_i686.whl": "c7a32a7f0d89f7d30cb8f4a84bdbd56d1eb88b78a2434534f62c71dac538c450",
+            "https://files.pythonhosted.org/packages/97/33/11e7273b663839626f714cb68f6eb49899da5a0d9b6bc47b41fe870259c2/nh3-0.3.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl": "389d93d59b8214d51c400fb5b07866c2a4f79e4e14b071ad66c92184fec3a392",
+            "https://files.pythonhosted.org/packages/9a/e0/af86d2a974c87a4ba7f19bc3b44a8eaa3da480de264138fec82fe17b340b/nh3-0.3.0-cp313-cp313t-win_arm64.whl": "16f8670201f7e8e0e05ed1a590eb84bfa51b01a69dd5caf1d3ea57733de6a52f",
+            "https://files.pythonhosted.org/packages/a3/e5/ac7fc565f5d8bce7f979d1afd68e8cb415020d62fa6507133281c7d49f91/nh3-0.3.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl": "af5aa8127f62bbf03d68f67a956627b1bd0469703a35b3dad28d0c1195e6c7fb",
+            "https://files.pythonhosted.org/packages/ad/7f/7c6b8358cf1222921747844ab0eef81129e9970b952fcb814df417159fb9/nh3-0.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "7c915060a2c8131bef6a29f78debc29ba40859b6dbe2362ef9e5fd44f11487c2",
+            "https://files.pythonhosted.org/packages/b4/11/340b7a551916a4b2b68c54799d710f86cf3838a4abaad8e74d35360343bb/nh3-0.3.0-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl": "a537ece1bf513e5a88d8cff8a872e12fe8d0f42ef71dd15a5e7520fecd191bbb",
+            "https://files.pythonhosted.org/packages/c3/a4/96cff0977357f60f06ec4368c4c7a7a26cccfe7c9fcd54f5378bf0428fd3/nh3-0.3.0.tar.gz": "d8ba24cb31525492ea71b6aac11a4adac91d828aadeff7c4586541bf5dc34d2f",
+            "https://files.pythonhosted.org/packages/c9/50/76936ec021fe1f3270c03278b8af5f2079038116b5d0bfe8538ffe699d69/nh3-0.3.0-cp38-abi3-win32.whl": "6d68fa277b4a3cf04e5c4b84dd0c6149ff7d56c12b3e3fab304c525b850f613d",
+            "https://files.pythonhosted.org/packages/ce/55/1974bcc16884a397ee699cebd3914e1f59be64ab305533347ca2d983756f/nh3-0.3.0-cp38-abi3-musllinux_1_2_x86_64.whl": "3f1b4f8a264a0c86ea01da0d0c390fe295ea0bcacc52c2103aca286f6884f518",
+            "https://files.pythonhosted.org/packages/ee/db/7aa11b44bae4e7474feb1201d8dee04fabe5651c7cb51409ebda94a4ed67/nh3-0.3.0-cp38-abi3-musllinux_1_2_armv7l.whl": "b0612ccf5de8a480cf08f047b08f9d3fecc12e63d2ee91769cb19d7290614c23",
+            "https://files.pythonhosted.org/packages/f3/ba/59e204d90727c25b253856e456ea61265ca810cda8ee802c35f3fadaab00/nh3-0.3.0-cp313-cp313t-musllinux_1_2_armv7l.whl": "e90883f9f85288f423c77b3f5a6f4486375636f25f793165112679a7b6363b35"
+          },
+          "packaging": {
+            "https://files.pythonhosted.org/packages/47/d5/aca8ff6f49aa5565df1c826e7bf5e85a6df852ee063600c1efa5b932968c/packaging-23.0.tar.gz": "b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97",
+            "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl": "8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7",
+            "https://files.pythonhosted.org/packages/ed/35/a31aed2993e398f6b09a790a181a7927eb14610ee8bbf02dc14d31677f1c/packaging-23.0-py3-none-any.whl": "714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+            "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz": "048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"
+          },
+          "pkginfo": {
+            "https://files.pythonhosted.org/packages/24/03/e26bf3d6453b7fda5bd2b84029a426553bb373d6277ef6b5ac8863421f87/pkginfo-1.12.1.2.tar.gz": "5cd957824ac36f140260964eba3c6be6442a8359b8c48f4adf90210f33a04b7b",
+            "https://files.pythonhosted.org/packages/b3/f2/6e95c86a23a30fa205ea6303a524b20cbae27fbee69216377e3d95266406/pkginfo-1.9.6-py3-none-any.whl": "4b7a555a6d5a22169fcc9cf7bfd78d296b0361adad412a346c1226849af5e546",
+            "https://files.pythonhosted.org/packages/b4/1c/89b38e431c20d6b2389ed8b3926c2ab72f58944733ba029354c6d9f69129/pkginfo-1.9.6.tar.gz": "8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046",
+            "https://files.pythonhosted.org/packages/fa/3d/f4f2ba829efb54b6cd2d91349c7463316a9cc55a43fc980447416c88540f/pkginfo-1.12.1.2-py3-none-any.whl": "c783ac885519cab2c34927ccfa6bf64b5a704d7c69afaea583dd9b7afe969343"
+          },
+          "pycparser": {
+            "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz": "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206",
+            "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"
+          },
+          "pygithub": {
+            "https://files.pythonhosted.org/packages/be/04/810d131be173cba445d3658a45512b2b2b3d0960d52c4a300d6ec5e00f52/PyGithub-2.1.1-py3-none-any.whl": "4b528d5d6f35e991ea5fd3f942f58748f24938805cb7fcf24486546637917337",
+            "https://files.pythonhosted.org/packages/e2/bc/b9a3c3d6870d1e216fa8c79cf6d183a2da3df1bdcb7823c79cd2a6faa6b6/PyGithub-2.1.1.tar.gz": "ecf12c2809c44147bce63b047b3d2e9dac8a41b63e90fcb263c703f64936b97c"
+          },
+          "pygments": {
+            "https://files.pythonhosted.org/packages/0b/42/d9d95cc461f098f204cd20c85642ae40fbff81f74c300341b8d0e0df14e0/Pygments-2.14.0-py3-none-any.whl": "fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717",
+            "https://files.pythonhosted.org/packages/55/59/8bccf4157baf25e4aa5a0bb7fa3ba8600907de105ebc22b0c78cfbf6f565/pygments-2.17.2.tar.gz": "da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367",
+            "https://files.pythonhosted.org/packages/97/9c/372fef8377a6e340b1704768d20daaded98bf13282b5327beb2e2fe2c7ef/pygments-2.17.2-py3-none-any.whl": "b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c",
+            "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz": "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+            "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl": "86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b",
+            "https://files.pythonhosted.org/packages/da/6a/c427c06913204e24de28de5300d3f0e809933f376e0b7df95194b2bb3f71/Pygments-2.14.0.tar.gz": "b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"
+          },
+          "pyjwt": {
+            "https://files.pythonhosted.org/packages/2b/4f/e04a8067c7c96c364cef7ef73906504e2f40d690811c021e1a1901473a19/PyJWT-2.8.0-py3-none-any.whl": "59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320",
+            "https://files.pythonhosted.org/packages/30/72/8259b2bccfe4673330cea843ab23f86858a419d8f1493f66d413a76c7e3b/PyJWT-2.8.0.tar.gz": "57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de"
+          },
+          "pynacl": {
+            "https://files.pythonhosted.org/packages/0a/1f/284efd64abcbfc433cd931324fefa70159bb5b2b0672537099453f8be34e/PyNaCl-1.4.0-cp35-cp35m-win32.whl": "06cbb4d9b2c4bd3c8dc0d267416aaed79906e7b33f114ddbf0911969794b1cc4",
+            "https://files.pythonhosted.org/packages/14/2a/185f30a9a4a0f5cff27617ce5bb8bfcd9ec59c1a057459b2224f0bf73e3a/PyNaCl-1.4.0-cp38-cp38-win32.whl": "9c4a7ea4fb81536c1b1f5cc44d54a296f96ae78c1ebd2311bd0b60be45a48d96",
+            "https://files.pythonhosted.org/packages/18/f3/e4424147cffbd80f0034b60d9e438ce6b78b3e285174656296353a398ba6/PyNaCl-1.4.0-cp37-cp37m-win32.whl": "8122ba5f2a2169ca5da936b2e5a511740ffb73979381b4229d9188f6dcb22f1f",
+            "https://files.pythonhosted.org/packages/4b/ae/5f94eaee82f9636c17e714f161f3bd3f53282ff48672f9e372e0632abbc0/PyNaCl-1.4.0-cp38-cp38-win_amd64.whl": "7c6092102219f59ff29788860ccb021e80fffd953920c4a8653889c029b2d420",
+            "https://files.pythonhosted.org/packages/50/b8/0918da3835e72a81dfe5da23e7f00b0bf6bafa44ff8e61d68d3789b72050/PyNaCl-1.4.0-cp35-abi3-win32.whl": "4e10569f8cbed81cb7526ae137049759d2a8d57726d52c1a000a3ce366779634",
+            "https://files.pythonhosted.org/packages/6d/50/06b72d6e1ad9718219d2e2d73362496f6907d1ff6590e9e3664bd4324750/PyNaCl-1.4.0-cp27-cp27m-manylinux1_x86_64.whl": "d452a6746f0a7e11121e64625109bc4468fc3100452817001dbe018bb8b08514",
+            "https://files.pythonhosted.org/packages/6d/d9/e07edb489aacc819ff76cab97d7de751c6d00f48c6a600a9f4b7745080c4/PyNaCl-1.4.0-cp37-cp37m-win_amd64.whl": "537a7ccbea22905a0ab36ea58577b39d1fa9b1884869d173b5cf111f006f689f",
+            "https://files.pythonhosted.org/packages/72/0a/c489e5fd7ed00993f0d7e96faa1b1ecbec6cb64e6fdeba1f200d3f7be410/PyNaCl-1.4.0-cp36-cp36m-win_amd64.whl": "cd401ccbc2a249a47a3a1724c2918fcd04be1f7b54eb2a5a71ff915db0ac51c6",
+            "https://files.pythonhosted.org/packages/8c/17/251c05c818e4e6142a035895b1ff88b8b15afc50d481ee77d020ceaffb58/PyNaCl-1.4.0-cp27-cp27m-macosx_10_10_x86_64.whl": "ea6841bc3a76fa4942ce00f3bda7d436fda21e2d91602b9e21b7ca9ecab8f3ff",
+            "https://files.pythonhosted.org/packages/8c/a6/1e94dd44f8b4a1be93a7cf5f61e5998475acd44b30cb49aee0beb5b62cc7/PyNaCl-1.4.0-cp35-abi3-win_amd64.whl": "c914f78da4953b33d4685e3cdc7ce63401247a21425c16a39760e282075ac4a6",
+            "https://files.pythonhosted.org/packages/9d/57/2f5e6226a674b2bcb6db531e8b383079b678df5b10cdaa610d6cf20d77ba/PyNaCl-1.4.0-cp35-abi3-manylinux1_x86_64.whl": "30f9b96db44e09b3304f9ea95079b1b7316b2b4f3744fe3aaecccd95d547063d",
+            "https://files.pythonhosted.org/packages/ac/2a/9053b4f121d2f99b7e9ae7cfb6e838d04aa824dd954b90693dc11417cd6b/PyNaCl-1.4.0-cp35-cp35m-win_amd64.whl": "511d269ee845037b95c9781aa702f90ccc36036f95d0f31373a6a79bd8242e25",
+            "https://files.pythonhosted.org/packages/b2/5c/666409c551f413a95ef57ed949122c32c4464e60d06c13c32ae007f2a9f9/PyNaCl-1.4.0-cp27-cp27m-win32.whl": "2fe0fc5a2480361dcaf4e6e7cea00e078fcda07ba45f811b167e3f99e8cff574",
+            "https://files.pythonhosted.org/packages/c3/9b/c13053cba246d309a1c7739cc4d21d25088007f5ca43d16ee43a6916e789/PyNaCl-1.4.0-cp36-cp36m-win32.whl": "11335f09060af52c97137d4ac54285bcb7df0cef29014a1a4efe64ac065434c4",
+            "https://files.pythonhosted.org/packages/cf/5a/25aeb636baeceab15c8e57e66b8aa930c011ec1c035f284170cacb05025e/PyNaCl-1.4.0.tar.gz": "54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505",
+            "https://files.pythonhosted.org/packages/d4/68/a84e1cc99e4b08f857f148ba5ff6653afb954e121e8362c7a6242d8755ef/PyNaCl-1.4.0-cp35-abi3-macosx_10_10_x86_64.whl": "757250ddb3bff1eecd7e41e65f7f833a8405fede0194319f87899690624f2122",
+            "https://files.pythonhosted.org/packages/d8/4c/b9911c363e9d69b7de636a435d44b49d113df98a064df7386a8ad57c342b/PyNaCl-1.4.0-cp27-cp27m-win_amd64.whl": "f8851ab9041756003119368c1e6cd0b9c631f46d686b3904b18c0139f4419f80",
+            "https://files.pythonhosted.org/packages/de/63/bb36279da38df643c6df3a8a389f29a6ff4a8854468f4c9b9d925b27d57d/PyNaCl-1.4.0-cp27-cp27mu-manylinux1_x86_64.whl": "7757ae33dae81c300487591c68790dfb5145c7d03324000433d9a2c141f82af7"
+          },
+          "pyparsing": {
+            "https://files.pythonhosted.org/packages/6c/10/a7d0fa5baea8fe7b50f448ab742f26f52b80bfca85ac2be9d35cdd9a3246/pyparsing-3.0.9-py3-none-any.whl": "5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc",
+            "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz": "2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"
+          },
+          "python-dateutil": {
+            "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl": "961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9",
+            "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz": "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
+          },
+          "pytz": {
+            "https://files.pythonhosted.org/packages/55/71/cb1b0a0035cf479eaf05109ea830323af66d48197bfc759a018f94acc3c4/pytz-2023.2.tar.gz": "a27dcf612c05d2ebde626f7d506555f10dfc815b3eddccfaadfc7d99b11c9a07",
+            "https://files.pythonhosted.org/packages/a3/21/0ffac8dacd94d20f4d1ceaaa91cf28ad94ec22e8f3ec9056976f1066ff24/pytz-2023.2-py2.py3-none-any.whl": "8a8baaf1e237175b02f5c751eea67168043a749c843989e2b3015aa1ad9db68b"
+          },
+          "readme-renderer": {
+            "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz": "8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1",
+            "https://files.pythonhosted.org/packages/81/c3/d20152fcd1986117b898f66928938f329d0c91ddc47f081c58e64e0f51dc/readme_renderer-37.3.tar.gz": "cd653186dfc73055656f090f227f5cb22a046d7f71a841dfa305f55c9a513273",
+            "https://files.pythonhosted.org/packages/97/52/fd8a77d6f0a9ddeb26ed8fb334e01ac546106bf0c5b8e40dc826c5bd160f/readme_renderer-37.3-py3-none-any.whl": "f67a16caedfa71eef48a31b39708637a6f4664c4394801a7b0d6432d13907343",
+            "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl": "2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151"
+          },
+          "requests": {
+            "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz": "c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652",
+            "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl": "3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b",
+            "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
+            "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz": "942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1",
+            "https://files.pythonhosted.org/packages/9d/ee/391076f5937f0a8cdf5e53b701ffc91753e87b07d66bae4a09aa671897bf/requests-2.28.2.tar.gz": "98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf",
+            "https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl": "64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"
+          },
+          "requests-toolbelt": {
+            "https://files.pythonhosted.org/packages/05/d3/bf87a36bff1cb88fd30a509fd366c70ec30676517ee791b2f77e0e29817a/requests_toolbelt-0.10.1-py2.py3-none-any.whl": "18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7",
+            "https://files.pythonhosted.org/packages/0c/4c/07f01c6ac44f7784fa399137fbc8d0cdc1b5d35304e8c0f278ad82105b58/requests-toolbelt-0.10.1.tar.gz": "62e09f7ff5ccbda92772a29f394a49c3ad6cb181d568b1337626b2abb628a63d",
+            "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl": "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06",
+            "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz": "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"
+          },
+          "rfc3986": {
+            "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz": "97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c",
+            "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl": "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd"
+          },
+          "rich": {
+            "https://files.pythonhosted.org/packages/0e/cf/a6369a2aee266c2d7604230f083d4bd14b8f69bc69eb25b3da63b9f2f853/rich-13.2.0-py3-none-any.whl": "7c963f0d03819221e9ac561e1bc866e3f95a02248c1234daa48954e6d381c003",
+            "https://files.pythonhosted.org/packages/9e/5e/c3dc3ea32e2c14bfe46e48de954dd175bff76bcc549dd300acb9689521ae/rich-13.2.0.tar.gz": "f1a00cdd3eebf999a15d85ec498bfe0b1a77efe9b34f645768a54132ef444ac5",
+            "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl": "536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f",
+            "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz": "e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8"
+          },
+          "secretstorage": {
+            "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz": "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
+            "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl": "f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99"
+          },
+          "setuptools": {
+            "https://files.pythonhosted.org/packages/a2/dd/d8cdd14320106ff58d4eb6e6553bae7a822e174ad5b05db486332d50d4ec/setuptools-65.0.0-py3-none-any.whl": "fe9a97f68b064a6ddd4bacfb0b4b93a4c65a556d97ce906255540439d0c35cef",
+            "https://files.pythonhosted.org/packages/e2/ed/749424fd3cc1b55bb4836878e86b981e85a6fa7db462f6b6577ce1ad62a7/setuptools-65.0.0.tar.gz": "d73f8cd714a1a6691f5eb5abeeacbf313242b7aa2f5eba93776542c1aad90c6f"
+          },
+          "six": {
+            "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+            "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+          },
+          "snowballstemmer": {
+            "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz": "09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
+            "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl": "c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
+          },
+          "sphinx": {
+            "https://files.pythonhosted.org/packages/2e/2c/22a20486cad91a66f4f70bd88c20c8bb306ae719cbba93d7debae7efa80d/sphinx-6.1.3-py3-none-any.whl": "807d1cb3d6be87eb78a381c3e70ebd8d346b9a25f3753e9947e866b2786865fc",
+            "https://files.pythonhosted.org/packages/c7/25/59211a67579385de7410d1005eded97afc7e09c7a90b4a458a38958586c9/Sphinx-3.0.0.tar.gz": "6a099e6faffdc3ceba99ca8c2d09982d43022245e409249375edf111caf79ed3",
+            "https://files.pythonhosted.org/packages/d1/8e/89eabf81ae9ecc988743a5a989ca53d64558b4ed78f50698257173541ce0/Sphinx-3.0.0-py3-none-any.whl": "b63a0c879c4ff9a4dffcb05217fa55672ce07abdeb81e33c73303a563f8d8901",
+            "https://files.pythonhosted.org/packages/db/0b/a0f60c4abd8a69bd5b0d20edde8a8d8d9d4ca825bbd920d328d248fd0290/Sphinx-6.1.3.tar.gz": "0dac3b698538ffef41716cf97ba26c1c7788dba73ce6f150c1ff5b4720786dd2"
+          },
+          "sphinx-rtd-theme": {
+            "https://files.pythonhosted.org/packages/35/b4/40faec6790d4b08a6ef878feddc6ad11c3872b75f52273f1418c39f67cd6/sphinx_rtd_theme-1.2.0.tar.gz": "a0d8bd1a2ed52e0b338cbe19c4b2eef3c5e7a048769753dac6a9f059c7b641b8",
+            "https://files.pythonhosted.org/packages/b3/46/c167351699e5dc126798385cf37c26ba9df7a26c6f8855661d9f966d6ced/sphinx_rtd_theme-1.2.0-py2.py3-none-any.whl": "f823f7e71890abe0ac6aaa6013361ea2696fc8d3e1fa798f463e82bdb77eeff2"
+          },
+          "sphinxcontrib-applehelp": {
+            "https://files.pythonhosted.org/packages/06/c1/5e2cafbd03105ce50d8500f9b4e8a6e8d02e22d0475b574c3b3e9451a15f/sphinxcontrib_applehelp-1.0.4-py3-none-any.whl": "29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228",
+            "https://files.pythonhosted.org/packages/26/6b/68f470fc337ed24043fec987b101f25b35010970bd958970c2ae5990859f/sphinxcontrib_applehelp-1.0.8.tar.gz": "c40a4f96f3776c4393d933412053962fac2b84f4c99a7982ba42e09576a70619",
+            "https://files.pythonhosted.org/packages/32/df/45e827f4d7e7fcc84e853bcef1d836effd762d63ccb86f43ede4e98b478c/sphinxcontrib-applehelp-1.0.4.tar.gz": "828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e",
+            "https://files.pythonhosted.org/packages/56/89/fea3fbf6785b388e6cb8a1beaf62f96e80b37311bdeed6e133388a732426/sphinxcontrib_applehelp-1.0.8-py3-none-any.whl": "cb61eb0ec1b61f349e5cc36b2028e9e7ca765be05e49641c97241274753067b4"
+          },
+          "sphinxcontrib-devhelp": {
+            "https://files.pythonhosted.org/packages/98/33/dc28393f16385f722c893cb55539c641c9aaec8d1bc1c15b69ce0ac2dbb3/sphinxcontrib-devhelp-1.0.2.tar.gz": "ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4",
+            "https://files.pythonhosted.org/packages/a0/52/1049d918d1d1c72857d285c3f0c64c1cbe0be394ce1c93a3d2aa4f39fe3b/sphinxcontrib_devhelp-1.0.6-py3-none-any.whl": "6485d09629944511c893fa11355bda18b742b83a2b181f9a009f7e500595c90f",
+            "https://files.pythonhosted.org/packages/c5/09/5de5ed43a521387f18bdf5f5af31d099605c992fd25372b2b9b825ce48ee/sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl": "8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
+            "https://files.pythonhosted.org/packages/c7/a1/80b7e9f677abc673cb9320bf255ad4e08931ccbc2e66bde4b59bad3809ad/sphinxcontrib_devhelp-1.0.6.tar.gz": "9893fd3f90506bc4b97bdb977ceb8fbd823989f4316b28c3841ec128544372d3"
+          },
+          "sphinxcontrib-htmlhelp": {
+            "https://files.pythonhosted.org/packages/6e/ee/a1f5e39046cbb5f8bc8fba87d1ddf1c6643fbc9194e58d26e606de4b9074/sphinxcontrib_htmlhelp-2.0.1-py3-none-any.whl": "c38cb46dccf316c79de6e5515e1770414b797162b23cd3d06e67020e1d2a6903",
+            "https://files.pythonhosted.org/packages/8a/03/2f9d699fbfdf03ecb3b6d0e2a268a8998d009f2a9f699c2dcc936899257d/sphinxcontrib_htmlhelp-2.0.5.tar.gz": "0dc87637d5de53dd5eec3a6a01753b1ccf99494bd756aafecd74b4fa9e729015",
+            "https://files.pythonhosted.org/packages/b3/47/64cff68ea3aa450c373301e5bebfbb9fce0a3e70aca245fcadd4af06cd75/sphinxcontrib-htmlhelp-2.0.1.tar.gz": "0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff",
+            "https://files.pythonhosted.org/packages/c2/e9/74c4cda5b409af3222fda38f0774e616011bc935f639dbc0da5ca2d1be7d/sphinxcontrib_htmlhelp-2.0.5-py3-none-any.whl": "393f04f112b4d2f53d93448d4bce35842f62b307ccdc549ec1585e950bc35e04"
+          },
+          "sphinxcontrib-jquery": {
+            "https://files.pythonhosted.org/packages/76/85/749bd22d1a68db7291c89e2ebca53f4306c3f205853cf31e9de279034c3c/sphinxcontrib_jquery-4.1-py2.py3-none-any.whl": "f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae",
+            "https://files.pythonhosted.org/packages/de/f3/aa67467e051df70a6330fe7770894b3e4f09436dea6881ae0b4f3d87cad8/sphinxcontrib-jquery-4.1.tar.gz": "1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a"
+          },
+          "sphinxcontrib-jsmath": {
+            "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz": "a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8",
+            "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl": "2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"
+          },
+          "sphinxcontrib-qthelp": {
+            "https://files.pythonhosted.org/packages/2b/14/05f9206cf4e9cfca1afb5fd224c7cd434dcc3a433d6d9e4e0264d29c6cdb/sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl": "bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6",
+            "https://files.pythonhosted.org/packages/80/b3/1beac14a88654d2e5120d0143b49be5ad450b86eb1963523d8dbdcc51eb2/sphinxcontrib_qthelp-1.0.7-py3-none-any.whl": "e2ae3b5c492d58fcbd73281fbd27e34b8393ec34a073c792642cd8e529288182",
+            "https://files.pythonhosted.org/packages/ac/29/705cd4e93e98a8473d62b5c32288e6de3f0c9660d3c97d4e80d3dbbad82b/sphinxcontrib_qthelp-1.0.7.tar.gz": "053dedc38823a80a7209a80860b16b722e9e0209e32fea98c90e4e6624588ed6",
+            "https://files.pythonhosted.org/packages/b1/8e/c4846e59f38a5f2b4a0e3b27af38f2fcf904d4bfd82095bf92de0b114ebd/sphinxcontrib-qthelp-1.0.3.tar.gz": "4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"
+          },
+          "sphinxcontrib-serializinghtml": {
+            "https://files.pythonhosted.org/packages/38/24/228bb903ea87b9e08ab33470e6102402a644127108c7117ac9c00d849f82/sphinxcontrib_serializinghtml-1.1.10-py3-none-any.whl": "326369b8df80a7d2d8d7f99aa5ac577f51ea51556ed974e7716cfd4fca3f6cb7",
+            "https://files.pythonhosted.org/packages/54/13/8dd7a7ed9c58e16e20c7f4ce8e4cb6943eb580955236d0c0d00079a73c49/sphinxcontrib_serializinghtml-1.1.10.tar.gz": "93f3f5dc458b91b192fe10c397e324f262cf163d79f3282c158e8436a2c4511f",
+            "https://files.pythonhosted.org/packages/b5/72/835d6fadb9e5d02304cf39b18f93d227cd93abd3c41ebf58e6853eeb1455/sphinxcontrib-serializinghtml-1.1.5.tar.gz": "aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952",
+            "https://files.pythonhosted.org/packages/c6/77/5464ec50dd0f1c1037e3c93249b040c8fc8078fdda97530eeb02424b6eea/sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl": "352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"
+          },
+          "tqdm": {
+            "https://files.pythonhosted.org/packages/47/bb/849011636c4da2e44f1253cd927cfb20ada4374d8b3a4e425416e84900cc/tqdm-4.64.1-py2.py3-none-any.whl": "6fee160d6ffcd1b1c68c65f14c829c22832bc401726335ce92c52d395944a6a1",
+            "https://files.pythonhosted.org/packages/c1/c2/d8a40e5363fb01806870e444fc1d066282743292ff32a9da54af51ce36a2/tqdm-4.64.1.tar.gz": "5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4"
+          },
+          "twine": {
+            "https://files.pythonhosted.org/packages/3a/38/a3f27a9e8ce45523d7d1e28c09e9085b61a98dab15d35ec086f36a44b37c/twine-4.0.2-py3-none-any.whl": "929bc3c280033347a00f847236564d1c52a3e61b1ac2516c97c48f3ceab756d8",
+            "https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl": "215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
+            "https://files.pythonhosted.org/packages/77/68/bd982e5e949ef8334e6f7dcf76ae40922a8750aa2e347291ae1477a4782b/twine-5.1.1.tar.gz": "9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db",
+            "https://files.pythonhosted.org/packages/b7/1a/a7884359429d801cd63c2c5512ad0a337a509994b0e42d9696d4778d71f6/twine-4.0.2.tar.gz": "9e102ef5fdd5a20661eb88fad46338806c3bd32cf1db729603fe3697b1bc83c8"
+          },
+          "typing-extensions": {
+            "https://files.pythonhosted.org/packages/0b/8e/f1a0a5a76cfef77e1eb6004cb49e5f8d72634da638420b9ea492ce8305e8/typing_extensions-4.4.0-py3-none-any.whl": "16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e",
+            "https://files.pythonhosted.org/packages/17/61/32c3ab8951142e061587d957226b5683d1387fb22d95b4f69186d92616d1/typing_extensions-4.0.0-py3-none-any.whl": "829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9",
+            "https://files.pythonhosted.org/packages/1a/23/748b0c9a5578110b31580c8d2643319adcb3ec91f601b50a955051b51f1d/typing_extensions-4.0.0.tar.gz": "2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed",
+            "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+            "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+            "https://files.pythonhosted.org/packages/e3/a7/8f4e456ef0adac43f452efc2d0e4b242ab831297f1bac60ac815d37eb9cf/typing_extensions-4.4.0.tar.gz": "1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"
+          },
+          "urllib3": {
+            "https://files.pythonhosted.org/packages/21/79/6372d8c0d0641b4072889f3ff84f279b738cd8595b64c8e0496d4e848122/urllib3-1.26.15.tar.gz": "8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305",
+            "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl": "bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4",
+            "https://files.pythonhosted.org/packages/7b/f5/890a0baca17a61c1f92f72b81d3c31523c99bec609e60c292ea55b387ae8/urllib3-1.26.15-py2.py3-none-any.whl": "aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42",
+            "https://files.pythonhosted.org/packages/c5/52/fe421fb7364aa738b3506a2d99e4f3a56e079c0a798e9f4fa5e14c60922f/urllib3-1.26.14.tar.gz": "076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+            "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz": "1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
+            "https://files.pythonhosted.org/packages/fe/ca/466766e20b767ddb9b951202542310cba37ea5f2d792dae7589f1741af58/urllib3-1.26.14-py2.py3-none-any.whl": "75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+          },
+          "webencodings": {
+            "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz": "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923",
+            "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl": "a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"
+          },
+          "wheel": {
+            "https://files.pythonhosted.org/packages/a2/b8/6a06ff0f13a00fc3c3e7d222a995526cbca26c1ad107691b6b1badbbabf1/wheel-0.38.4.tar.gz": "965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac",
+            "https://files.pythonhosted.org/packages/bd/7c/d38a0b30ce22fc26ed7dbc087c6d00851fb3395e9d0dac40bec1f905030c/wheel-0.38.4-py3-none-any.whl": "b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8"
+          },
+          "wrapt": {
+            "https://files.pythonhosted.org/packages/01/db/4b29ba5f97d2a0aa97ec41eba1036b7c3eaf6e61e1f4639420cec2463a01/wrapt-1.16.0-cp38-cp38-win_amd64.whl": "490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41",
+            "https://files.pythonhosted.org/packages/03/60/67dbc0624f1c86cce6150c0b2e13d906009fd6d33128add60a8a2d23137d/wrapt-1.16.0-cp37-cp37m-musllinux_1_1_i686.whl": "b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f",
+            "https://files.pythonhosted.org/packages/07/44/359e4724a92369b88dbf09878a7cde7393cf3da885567ea898e5904049a3/wrapt-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl": "bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136",
+            "https://files.pythonhosted.org/packages/09/43/b26852e9c45a1aac0d14b1080b25b612fa840ba99739c5fc55db07b7ce08/wrapt-1.16.0-cp39-cp39-win32.whl": "ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3",
+            "https://files.pythonhosted.org/packages/0f/16/ea627d7817394db04518f62934a5de59874b587b792300991b3c347ff5e0/wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl": "75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d",
+            "https://files.pythonhosted.org/packages/0f/ef/0ecb1fa23145560431b970418dce575cfaec555ab08617d82eb92afc7ccf/wrapt-1.16.0-cp311-cp311-musllinux_1_1_i686.whl": "6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956",
+            "https://files.pythonhosted.org/packages/11/fb/18ec40265ab81c0e82a934de04596b6ce972c27ba2592c8b53d5585e6bcd/wrapt-1.16.0-cp311-cp311-musllinux_1_1_aarch64.whl": "d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3",
+            "https://files.pythonhosted.org/packages/14/26/93a9fa02c6f257df54d7570dfe8011995138118d11939a4ecd82cb849613/wrapt-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl": "418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c",
+            "https://files.pythonhosted.org/packages/15/4e/081f59237b620a124b035f1229f55db40841a9339fdb8ef60b4decc44df9/wrapt-1.16.0-cp38-cp38-musllinux_1_1_x86_64.whl": "d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6",
+            "https://files.pythonhosted.org/packages/19/2b/548d23362e3002ebbfaefe649b833fa43f6ca37ac3e95472130c4b69e0b4/wrapt-1.16.0-cp310-cp310-win_amd64.whl": "decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2",
+            "https://files.pythonhosted.org/packages/19/d4/cd33d3a82df73a064c9b6401d14f346e1d2fb372885f0295516ec08ed2ee/wrapt-1.16.0-cp310-cp310-musllinux_1_1_aarch64.whl": "73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72",
+            "https://files.pythonhosted.org/packages/25/62/cd284b2b747f175b5a96cbd8092b32e7369edab0644c45784871528eb852/wrapt-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl": "eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d",
+            "https://files.pythonhosted.org/packages/26/dd/1ea7cb367962a6132ab163e7b2d270049e0f471f0238d0e55cfd27219721/wrapt-1.16.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5",
+            "https://files.pythonhosted.org/packages/28/d3/4f079f649c515727c127c987b2ec2e0816b80d95784f2d28d1a57d2a1029/wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8",
+            "https://files.pythonhosted.org/packages/32/12/e11adfde33444986135d8881b401e4de6cbb4cced046edc6b464e6ad7547/wrapt-1.16.0-cp310-cp310-macosx_11_0_arm64.whl": "e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020",
+            "https://files.pythonhosted.org/packages/33/df/6d33cd045919567de125ee86df4ea57077019619d038c1509b4bffdf8bcb/wrapt-1.16.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c",
+            "https://files.pythonhosted.org/packages/34/37/e5540d14befd0e62cfed1820b76196b5c39029e63dc9c67630d9fbcf27f4/wrapt-1.16.0-cp36-cp36m-macosx_10_9_x86_64.whl": "d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8",
+            "https://files.pythonhosted.org/packages/34/49/589db6fa2d5d428b71716815bca8b39196fdaeea7c247a719ed2f93b0ab4/wrapt-1.16.0-cp38-cp38-musllinux_1_1_aarch64.whl": "6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267",
+            "https://files.pythonhosted.org/packages/36/fc/318d240d1360e6e8f975ae35ca8983d8a1d0fe2264ce4fae38db844615ed/wrapt-1.16.0-cp36-cp36m-win_amd64.whl": "6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966",
+            "https://files.pythonhosted.org/packages/39/af/1cc9d51588d865395b620b58c6ae18e9a0da105bbcbde719ba39b4d80f02/wrapt-1.16.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39",
+            "https://files.pythonhosted.org/packages/3a/ad/9d26a33bc80444ff97b937f94611f3b986fd40f735823558dfdf05ef9db8/wrapt-1.16.0-cp38-cp38-win32.whl": "c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b",
+            "https://files.pythonhosted.org/packages/47/cf/c2861bc5e0d5f4f277e1cefd7b3f8904794cc58469d35eaa82032a84e1c9/wrapt-1.16.0-cp37-cp37m-macosx_10_9_x86_64.whl": "a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593",
+            "https://files.pythonhosted.org/packages/49/4e/5d2f6d7b57fc9956bf06e944eb00463551f7d52fc73ca35cfc4c2cdb7aed/wrapt-1.16.0-cp312-cp312-musllinux_1_1_aarch64.whl": "14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81",
+            "https://files.pythonhosted.org/packages/49/83/b40bc1ad04a868b5b5bcec86349f06c1ee1ea7afe51dc3e46131e4f39308/wrapt-1.16.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf",
+            "https://files.pythonhosted.org/packages/4a/cc/3402bcc897978be00fef608cd9e3e39ec8869c973feeb5e1e277670e5ad2/wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl": "2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb",
+            "https://files.pythonhosted.org/packages/54/39/04409d9fc89f77bce37b98545b6ee7247ad11df28373206536eea078a390/wrapt-1.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292",
+            "https://files.pythonhosted.org/packages/57/cf/caaec865789ec7ef277fbf65f09128237f41c17774f242023739f3c98709/wrapt-1.16.0-cp36-cp36m-musllinux_1_1_x86_64.whl": "bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465",
+            "https://files.pythonhosted.org/packages/58/43/d72e625edb5926483c9868214d25b5e7d5858ace6a80c9dfddfbadf4d8f9/wrapt-1.16.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e",
+            "https://files.pythonhosted.org/packages/5c/cc/8297f9658506b224aa4bd71906447dea6bb0ba629861a758c28f67428b91/wrapt-1.16.0-cp312-cp312-win_amd64.whl": "dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8",
+            "https://files.pythonhosted.org/packages/62/62/30ca2405de6a20448ee557ab2cd61ab9c5900be7cbd18a2639db595f0b98/wrapt-1.16.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b",
+            "https://files.pythonhosted.org/packages/66/50/1c5ccb23dd63f8f3d312dc2d5e0e64c681faf7c2388fa1ab2553713cef11/wrapt-1.16.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40",
+            "https://files.pythonhosted.org/packages/66/a5/50e6a2bd4cbf6671012771ec35085807a375da5e61540bc5f62de62ba955/wrapt-1.16.0-cp37-cp37m-win_amd64.whl": "66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00",
+            "https://files.pythonhosted.org/packages/69/21/b2ba809bafc9b6265e359f9c259c6d9a52a16cf6be20c72d95e76da609dd/wrapt-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0",
+            "https://files.pythonhosted.org/packages/6a/d7/cfcd73e8f4858079ac59d9db1ec5a1349bc486ae8e9ba55698cc1f4a1dff/wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl": "9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36",
+            "https://files.pythonhosted.org/packages/6e/52/2da48b35193e39ac53cfb141467d9f259851522d0e8c87153f0ba4205fb1/wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1",
+            "https://files.pythonhosted.org/packages/70/7d/3dcc4a7e96f8d3e398450ec7703db384413f79bd6c0196e0e139055ce00f/wrapt-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440",
+            "https://files.pythonhosted.org/packages/70/cc/b92e1da2cad6a9f8ee481000ece07a35e3b24e041e60ff8b850c079f0ebf/wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl": "9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2",
+            "https://files.pythonhosted.org/packages/72/b5/0c9be75f826c8e8d583a4ab312552d63d9f7c0768710146a22ac59bda4a9/wrapt-1.16.0-cp38-cp38-macosx_11_0_arm64.whl": "44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202",
+            "https://files.pythonhosted.org/packages/74/f2/96ed140b08743f7f68d5bda35a2a589600781366c3da96f056043d258b1a/wrapt-1.16.0-cp39-cp39-win_amd64.whl": "eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35",
+            "https://files.pythonhosted.org/packages/78/98/6307b4da5080432c5a37b69da92ae0582fd284441025014047e98a002ea1/wrapt-1.16.0-cp37-cp37m-win32.whl": "9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c",
+            "https://files.pythonhosted.org/packages/7e/79/5ff0a5c54bda5aec75b36453d06be4f83d5cd4932cc84b7cb2b52cee23e2/wrapt-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73",
+            "https://files.pythonhosted.org/packages/7f/46/896369f2550d1ecb5e776f532aada5e77e5e13f821045978cf3d7f3f236b/wrapt-1.16.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf",
+            "https://files.pythonhosted.org/packages/7f/a7/f1212ba098f3de0fd244e2de0f8791ad2539c03bef6c05a9fcb03e45b089/wrapt-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl": "a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389",
+            "https://files.pythonhosted.org/packages/88/8f/706f2fee019360cc1da652353330350c76aa5746b4e191082e45d6838faf/wrapt-1.16.0-cp310-cp310-win32.whl": "f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d",
+            "https://files.pythonhosted.org/packages/8e/36/517a47f1b286f97433cf46201745917db5d9944cbb97fb45f55cc71024d0/wrapt-1.16.0-cp36-cp36m-win32.whl": "da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e",
+            "https://files.pythonhosted.org/packages/8e/5f/574076e289c42e7c1c2abe944fd9dafb5adcb20b36577d4966ddef145539/wrapt-1.16.0-cp37-cp37m-musllinux_1_1_x86_64.whl": "db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c",
+            "https://files.pythonhosted.org/packages/92/17/224132494c1e23521868cdd57cd1e903f3b6a7ba6996b7b8f077ff8ac7fe/wrapt-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl": "5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b",
+            "https://files.pythonhosted.org/packages/95/4c/063a912e20bcef7124e0df97282a8af3ff3e4b603ce84c481d6d7346be0a/wrapt-1.16.0.tar.gz": "5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d",
+            "https://files.pythonhosted.org/packages/96/e8/27ef35cf61e5147c1c3abcb89cfbb8d691b2bb8364803fcc950140bc14d8/wrapt-1.16.0-cp39-cp39-musllinux_1_1_i686.whl": "db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f",
+            "https://files.pythonhosted.org/packages/a2/5b/4660897233eb2c8c4de3dc7cefed114c61bacb3c28327e64150dc44ee2f6/wrapt-1.16.0-cp312-cp312-win32.whl": "685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc",
+            "https://files.pythonhosted.org/packages/a3/1c/226c2a4932e578a2241dcb383f425995f80224b446f439c2e112eb51c3a6/wrapt-1.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c",
+            "https://files.pythonhosted.org/packages/a6/9b/c2c21b44ff5b9bf14a83252a8b973fb84923764ff63db3e6dfc3895cf2e0/wrapt-1.16.0-cp312-cp312-musllinux_1_1_i686.whl": "49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9",
+            "https://files.pythonhosted.org/packages/a8/c6/5375258add3777494671d8cec27cdf5402abd91016dee24aa2972c61fedf/wrapt-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl": "ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4",
+            "https://files.pythonhosted.org/packages/b1/e7/459a8a4f40f2fa65eb73cb3f339e6d152957932516d18d0e996c7ae2d7ae/wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a",
+            "https://files.pythonhosted.org/packages/b6/ad/7a0766341081bfd9f18a7049e4d6d45586ae5c5bb0a640f05e2f558e849c/wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl": "edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537",
+            "https://files.pythonhosted.org/packages/b7/96/bb5e08b3d6db003c9ab219c487714c13a237ee7dcc572a555eaf1ce7dc82/wrapt-1.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060",
+            "https://files.pythonhosted.org/packages/bf/42/1241b88440ccf8adbf78c81c8899001459102031cc52668cc4e749d9987e/wrapt-1.16.0-cp37-cp37m-musllinux_1_1_aarch64.whl": "73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228",
+            "https://files.pythonhosted.org/packages/c4/81/e799bf5d419f422d8712108837c1d9bf6ebe3cb2a81ad94413449543a923/wrapt-1.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809",
+            "https://files.pythonhosted.org/packages/c5/0f/8245c6167ef25965abfe108400710ef568f84ba53ef3c10873586b75d329/wrapt-1.16.0-cp36-cp36m-musllinux_1_1_aarch64.whl": "0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc",
+            "https://files.pythonhosted.org/packages/c5/40/3eabe06c8dc54fada7364f34e8caa562efe3bf3f769bf3258de9c785a27f/wrapt-1.16.0-cp38-cp38-musllinux_1_1_i686.whl": "1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca",
+            "https://files.pythonhosted.org/packages/cf/95/cd839cf67a9afd588e09ce8139d6afa8b5c81a8a7be7804744c715c7141e/wrapt-1.16.0-cp36-cp36m-musllinux_1_1_i686.whl": "1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e",
+            "https://files.pythonhosted.org/packages/cf/c3/0084351951d9579ae83a3d9e38c140371e4c6b038136909235079f2e6e78/wrapt-1.16.0-cp311-cp311-win_amd64.whl": "aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89",
+            "https://files.pythonhosted.org/packages/d1/c4/8dfdc3c2f0b38be85c8d9fdf0011ebad2f54e40897f9549a356bebb63a97/wrapt-1.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl": "2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487",
+            "https://files.pythonhosted.org/packages/da/6f/6d0b3c4983f1fc764a422989dabc268ee87d937763246cd48aa92f1eed1e/wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl": "5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664",
+            "https://files.pythonhosted.org/packages/e5/a7/47b7ff74fbadf81b696872d5ba504966591a3468f1bc86bca2f407baef68/wrapt-1.16.0-cp311-cp311-win32.whl": "66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362",
+            "https://files.pythonhosted.org/packages/ef/58/2fde309415b5fa98fd8f5f4a11886cbf276824c4c64d45a39da342fff6fe/wrapt-1.16.0-cp310-cp310-musllinux_1_1_i686.whl": "807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0",
+            "https://files.pythonhosted.org/packages/ef/c6/56e718e2c58a4078518c14d97e531ef1e9e8a5c1ddafdc0d264a92be1a1a/wrapt-1.16.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f",
+            "https://files.pythonhosted.org/packages/fd/03/c188ac517f402775b90d6f312955a5e53b866c964b32119f2ed76315697e/wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl": "1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09",
+            "https://files.pythonhosted.org/packages/fe/9e/d3bc95e75670ba15c5b25ecf07fc49941843e2678d777ca59339348d1c96/wrapt-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl": "1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0",
+            "https://files.pythonhosted.org/packages/ff/21/abdedb4cdf6ff41ebf01a74087740a709e2edb146490e4d9beea054b0b7a/wrapt-1.16.0-py3-none-any.whl": "6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1"
+          },
+          "zipp": {
+            "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+            "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl": "071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e",
+            "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+            "https://files.pythonhosted.org/packages/8e/b3/8b16a007184714f71157b1a71bbe632c5d66dd43bc8152b3c799b13881e1/zipp-3.11.0.tar.gz": "a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766",
+            "https://files.pythonhosted.org/packages/d8/20/256eb3f3f437c575fb1a2efdce5e801a5ce3162ea8117da96c43e6ee97d8/zipp-3.11.0-py3-none-any.whl": "83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
+            "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz": "a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"
+          }
+        }
+      },
+      "fact_version": "v1",
+      "index_urls": {
+        "https://pypi.org/simple/": {
+          "alabaster": "/simple/alabaster/",
+          "babel": "/simple/babel/",
+          "backports_tarfile": "/simple/backports-tarfile/",
+          "bleach": "/simple/bleach/",
+          "certifi": "/simple/certifi/",
+          "cffi": "/simple/cffi/",
+          "chardet": "/simple/chardet/",
+          "charset_normalizer": "/simple/charset-normalizer/",
+          "colorama": "/simple/colorama/",
+          "cryptography": "/simple/cryptography/",
+          "deprecated": "/simple/deprecated/",
+          "docutils": "/simple/docutils/",
+          "idna": "/simple/idna/",
+          "imagesize": "/simple/imagesize/",
+          "importlib_metadata": "/simple/importlib-metadata/",
+          "importlib_resources": "/simple/importlib-resources/",
+          "jaraco_classes": "/simple/jaraco-classes/",
+          "jaraco_context": "/simple/jaraco-context/",
+          "jaraco_functools": "/simple/jaraco-functools/",
+          "jeepney": "/simple/jeepney/",
+          "jinja2": "/simple/jinja2/",
+          "keyring": "/simple/keyring/",
+          "markdown_it_py": "/simple/markdown-it-py/",
+          "markupsafe": "/simple/markupsafe/",
+          "mdurl": "/simple/mdurl/",
+          "more_itertools": "/simple/more-itertools/",
+          "nh3": "/simple/nh3/",
+          "packaging": "/simple/packaging/",
+          "pkginfo": "/simple/pkginfo/",
+          "pycparser": "/simple/pycparser/",
+          "pygithub": "/simple/pygithub/",
+          "pygments": "/simple/pygments/",
+          "pyjwt": "/simple/pyjwt/",
+          "pynacl": "/simple/pynacl/",
+          "pyparsing": "/simple/pyparsing/",
+          "python_dateutil": "/simple/python-dateutil/",
+          "pytz": "/simple/pytz/",
+          "readme_renderer": "/simple/readme-renderer/",
+          "requests": "/simple/requests/",
+          "requests_toolbelt": "/simple/requests-toolbelt/",
+          "rfc3986": "/simple/rfc3986/",
+          "rich": "/simple/rich/",
+          "secretstorage": "/simple/secretstorage/",
+          "setuptools": "/simple/setuptools/",
+          "six": "/simple/six/",
+          "snowballstemmer": "/simple/snowballstemmer/",
+          "sphinx": "/simple/sphinx/",
+          "sphinx_rtd_theme": "/simple/sphinx-rtd-theme/",
+          "sphinxcontrib_applehelp": "/simple/sphinxcontrib-applehelp/",
+          "sphinxcontrib_devhelp": "/simple/sphinxcontrib-devhelp/",
+          "sphinxcontrib_htmlhelp": "/simple/sphinxcontrib-htmlhelp/",
+          "sphinxcontrib_jquery": "/simple/sphinxcontrib-jquery/",
+          "sphinxcontrib_jsmath": "/simple/sphinxcontrib-jsmath/",
+          "sphinxcontrib_qthelp": "/simple/sphinxcontrib-qthelp/",
+          "sphinxcontrib_serializinghtml": "/simple/sphinxcontrib-serializinghtml/",
+          "tqdm": "/simple/tqdm/",
+          "twine": "/simple/twine/",
+          "typing_extensions": "/simple/typing-extensions/",
+          "urllib3": "/simple/urllib3/",
+          "webencodings": "/simple/webencodings/",
+          "wheel": "/simple/wheel/",
+          "wrapt": "/simple/wrapt/",
+          "zipp": "/simple/zipp/"
+        }
       }
     }
   }

--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -189,6 +189,11 @@ string_enum! { ValueType
     String = "string",
 }
 
+string_enum! { VectorPrecision
+    F8 = "f8",
+    F64 = "f64",
+}
+
 string_enum! { Order
     Asc = "asc",
     Desc = "desc",

--- a/rust/common/token.rs
+++ b/rust/common/token.rs
@@ -190,8 +190,7 @@ string_enum! { ValueType
 }
 
 string_enum! { VectorPrecision
-    F8 = "f8",
-    F64 = "f64",
+    Float32 = "float32",
 }
 
 string_enum! { Order

--- a/rust/expression/mod.rs
+++ b/rust/expression/mod.rs
@@ -214,6 +214,34 @@ impl fmt::Display for List {
     }
 }
 
+// fixed-size vector embedding literal, e.g. vector([1.0, 2.0, 3.0], "float32")
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct VectorLiteral {
+    pub span: Option<Span>,
+    pub list: Expression,
+    pub precision: token::VectorPrecision,
+}
+
+impl VectorLiteral {
+    pub fn new(span: Option<Span>, list: Expression, precision: token::VectorPrecision) -> Self {
+        Self { span, list, precision }
+    }
+}
+
+impl Spanned for VectorLiteral {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
+impl Pretty for VectorLiteral {}
+
+impl fmt::Display for VectorLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "vector({}, \"{}\")", self.list, self.precision)
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ListIndexRange {
     pub span: Option<Span>,
@@ -251,6 +279,7 @@ pub enum Expression {
     Operation(Box<Operation>),
     Paren(Box<Paren>),
     List(List),
+    Vector(Box<VectorLiteral>),
     ListIndexRange(Box<ListIndexRange>),
     ScopedLabel(ScopedLabel),
     Label(Label),
@@ -266,6 +295,7 @@ impl Spanned for Expression {
             Self::Operation(inner) => inner.span(),
             Self::Paren(inner) => inner.span(),
             Self::List(inner) => inner.span(),
+            Self::Vector(inner) => inner.span(),
             Self::ListIndexRange(inner) => inner.span(),
             Self::ScopedLabel(inner) => inner.span(),
             Self::Label(inner) => inner.span(),
@@ -283,6 +313,7 @@ impl Pretty for Expression {
             Self::Operation(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Paren(inner) => Pretty::fmt(inner, indent_level, f),
             Self::List(inner) => Pretty::fmt(inner, indent_level, f),
+            Self::Vector(inner) => Pretty::fmt(inner, indent_level, f),
             Self::ListIndexRange(inner) => Pretty::fmt(inner, indent_level, f),
             Self::ScopedLabel(inner) => Pretty::fmt(inner, indent_level, f),
             Self::Label(inner) => Pretty::fmt(inner, indent_level, f),
@@ -300,6 +331,7 @@ impl fmt::Display for Expression {
             Self::Operation(inner) => fmt::Display::fmt(inner, f),
             Self::Paren(inner) => fmt::Display::fmt(inner, f),
             Self::List(inner) => fmt::Display::fmt(inner, f),
+            Self::Vector(inner) => fmt::Display::fmt(inner, f),
             Self::ListIndexRange(inner) => fmt::Display::fmt(inner, f),
             Self::ScopedLabel(inner) => fmt::Display::fmt(inner, f),
             Self::Label(inner) => fmt::Display::fmt(inner, f),

--- a/rust/expression/mod.rs
+++ b/rust/expression/mod.rs
@@ -214,7 +214,6 @@ impl fmt::Display for List {
     }
 }
 
-// fixed-size vector embedding literal, e.g. vector([1.0, 2.0, 3.0], "float32")
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct VectorLiteral {
     pub span: Option<Span>,

--- a/rust/parser/expression.rs
+++ b/rust/parser/expression.rs
@@ -11,6 +11,7 @@ use crate::{
     common::{Spanned, error::TypeQLError, token},
     expression::{
         BuiltinFunctionName, Expression, FunctionCall, FunctionName, List, ListIndex, ListIndexRange, Operation, Paren,
+        VectorLiteral,
     },
     parser::{type_::visit_label_scoped, visit_label},
     value::{Literal, StructLiteral, ValueLiteral},
@@ -78,10 +79,23 @@ fn visit_expression_base(node: Node<'_>) -> Expression {
         Rule::expression_function => Expression::Function(visit_expression_function(child)),
         Rule::expression_parenthesis => Expression::Paren(Box::new(visit_expression_parenthesis(child))),
         Rule::expression_list_index => Expression::ListIndex(Box::new(visit_expression_list_index(child))),
+        Rule::vector_literal => Expression::Vector(Box::new(visit_vector_literal(child))),
         Rule::label_scoped => Expression::ScopedLabel(visit_label_scoped(child)),
         Rule::label => Expression::Label(visit_label(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.as_str().to_owned() }),
     }
+}
+
+fn visit_vector_literal(node: Node<'_>) -> VectorLiteral {
+    debug_assert_eq!(node.as_rule(), Rule::vector_literal);
+    let span = node.span();
+    let mut children = node.into_children();
+    children.skip_expected(Rule::VECTOR);
+    let list = visit_expression_list(children.consume_expected(Rule::expression_list));
+    let precision =
+        token::VectorPrecision::from(children.consume_expected(Rule::vector_precision).as_str().trim_matches('"'));
+    debug_assert_eq!(children.try_consume_any(), None);
+    VectorLiteral::new(span, list, precision)
 }
 
 fn visit_expression_list_index(node: Node<'_>) -> ListIndex {

--- a/rust/parser/statement/thing.rs
+++ b/rust/parser/statement/thing.rs
@@ -120,7 +120,6 @@ fn visit_has_constraint(node: Node<'_>) -> Has {
                     Expression::Variable(variable) => HasValue::Variable(variable),
                     expr => HasValue::Expression(expr),
                 },
-                Rule::expression_list => HasValue::Expression(visit_expression_list(value_node)),
                 _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: value_node.as_str().to_owned() }),
             };
             Has::new(span, type_, value)

--- a/rust/parser/statement/thing.rs
+++ b/rust/parser/statement/thing.rs
@@ -120,6 +120,7 @@ fn visit_has_constraint(node: Node<'_>) -> Has {
                     Expression::Variable(variable) => HasValue::Variable(variable),
                     expr => HasValue::Expression(expr),
                 },
+                Rule::expression_list => HasValue::Expression(visit_expression_list(value_node)),
                 _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: value_node.as_str().to_owned() }),
             };
             Has::new(span, type_, value)

--- a/rust/parser/test/builtin_functions.rs
+++ b/rust/parser/test/builtin_functions.rs
@@ -26,13 +26,11 @@ let $gross = min($net * 1.21, $net + 100.0);"#;
 }
 
 #[test]
-fn test_function_cosine_similarity() {
+fn test_function_cosine_similarity_search() {
     let query = r#"match
+let $e in cosine_similarity_search(embedding, vector([0.1, 0.2, 0.3], "float32"), 0.8);
 $doc isa document,
     has embedding $e;
-let $score = cosine_similarity($e, [0.1, 0.2, 0.3]);
-$score >= 0.8;
-sort $score desc;
 limit 10;"#;
     let parsed = parse_query(query).unwrap();
     assert_valid_eq_repr!(expected, parsed, query);

--- a/rust/parser/test/builtin_functions.rs
+++ b/rust/parser/test/builtin_functions.rs
@@ -26,6 +26,19 @@ let $gross = min($net * 1.21, $net + 100.0);"#;
 }
 
 #[test]
+fn test_function_cosine_similarity() {
+    let query = r#"match
+$doc isa document,
+    has embedding $e;
+let $score = cosine_similarity($e, [0.1, 0.2, 0.3]);
+$score >= 0.8;
+sort $score desc;
+limit 10;"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}
+
+#[test]
 fn test_function_max() {
     let query = r#"match
 $x isa commodity,

--- a/rust/parser/test/schema_queries.rs
+++ b/rust/parser/test/schema_queries.rs
@@ -130,6 +130,15 @@ attribute my-type,
 }
 
 #[test]
+fn test_define_double_array_value_type_query() {
+    let query = r#"define
+attribute embedding,
+    value double[64];"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}
+
+#[test]
 fn define_attribute_type_regex() {
     let query = r#"define
 attribute digit,

--- a/rust/parser/test/schema_queries.rs
+++ b/rust/parser/test/schema_queries.rs
@@ -130,10 +130,10 @@ attribute my-type,
 }
 
 #[test]
-fn test_define_double_array_value_type_query() {
+fn test_define_vector_value_type_query() {
     let query = r#"define
 attribute embedding,
-    value double[64];"#;
+    value vector(64, f8);"#;
     let parsed = parse_query(query).unwrap();
     assert_valid_eq_repr!(expected, parsed, query);
 }

--- a/rust/parser/test/schema_queries.rs
+++ b/rust/parser/test/schema_queries.rs
@@ -133,7 +133,7 @@ attribute my-type,
 fn test_define_vector_value_type_query() {
     let query = r#"define
 attribute embedding,
-    value vector(64, f8);"#;
+    value vector(64, "float32");"#;
     let parsed = parse_query(query).unwrap();
     assert_valid_eq_repr!(expected, parsed, query);
 }

--- a/rust/parser/test/write_queries.rs
+++ b/rust/parser/test/write_queries.rs
@@ -46,10 +46,20 @@ $z isa pokemon,
 }
 
 #[test]
-fn test_insert_double_array_value() {
+fn test_insert_vector_value() {
     let query = r#"insert
 $x isa document,
-    has embedding [0.1, 0.2, 0.3];"#;
+    has embedding vector([1.0, 2.0, 3.0], "float32");"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}
+
+#[test]
+fn test_insert_vector_value_given() {
+    let query = r#"given $e: vector(64, "float32");
+insert
+$x isa document,
+    has embedding $e;"#;
     let parsed = parse_query(query).unwrap();
     assert_valid_eq_repr!(expected, parsed, query);
 }

--- a/rust/parser/test/write_queries.rs
+++ b/rust/parser/test/write_queries.rs
@@ -46,6 +46,15 @@ $z isa pokemon,
 }
 
 #[test]
+fn test_insert_double_array_value() {
+    let query = r#"insert
+$x isa document,
+    has embedding [0.1, 0.2, 0.3];"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}
+
+#[test]
 fn test_update_query() {
     let query = r#"match
 $x isa person,

--- a/rust/parser/type_.rs
+++ b/rust/parser/type_.rs
@@ -4,11 +4,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use super::{IntoChildNodes, Node, Rule, RuleMatcher, visit_identifier, visit_var};
+use super::{IntoChildNodes, Node, Rule, RuleMatcher, literal::visit_integer_literal, visit_identifier, visit_var};
 use crate::{
     ScopedLabel,
     common::{Spanned, error::TypeQLError, token},
-    type_::{BuiltinValueType, Label, NamedType, NamedTypeAny, NamedTypeList, NamedTypeOptional, TypeRef, TypeRefList},
+    type_::{
+        BuiltinValueType, BuiltinValueTypeArray, Label, NamedType, NamedTypeAny, NamedTypeList, NamedTypeOptional,
+        TypeRef, TypeRefList,
+    },
 };
 
 pub(super) fn visit_type_ref(node: Node<'_>) -> TypeRef {
@@ -92,10 +95,21 @@ pub(super) fn visit_value_type(node: Node<'_>) -> NamedType {
     debug_assert_eq!(node.as_rule(), Rule::value_type);
     let child = node.into_child();
     match child.as_rule() {
+        Rule::value_type_primitive_array => NamedType::BuiltinValueTypeArray(visit_value_type_primitive_array(child)),
         Rule::value_type_primitive => NamedType::BuiltinValueType(visit_value_type_primitive(child)),
         Rule::label => NamedType::Label(visit_label(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.as_str().to_owned() }),
     }
+}
+
+pub(super) fn visit_value_type_primitive_array(node: Node<'_>) -> BuiltinValueTypeArray {
+    debug_assert_eq!(node.as_rule(), Rule::value_type_primitive_array);
+    let span = node.span();
+    let mut children = node.into_children();
+    children.skip_expected(Rule::DOUBLE);
+    let length = visit_integer_literal(children.consume_expected(Rule::integer_literal));
+    debug_assert_eq!(children.try_consume_any(), None);
+    BuiltinValueTypeArray::new(span, token::ValueType::Double, length)
 }
 
 pub(super) fn visit_value_type_optional(node: Node<'_>) -> NamedTypeOptional {

--- a/rust/parser/type_.rs
+++ b/rust/parser/type_.rs
@@ -9,8 +9,8 @@ use crate::{
     ScopedLabel,
     common::{Spanned, error::TypeQLError, token},
     type_::{
-        BuiltinValueType, BuiltinValueTypeArray, Label, NamedType, NamedTypeAny, NamedTypeList, NamedTypeOptional,
-        TypeRef, TypeRefList,
+        BuiltinValueType, Label, NamedType, NamedTypeAny, NamedTypeList, NamedTypeOptional, TypeRef, TypeRefList,
+        VectorType,
     },
 };
 
@@ -95,21 +95,22 @@ pub(super) fn visit_value_type(node: Node<'_>) -> NamedType {
     debug_assert_eq!(node.as_rule(), Rule::value_type);
     let child = node.into_child();
     match child.as_rule() {
-        Rule::value_type_primitive_array => NamedType::BuiltinValueTypeArray(visit_value_type_primitive_array(child)),
+        Rule::value_type_vector => NamedType::Vector(visit_value_type_vector(child)),
         Rule::value_type_primitive => NamedType::BuiltinValueType(visit_value_type_primitive(child)),
         Rule::label => NamedType::Label(visit_label(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.as_str().to_owned() }),
     }
 }
 
-pub(super) fn visit_value_type_primitive_array(node: Node<'_>) -> BuiltinValueTypeArray {
-    debug_assert_eq!(node.as_rule(), Rule::value_type_primitive_array);
+pub(super) fn visit_value_type_vector(node: Node<'_>) -> VectorType {
+    debug_assert_eq!(node.as_rule(), Rule::value_type_vector);
     let span = node.span();
     let mut children = node.into_children();
-    children.skip_expected(Rule::DOUBLE);
+    children.skip_expected(Rule::VECTOR);
     let length = visit_integer_literal(children.consume_expected(Rule::integer_literal));
+    let precision = token::VectorPrecision::from(children.consume_expected(Rule::vector_precision).as_str());
     debug_assert_eq!(children.try_consume_any(), None);
-    BuiltinValueTypeArray::new(span, token::ValueType::Double, length)
+    VectorType::new(span, length, precision)
 }
 
 pub(super) fn visit_value_type_optional(node: Node<'_>) -> NamedTypeOptional {

--- a/rust/parser/type_.rs
+++ b/rust/parser/type_.rs
@@ -48,6 +48,7 @@ pub(super) fn visit_named_type(node: Node<'_>) -> NamedType {
     let child = node.into_child();
     match child.as_rule() {
         Rule::label => NamedType::Label(visit_label(child)),
+        Rule::value_type_vector => NamedType::Vector(visit_value_type_vector(child)),
         Rule::value_type_primitive => NamedType::BuiltinValueType(visit_value_type_primitive(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.as_str().to_owned() }),
     }
@@ -108,7 +109,8 @@ pub(super) fn visit_value_type_vector(node: Node<'_>) -> VectorType {
     let mut children = node.into_children();
     children.skip_expected(Rule::VECTOR);
     let length = visit_integer_literal(children.consume_expected(Rule::integer_literal));
-    let precision = token::VectorPrecision::from(children.consume_expected(Rule::vector_precision).as_str());
+    let precision =
+        token::VectorPrecision::from(children.consume_expected(Rule::vector_precision).as_str().trim_matches('"'));
     debug_assert_eq!(children.try_consume_any(), None);
     VectorType::new(span, length, precision)
 }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -317,9 +317,11 @@ identifier_var = @{ IDENTIFIER_VAR_H ~ IDENTIFIER_VAR_T* ~ WB }
 
 // VALUES ========================================================
 
-value_type = { value_type_primitive | label }
+value_type = { value_type_primitive_array | value_type_primitive | label }
 value_type_optional = { value_type ~ QUESTION }
 value_type_list = { value_type ~ SQ_BRACKET_OPEN ~ SQ_BRACKET_CLOSE }
+// fixed-size array (currently only supports `double`)
+value_type_primitive_array = { DOUBLE ~ SQ_BRACKET_OPEN ~ integer_literal ~ SQ_BRACKET_CLOSE }
 
 value_type_primitive = { BOOLEAN | INTEGER | DOUBLE | DECIMAL
                        | DATETIME_TZ | DATETIME | DATE | DURATION

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -149,7 +149,7 @@ comparator = { EQ | NEQ | GTE | GT | LTE | LT | CONTAINS | LIKE }
 expression = { expression_list | expression_value }
 
 expression_value = { expression_base ~ ( expression_operator ~ expression_base )* }
-expression_base = { expression_list_index | expression_parenthesis | expression_function | vector_literal | value_literal | var | label_scoped | label }
+expression_base = { expression_list_index | expression_parenthesis | vector_literal | expression_function | value_literal | var | label_scoped | label }
 
 expression_operator = _{ POWER | TIMES | DIVIDE | MODULO | PLUS | MINUS }
 expression_parenthesis = { PAREN_OPEN ~ expression_value ~ PAREN_CLOSE }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -317,11 +317,12 @@ identifier_var = @{ IDENTIFIER_VAR_H ~ IDENTIFIER_VAR_T* ~ WB }
 
 // VALUES ========================================================
 
-value_type = { value_type_primitive_array | value_type_primitive | label }
+value_type = { value_type_vector | value_type_primitive | label }
 value_type_optional = { value_type ~ QUESTION }
 value_type_list = { value_type ~ SQ_BRACKET_OPEN ~ SQ_BRACKET_CLOSE }
-// fixed-size array (currently only supports `double`)
-value_type_primitive_array = { DOUBLE ~ SQ_BRACKET_OPEN ~ integer_literal ~ SQ_BRACKET_CLOSE }
+// fixed-size vector embedding, e.g. vector(64, f8)
+value_type_vector = { VECTOR ~ PAREN_OPEN ~ integer_literal ~ COMMA ~ vector_precision ~ PAREN_CLOSE }
+vector_precision = @{ ( "f8" | "f64" ) ~ WB }
 
 value_type_primitive = { BOOLEAN | INTEGER | DOUBLE | DECIMAL
                        | DATETIME_TZ | DATETIME | DATE | DURATION
@@ -563,6 +564,7 @@ DURATION = @{ "duration" ~ WB }
 
 STRING = @{ "string" ~ WB }
 STRUCT = @{ "struct" ~ WB }
+VECTOR = @{ "vector" ~ WB }
 
 // LITERAL VALUE KEYWORDS
 boolean_literal = ${ TRUE | FALSE } // order of lexer declaration matters

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -149,9 +149,7 @@ comparator = { EQ | NEQ | GTE | GT | LTE | LT | CONTAINS | LIKE }
 expression = { expression_list | expression_value }
 
 expression_value = { expression_base ~ ( expression_operator ~ expression_base )* }
-// vector_literal must precede expression_function: `vector(...)` would otherwise parse as a call to a function named "vector"
-expression_base = { expression_list_index | expression_parenthesis | vector_literal | expression_function | value_literal | var | label_scoped | label }
-vector_literal = { VECTOR ~ PAREN_OPEN ~ expression_list ~ COMMA ~ vector_precision ~ PAREN_CLOSE }
+expression_base = { expression_list_index | expression_parenthesis | expression_function | vector_literal | value_literal | var | label_scoped | label }
 
 expression_operator = _{ POWER | TIMES | DIVIDE | MODULO | PLUS | MINUS }
 expression_parenthesis = { PAREN_OPEN ~ expression_value ~ PAREN_CLOSE }
@@ -170,6 +168,8 @@ list_range = { SQ_BRACKET_OPEN ~ expression_value ~ DOUBLE_DOT ~ expression_valu
 
 expression_struct = { CURLY_OPEN ~ struct_key ~ COLON ~ struct_value ~ CURLY_CLOSE }
 struct_value = { expression_value | expression_struct }
+
+vector_literal = { VECTOR ~ PAREN_OPEN ~ expression_list ~ COMMA ~ vector_precision ~ PAREN_CLOSE }
 
 // FETCH QUERY =================================================================
 
@@ -322,7 +322,6 @@ identifier_var = @{ IDENTIFIER_VAR_H ~ IDENTIFIER_VAR_T* ~ WB }
 value_type = { value_type_vector | value_type_primitive | label }
 value_type_optional = { value_type ~ QUESTION }
 value_type_list = { value_type ~ SQ_BRACKET_OPEN ~ SQ_BRACKET_CLOSE }
-// fixed-size vector embedding, e.g. vector(64, "float32")
 value_type_vector = { VECTOR ~ PAREN_OPEN ~ integer_literal ~ COMMA ~ vector_precision ~ PAREN_CLOSE }
 vector_precision = @{ "\"" ~ "float32" ~ "\"" }
 

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -112,7 +112,7 @@ thing_constraint = { isa_constraint | iid_constraint | has_constraint | links_co
 isa_constraint = { ISA_ ~ type_ref ~ ( relation | comparison | expression | value_literal | expression_struct )? }
 iid_constraint = { IID ~ iid_value }
 has_constraint = { HAS ~ type_ref_list ~ ( comparison | expression_list | var )
-                 | HAS ~ type_ref ~ ( comparison | expression_value | var )
+                 | HAS ~ type_ref ~ ( comparison | expression_list | expression_value | var )
                  | HAS ~ var
                  }
 links_constraint = { LINKS ~ relation }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -112,7 +112,7 @@ thing_constraint = { isa_constraint | iid_constraint | has_constraint | links_co
 isa_constraint = { ISA_ ~ type_ref ~ ( relation | comparison | expression | value_literal | expression_struct )? }
 iid_constraint = { IID ~ iid_value }
 has_constraint = { HAS ~ type_ref_list ~ ( comparison | expression_list | var )
-                 | HAS ~ type_ref ~ ( comparison | expression_list | expression_value | var )
+                 | HAS ~ type_ref ~ ( comparison | expression_value | var )
                  | HAS ~ var
                  }
 links_constraint = { LINKS ~ relation }
@@ -149,7 +149,9 @@ comparator = { EQ | NEQ | GTE | GT | LTE | LT | CONTAINS | LIKE }
 expression = { expression_list | expression_value }
 
 expression_value = { expression_base ~ ( expression_operator ~ expression_base )* }
-expression_base = { expression_list_index | expression_parenthesis | expression_function | value_literal | var | label_scoped | label }
+// vector_literal must precede expression_function: `vector(...)` would otherwise parse as a call to a function named "vector"
+expression_base = { expression_list_index | expression_parenthesis | vector_literal | expression_function | value_literal | var | label_scoped | label }
+vector_literal = { VECTOR ~ PAREN_OPEN ~ expression_list ~ COMMA ~ vector_precision ~ PAREN_CLOSE }
 
 expression_operator = _{ POWER | TIMES | DIVIDE | MODULO | PLUS | MINUS }
 expression_parenthesis = { PAREN_OPEN ~ expression_value ~ PAREN_CLOSE }
@@ -288,7 +290,7 @@ undefine_struct = { STRUCT ~ identifier }
 type_ref = { label_scoped | label | var }
 type_ref_list = { type_ref ~ SQ_BRACKET_OPEN ~ SQ_BRACKET_CLOSE }
 
-named_type = { value_type_primitive | label }
+named_type = { value_type_vector | value_type_primitive | label }
 named_type_optional = { named_type ~ QUESTION }
 named_type_list = { named_type ~ SQ_BRACKET_OPEN ~ SQ_BRACKET_CLOSE }
 named_type_any = { named_type_optional | named_type_list | named_type }
@@ -320,9 +322,9 @@ identifier_var = @{ IDENTIFIER_VAR_H ~ IDENTIFIER_VAR_T* ~ WB }
 value_type = { value_type_vector | value_type_primitive | label }
 value_type_optional = { value_type ~ QUESTION }
 value_type_list = { value_type ~ SQ_BRACKET_OPEN ~ SQ_BRACKET_CLOSE }
-// fixed-size vector embedding, e.g. vector(64, f8)
+// fixed-size vector embedding, e.g. vector(64, "float32")
 value_type_vector = { VECTOR ~ PAREN_OPEN ~ integer_literal ~ COMMA ~ vector_precision ~ PAREN_CLOSE }
-vector_precision = @{ ( "f8" | "f64" ) ~ WB }
+vector_precision = @{ "\"" ~ "float32" ~ "\"" }
 
 value_type_primitive = { BOOLEAN | INTEGER | DOUBLE | DECIMAL
                        | DATETIME_TZ | DATETIME | DATE | DURATION

--- a/rust/type_.rs
+++ b/rust/type_.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use crate::{
     common::{Span, Spanned, identifier::Identifier, token},
     pretty::Pretty,
+    value::IntegerLiteral,
     variable::Variable,
 };
 
@@ -91,10 +92,39 @@ impl fmt::Display for ScopedLabel {
     }
 }
 
+// fixed-size array value type; only `double` is supported (e.g. double[64])
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct BuiltinValueTypeArray {
+    pub span: Option<Span>,
+    pub token: token::ValueType,
+    pub length: IntegerLiteral,
+}
+
+impl BuiltinValueTypeArray {
+    pub fn new(span: Option<Span>, token: token::ValueType, length: IntegerLiteral) -> Self {
+        Self { span, token, length }
+    }
+}
+
+impl Spanned for BuiltinValueTypeArray {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
+impl Pretty for BuiltinValueTypeArray {}
+
+impl fmt::Display for BuiltinValueTypeArray {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}[{}]", self.token, self.length)
+    }
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum NamedType {
     Label(Label),
     BuiltinValueType(BuiltinValueType),
+    BuiltinValueTypeArray(BuiltinValueTypeArray),
 }
 
 impl Spanned for NamedType {
@@ -102,6 +132,7 @@ impl Spanned for NamedType {
         match self {
             Self::Label(inner) => inner.span(),
             Self::BuiltinValueType(inner) => inner.span(),
+            Self::BuiltinValueTypeArray(inner) => inner.span(),
         }
     }
 }
@@ -111,6 +142,7 @@ impl fmt::Display for NamedType {
         match self {
             Self::Label(inner) => fmt::Display::fmt(inner, f),
             Self::BuiltinValueType(inner) => fmt::Display::fmt(inner, f),
+            Self::BuiltinValueTypeArray(inner) => fmt::Display::fmt(inner, f),
         }
     }
 }

--- a/rust/type_.rs
+++ b/rust/type_.rs
@@ -92,7 +92,6 @@ impl fmt::Display for ScopedLabel {
     }
 }
 
-// fixed-size vector embedding value type, e.g. vector(64, "float32")
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct VectorType {
     pub span: Option<Span>,

--- a/rust/type_.rs
+++ b/rust/type_.rs
@@ -92,7 +92,7 @@ impl fmt::Display for ScopedLabel {
     }
 }
 
-// fixed-size vector embedding value type, e.g. vector(64, f8)
+// fixed-size vector embedding value type, e.g. vector(64, "float32")
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct VectorType {
     pub span: Option<Span>,
@@ -116,7 +116,7 @@ impl Pretty for VectorType {}
 
 impl fmt::Display for VectorType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "vector({}, {})", self.length, self.precision)
+        write!(f, "vector({}, \"{}\")", self.length, self.precision)
     }
 }
 

--- a/rust/type_.rs
+++ b/rust/type_.rs
@@ -92,31 +92,31 @@ impl fmt::Display for ScopedLabel {
     }
 }
 
-// fixed-size array value type; only `double` is supported (e.g. double[64])
+// fixed-size vector embedding value type, e.g. vector(64, f8)
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
-pub struct BuiltinValueTypeArray {
+pub struct VectorType {
     pub span: Option<Span>,
-    pub token: token::ValueType,
     pub length: IntegerLiteral,
+    pub precision: token::VectorPrecision,
 }
 
-impl BuiltinValueTypeArray {
-    pub fn new(span: Option<Span>, token: token::ValueType, length: IntegerLiteral) -> Self {
-        Self { span, token, length }
+impl VectorType {
+    pub fn new(span: Option<Span>, length: IntegerLiteral, precision: token::VectorPrecision) -> Self {
+        Self { span, length, precision }
     }
 }
 
-impl Spanned for BuiltinValueTypeArray {
+impl Spanned for VectorType {
     fn span(&self) -> Option<Span> {
         self.span
     }
 }
 
-impl Pretty for BuiltinValueTypeArray {}
+impl Pretty for VectorType {}
 
-impl fmt::Display for BuiltinValueTypeArray {
+impl fmt::Display for VectorType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}[{}]", self.token, self.length)
+        write!(f, "vector({}, {})", self.length, self.precision)
     }
 }
 
@@ -124,7 +124,7 @@ impl fmt::Display for BuiltinValueTypeArray {
 pub enum NamedType {
     Label(Label),
     BuiltinValueType(BuiltinValueType),
-    BuiltinValueTypeArray(BuiltinValueTypeArray),
+    Vector(VectorType),
 }
 
 impl Spanned for NamedType {
@@ -132,7 +132,7 @@ impl Spanned for NamedType {
         match self {
             Self::Label(inner) => inner.span(),
             Self::BuiltinValueType(inner) => inner.span(),
-            Self::BuiltinValueTypeArray(inner) => inner.span(),
+            Self::Vector(inner) => inner.span(),
         }
     }
 }
@@ -142,7 +142,7 @@ impl fmt::Display for NamedType {
         match self {
             Self::Label(inner) => fmt::Display::fmt(inner, f),
             Self::BuiltinValueType(inner) => fmt::Display::fmt(inner, f),
-            Self::BuiltinValueTypeArray(inner) => fmt::Display::fmt(inner, f),
+            Self::Vector(inner) => fmt::Display::fmt(inner, f),
         }
     }
 }

--- a/rust/value.rs
+++ b/rust/value.rs
@@ -22,7 +22,7 @@ pub struct StringLiteral {
     pub value: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct IntegerLiteral {
     pub value: String,
 }


### PR DESCRIPTION
## Product change and motivation

Adds support for declaring `vector`. This lets users work with embeddings, and later express vector-similarity queries.

1. Declaring a vector embedding attribute 
```typeql
define
attribute embedding,
    value vector(64, "float32");
```

2. Inserting a vector embedding attribute: using declarative syntax
```typeql
insert
$x isa document,
    has embedding vector([1.0, 2.0, 3.0], "float32");
```

3. Inserting a vector embedding attribute: using `given` syntax
```typeql
given $e: vector(64, "float8");
insert
$x isa document,
    has embedding $e;
```

## Implementation

- Updated Pest grammar to allow array declarations
- AST & parser: `BuiltinValueTypeArray` struct and visitors
- Updated tests: declaring double array, inserting an array, and calling a function using an array