### PR TITLE
Introduce grammar changes for renaming types

### DIFF
--- a/rust/parser/redefine.rs
+++ b/rust/parser/redefine.rs
@@ -11,9 +11,8 @@ use crate::{
     common::{Spanned, error::TypeQLError},
     parser::{annotation::visit_annotations, define::function::visit_definition_function, type_::visit_label_scoped},
     query::schema::Redefine,
-    schema::definable::{Definable, Type, TypeRename},
+    schema::definable::{Definable, RoleTypeRename, Type, TypeRename},
 };
-use crate::schema::definable::RoleTypeRename;
 
 pub(super) fn visit_query_redefine(node: Node<'_>) -> Redefine {
     debug_assert_eq!(node.as_rule(), Rule::query_redefine);
@@ -44,15 +43,15 @@ fn visit_redefinable_label(node: Node<'_>) -> Definable {
             let from = visit_label(children.consume_expected(Rule::label));
             children.skip_expected(Rule::LABEL);
             let to = visit_label(children.consume_expected(Rule::label));
-            Definable::TypeRename(TypeRename { kind , from, to, span })
-        },
+            Definable::TypeRename(TypeRename { kind, from, to, span })
+        }
         Rule::label => {
             let kind = None;
             let from = visit_label(first_child);
             children.skip_expected(Rule::LABEL);
             let to = visit_label(children.consume_expected(Rule::label));
-            Definable::TypeRename(TypeRename { kind , from, to, span })
-        },
+            Definable::TypeRename(TypeRename { kind, from, to, span })
+        }
         Rule::label_scoped => {
             let from = visit_label_scoped(first_child);
             children.skip_expected(Rule::LABEL);

--- a/rust/parser/redefine.rs
+++ b/rust/parser/redefine.rs
@@ -11,7 +11,7 @@ use crate::{
     common::{Spanned, error::TypeQLError},
     parser::{annotation::visit_annotations, define::function::visit_definition_function},
     query::schema::Redefine,
-    schema::definable::{Definable, Type},
+    schema::definable::{Definable, Type, TypeRename},
 };
 
 pub(super) fn visit_query_redefine(node: Node<'_>) -> Redefine {
@@ -25,13 +25,23 @@ fn visit_redefinable(node: Node<'_>) -> Definable {
     debug_assert_eq!(node.as_rule(), Rule::redefinable);
     let child = node.into_child();
     match child.as_rule() {
-        Rule::redefinable_type => visit_redefinable_kind(child),
+        Rule::redefinable_label => visit_redefinable_label(child),
+        Rule::redefinable_type => visit_redefinable_type(child),
         Rule::definition_function => Definable::Function(visit_definition_function(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.as_str().to_owned() }),
     }
 }
+fn visit_redefinable_label(node: Node<'_>) -> Definable {
+    let span = node.span();
+    let mut children = node.into_children();
+    let kind = children.try_consume_expected(Rule::kind).map(visit_kind);
+    let from = visit_label(children.consume_expected(Rule::label));
+    children.skip_expected(Rule::LABEL);
+    let to = visit_label(children.consume_expected(Rule::label));
+    Definable::TypeRename(TypeRename { kind, from, to, span })
+}
 
-fn visit_redefinable_kind(node: Node<'_>) -> Definable {
+fn visit_redefinable_type(node: Node<'_>) -> Definable {
     let span = node.span();
     let mut children = node.into_children();
     let kind = children.try_consume_expected(Rule::kind).map(visit_kind);

--- a/rust/parser/redefine.rs
+++ b/rust/parser/redefine.rs
@@ -9,10 +9,11 @@ use super::{
 };
 use crate::{
     common::{Spanned, error::TypeQLError},
-    parser::{annotation::visit_annotations, define::function::visit_definition_function},
+    parser::{annotation::visit_annotations, define::function::visit_definition_function, type_::visit_label_scoped},
     query::schema::Redefine,
     schema::definable::{Definable, Type, TypeRename},
 };
+use crate::schema::definable::RoleTypeRename;
 
 pub(super) fn visit_query_redefine(node: Node<'_>) -> Redefine {
     debug_assert_eq!(node.as_rule(), Rule::query_redefine);
@@ -31,14 +32,37 @@ fn visit_redefinable(node: Node<'_>) -> Definable {
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.as_str().to_owned() }),
     }
 }
+
 fn visit_redefinable_label(node: Node<'_>) -> Definable {
+    debug_assert_eq!(node.as_rule(), Rule::redefinable_label);
     let span = node.span();
     let mut children = node.into_children();
-    let kind = children.try_consume_expected(Rule::kind).map(visit_kind);
-    let from = visit_label(children.consume_expected(Rule::label));
-    children.skip_expected(Rule::LABEL);
-    let to = visit_label(children.consume_expected(Rule::label));
-    Definable::TypeRename(TypeRename { kind, from, to, span })
+    let first_child = children.consume_any();
+    match first_child.as_rule() {
+        Rule::kind => {
+            let kind = Some(visit_kind(first_child));
+            let from = visit_label(children.consume_expected(Rule::label));
+            children.skip_expected(Rule::LABEL);
+            let to = visit_label(children.consume_expected(Rule::label));
+            Definable::TypeRename(TypeRename { kind , from, to, span })
+        },
+        Rule::label => {
+            let kind = None;
+            let from = visit_label(first_child);
+            children.skip_expected(Rule::LABEL);
+            let to = visit_label(children.consume_expected(Rule::label));
+            Definable::TypeRename(TypeRename { kind , from, to, span })
+        },
+        Rule::label_scoped => {
+            let from = visit_label_scoped(first_child);
+            children.skip_expected(Rule::LABEL);
+            let to = visit_label(children.consume_expected(Rule::label));
+            Definable::RoleTypeRename(RoleTypeRename { from, to, span })
+        }
+        _ => {
+            unreachable!("{}", TypeQLError::IllegalGrammar { input: first_child.as_str().to_owned() })
+        }
+    }
 }
 
 fn visit_redefinable_type(node: Node<'_>) -> Definable {

--- a/rust/parser/test/schema_queries.rs
+++ b/rust/parser/test/schema_queries.rs
@@ -200,3 +200,11 @@ person label user;"#;
     let parsed = parse_query(query).unwrap();
     assert_valid_eq_repr!(expected, parsed, query);
 }
+
+#[test]
+fn redefine_role_type() {
+    let query = r#"redefine
+rel:old-role label new-role;"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}

--- a/rust/parser/test/schema_queries.rs
+++ b/rust/parser/test/schema_queries.rs
@@ -192,3 +192,11 @@ fun greet($p: person, $g: string,) -> string:
     match $p has name $n; return first $n;"#;
     parse_query(query).unwrap();
 }
+
+#[test]
+fn redefine_rename_type() {
+    let query = r#"redefine
+person label user;"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -259,7 +259,8 @@ struct_destructor_value = { var | struct_destructor }
 // REDEFINE QUERY ==============================================================
 
 query_redefine = { REDEFINE ~ ( redefinable )* }
-redefinable = { redefinable_type | definition_function }
+redefinable = { redefinable_label | redefinable_type | definition_function }
+redefinable_label = { kind? ~ label ~ LABEL ~ label ~ SEMICOLON }
 redefinable_type = { kind? ~ label ~ COMMA? ~ ( annotations | type_capability ) ~ SEMICOLON }
 // TODO: add `redefine <person> label <new_person_label>
 

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -260,7 +260,7 @@ struct_destructor_value = { var | struct_destructor }
 
 query_redefine = { REDEFINE ~ ( redefinable )* }
 redefinable = { redefinable_label | redefinable_type | definition_function }
-redefinable_label = { kind? ~ label ~ LABEL ~ label ~ SEMICOLON }
+redefinable_label = { (label_scoped | (kind? ~ label) ) ~ LABEL ~ label ~ SEMICOLON }
 redefinable_type = { kind? ~ label ~ COMMA? ~ ( annotations | type_capability ) ~ SEMICOLON }
 // TODO: add `redefine <person> label <new_person_label>
 

--- a/rust/schema/definable/mod.rs
+++ b/rust/schema/definable/mod.rs
@@ -8,6 +8,7 @@ use std::fmt;
 
 pub use self::{function::Function, struct_::Struct, type_::Type};
 use crate::{Label, common::Span, pretty::Pretty, token};
+use crate::common::Spanned;
 
 pub mod function;
 pub mod struct_;
@@ -55,6 +56,12 @@ pub struct TypeRename {
     pub kind: Option<token::Kind>,
     pub from: Label,
     pub to: Label,
+}
+
+impl Spanned for TypeRename {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
 }
 
 impl Pretty for TypeRename {

--- a/rust/schema/definable/mod.rs
+++ b/rust/schema/definable/mod.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 
 pub use self::{function::Function, struct_::Struct, type_::Type};
-use crate::pretty::Pretty;
+use crate::{Label, common::Span, pretty::Pretty, token};
 
 pub mod function;
 pub mod struct_;
@@ -15,6 +15,7 @@ pub mod type_;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Definable {
+    TypeRename(TypeRename),
     TypeDeclaration(Type),
     Function(Function),
     Struct(Struct),
@@ -29,6 +30,7 @@ impl From<Type> for Definable {
 impl Pretty for Definable {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::TypeRename(declaration) => Pretty::fmt(declaration, indent_level, f),
             Self::TypeDeclaration(declaration) => Pretty::fmt(declaration, indent_level, f),
             Self::Function(declaration) => Pretty::fmt(declaration, indent_level, f),
             Self::Struct(declaration) => Pretty::fmt(declaration, indent_level, f),
@@ -39,9 +41,38 @@ impl Pretty for Definable {
 impl fmt::Display for Definable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::TypeRename(declaration) => fmt::Display::fmt(declaration, f),
             Self::TypeDeclaration(declaration) => fmt::Display::fmt(declaration, f),
             Self::Function(declaration) => fmt::Display::fmt(declaration, f),
             Self::Struct(declaration) => fmt::Display::fmt(declaration, f),
         }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct TypeRename {
+    pub span: Option<Span>,
+    pub kind: Option<token::Kind>,
+    pub from: Label,
+    pub to: Label,
+}
+
+impl Pretty for TypeRename {
+    fn fmt(&self, _indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(kind) = &self.kind {
+            write!(f, "{} ", kind)?;
+        }
+        write!(f, "{} {} {};", self.from, token::Keyword::Label, self.to)?;
+        Ok(())
+    }
+}
+
+impl fmt::Display for TypeRename {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(kind) = &self.kind {
+            write!(f, "{} ", kind)?;
+        }
+        write!(f, "{} {} {};", self.from, token::Keyword::Label, self.to)?;
+        Ok(())
     }
 }

--- a/rust/schema/definable/mod.rs
+++ b/rust/schema/definable/mod.rs
@@ -7,8 +7,12 @@
 use std::fmt;
 
 pub use self::{function::Function, struct_::Struct, type_::Type};
-use crate::{Label, common::Span, pretty::Pretty, token};
-use crate::common::Spanned;
+use crate::{
+    Label, ScopedLabel,
+    common::{Span, Spanned},
+    pretty::Pretty,
+    token,
+};
 
 pub mod function;
 pub mod struct_;
@@ -17,6 +21,7 @@ pub mod type_;
 #[derive(Debug, Eq, PartialEq)]
 pub enum Definable {
     TypeRename(TypeRename),
+    RoleTypeRename(RoleTypeRename),
     TypeDeclaration(Type),
     Function(Function),
     Struct(Struct),
@@ -32,6 +37,7 @@ impl Pretty for Definable {
     fn fmt(&self, indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::TypeRename(declaration) => Pretty::fmt(declaration, indent_level, f),
+            Self::RoleTypeRename(declaration) => Pretty::fmt(declaration, indent_level, f),
             Self::TypeDeclaration(declaration) => Pretty::fmt(declaration, indent_level, f),
             Self::Function(declaration) => Pretty::fmt(declaration, indent_level, f),
             Self::Struct(declaration) => Pretty::fmt(declaration, indent_level, f),
@@ -43,6 +49,7 @@ impl fmt::Display for Definable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::TypeRename(declaration) => fmt::Display::fmt(declaration, f),
+            Self::RoleTypeRename(declaration) => fmt::Display::fmt(declaration, f),
             Self::TypeDeclaration(declaration) => fmt::Display::fmt(declaration, f),
             Self::Function(declaration) => fmt::Display::fmt(declaration, f),
             Self::Struct(declaration) => fmt::Display::fmt(declaration, f),
@@ -81,5 +88,30 @@ impl fmt::Display for TypeRename {
         }
         write!(f, "{} {} {};", self.from, token::Keyword::Label, self.to)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct RoleTypeRename {
+    pub span: Option<Span>,
+    pub from: ScopedLabel,
+    pub to: Label,
+}
+
+impl Spanned for RoleTypeRename {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
+impl Pretty for RoleTypeRename {
+    fn fmt(&self, _indent_level: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {} {};", self.from, token::Keyword::Label, self.to)
+    }
+}
+
+impl fmt::Display for RoleTypeRename {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {} {};", self.from, token::Keyword::Label, self.to)
     }
 }


### PR DESCRIPTION
## Product change and motivation
Entity, relation and attribute types can be renamed by doing `redefine old-label label new-label;`. Role types can be renamed by doing `redefine declaration-relation:old-role label new-role;`.

