### PR TITLE
Allow scientific notation for double literal without decimal part

### DIFF
--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -570,7 +570,7 @@ FALSE = @{ "false" ~ WB }
 
 integer_literal = @{ ASCII_DIGIT+ }
 decimal_literal = @{ ASCII_DIGIT+ ~ ( "." ~ ASCII_DIGIT+ )? ~ "dec" }
-double_literal = @{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ ( ^"e" ~ sign? ~ integer_literal )? }
+double_literal = @{ ASCII_DIGIT+ ~ ( ( "." ~ ASCII_DIGIT+ )? ~ ^"e" ~ sign? ~ integer_literal | "." ~ ASCII_DIGIT+ ) }
 numeric_literal = @{ double_literal | integer_literal }
 
 date_literal = ${ date_fragment ~ WB }


### PR DESCRIPTION
## Product change and motivation

Allow literals like `1e-6` to parse without requiring `1.0e-6`.

## Implementation

Before: `Int Frac Exp?`
After: `Int (Frac? Exp | Frac)`