### PR TITLE
Support fully qualified names for builtin functions to emulate namespacing

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -92,7 +92,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "c4004a7e787ac111ce83d35230deea60fb6f3eda",
+    commit = "a428985711011ee5b9164bad65238a591f23e3ca",
 )
 
 # workspace_refs for rust sync

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -228,7 +228,6 @@
     "https://bcr.bazel.build/modules/rules_python/1.0.0/MODULE.bazel": "898a3d999c22caa585eb062b600f88654bf92efb204fa346fb55f6f8edffca43",
     "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
     "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
-    "https://bcr.bazel.build/modules/rules_python/2.0.0/MODULE.bazel": "1459089e2d4194d2a49e07896f5334fb230a8f2966ae945b1f793bef87a292fd",
     "https://bcr.bazel.build/modules/rules_python/2.3.2/MODULE.bazel": "5fdf04732b804f4e75011007ba91a68a37f6639665e2e5f8e26294cee1d56750",
     "https://bcr.bazel.build/modules/rules_python/2.3.2/source.json": "40ebd885174966190b81190f00b0ab3af52dad0cd768624b26d27ac9f42567e2",
     "https://bcr.bazel.build/modules/rules_robolectric/4.14.1.2/MODULE.bazel": "d44fec647d0aeb67b9f3b980cf68ba634976f3ae7ccd6c07d790b59b87a4f251",

--- a/rust/expression/mod.rs
+++ b/rust/expression/mod.rs
@@ -46,8 +46,35 @@ impl fmt::Display for BuiltinFunctionName {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+pub struct NamespacedFunctionName {
+    pub span: Option<Span>,
+    pub name: String,
+}
+
+impl NamespacedFunctionName {
+    pub fn new(span: Option<Span>, name: String) -> Self {
+        Self { span, name }
+    }
+}
+
+impl Spanned for NamespacedFunctionName {
+    fn span(&self) -> Option<Span> {
+        self.span
+    }
+}
+
+impl Pretty for NamespacedFunctionName {}
+
+impl fmt::Display for NamespacedFunctionName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum FunctionName {
     Builtin(BuiltinFunctionName),
+    Namespaced(NamespacedFunctionName),
     Identifier(Identifier),
 }
 
@@ -57,6 +84,7 @@ impl Spanned for FunctionName {
     fn span(&self) -> Option<Span> {
         match self {
             Self::Builtin(inner) => inner.span(),
+            Self::Namespaced(inner) => inner.span(),
             Self::Identifier(inner) => inner.span(),
         }
     }
@@ -66,6 +94,7 @@ impl fmt::Display for FunctionName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Builtin(inner) => fmt::Display::fmt(inner, f),
+            Self::Namespaced(inner) => fmt::Display::fmt(inner, f),
             Self::Identifier(inner) => fmt::Display::fmt(inner, f),
         }
     }

--- a/rust/parser/expression.rs
+++ b/rust/parser/expression.rs
@@ -10,7 +10,8 @@ use super::{IntoChildNodes, Node, Rule, RuleMatcher, literal::visit_value_litera
 use crate::{
     common::{Spanned, error::TypeQLError, token},
     expression::{
-        BuiltinFunctionName, Expression, FunctionCall, FunctionName, List, ListIndex, ListIndexRange, Operation, Paren,
+        BuiltinFunctionName, Expression, FunctionCall, FunctionName, List, ListIndex, ListIndexRange,
+        NamespacedFunctionName, Operation, Paren,
     },
     parser::{type_::visit_label_scoped, visit_label},
     value::{Literal, StructLiteral, ValueLiteral},
@@ -151,6 +152,7 @@ fn visit_expression_function_name(node: Node<'_>) -> FunctionName {
     match child.as_rule() {
         Rule::identifier => FunctionName::Identifier(visit_identifier(child)),
         Rule::builtin_func_name => FunctionName::Builtin(visit_builtin_func_name(child)),
+        Rule::namespaced_func_name => FunctionName::Namespaced(visit_namespaced_func_name(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.as_str().to_owned() }),
     }
 }
@@ -172,4 +174,11 @@ fn visit_builtin_func_name(node: Node<'_>) -> BuiltinFunctionName {
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.as_str().to_owned() }),
     };
     BuiltinFunctionName::new(span, token)
+}
+
+fn visit_namespaced_func_name(node: Node<'_>) -> NamespacedFunctionName {
+    debug_assert_eq!(node.as_rule(), Rule::namespaced_func_name);
+    let span = node.span();
+    let name = node.as_str().to_owned();
+    NamespacedFunctionName::new(span, name)
 }

--- a/rust/parser/expression.rs
+++ b/rust/parser/expression.rs
@@ -152,7 +152,7 @@ fn visit_expression_function_name(node: Node<'_>) -> FunctionName {
     match child.as_rule() {
         Rule::identifier => FunctionName::Identifier(visit_identifier(child)),
         Rule::builtin_func_name => FunctionName::Builtin(visit_builtin_func_name(child)),
-        Rule::namespaced_func_name => FunctionName::Namespaced(visit_namespaced_func_name(child)),
+        Rule::namespaced_identifier => FunctionName::Namespaced(visit_namespaced_identifier(child)),
         _ => unreachable!("{}", TypeQLError::IllegalGrammar { input: child.as_str().to_owned() }),
     }
 }
@@ -176,8 +176,8 @@ fn visit_builtin_func_name(node: Node<'_>) -> BuiltinFunctionName {
     BuiltinFunctionName::new(span, token)
 }
 
-fn visit_namespaced_func_name(node: Node<'_>) -> NamespacedFunctionName {
-    debug_assert_eq!(node.as_rule(), Rule::namespaced_func_name);
+fn visit_namespaced_identifier(node: Node<'_>) -> NamespacedFunctionName {
+    debug_assert_eq!(node.as_rule(), Rule::namespaced_identifier);
     let span = node.span();
     let name = node.as_str().to_owned();
     NamespacedFunctionName::new(span, name)

--- a/rust/parser/test/builtin_functions.rs
+++ b/rust/parser/test/builtin_functions.rs
@@ -114,3 +114,11 @@ let $value = round($net * 1.21);"#;
     //     );
     assert_valid_eq_repr!(expected, parsed, query);
 }
+
+#[test]
+fn test_std_namespaced_func() {
+    let query = r#"match
+let $x = first::second::third($y);"#;
+    let parsed = parse_query(query).unwrap();
+    assert_valid_eq_repr!(expected, parsed, query);
+}

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -158,7 +158,8 @@ expression_list_index = { var ~ list_index }
 list_index = { SQ_BRACKET_OPEN ~ expression_value ~ SQ_BRACKET_CLOSE }
 
 expression_function = { expression_function_name ~ PAREN_OPEN ~ expression_arguments? ~ PAREN_CLOSE }
-expression_function_name = { builtin_func_name | identifier }
+expression_function_name = { namespaced_func_name | builtin_func_name | identifier }
+namespaced_func_name = { identifier ~ (NAMESPACE_SEP ~ identifier)+ } // Plain identifiers could be namespaced
 expression_arguments = { expression ~ ( COMMA ~ expression )* ~ COMMA? }
 
 expression_list = { expression_list_subrange | expression_list_new }
@@ -535,6 +536,9 @@ CEIL = @{ "ceil" ~ WB }
 FLOOR = @{ "floor" ~ WB }
 LEN = @{ "len" ~ WB }
 ROUND = @{ "round" ~ WB }
+
+// NAMESPACED FUNCTIONS
+NAMESPACE_SEP = @{ "::" }
 
 // GROUP AND AGGREGATE QUERY KEYWORDS
 

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -158,8 +158,8 @@ expression_list_index = { var ~ list_index }
 list_index = { SQ_BRACKET_OPEN ~ expression_value ~ SQ_BRACKET_CLOSE }
 
 expression_function = { expression_function_name ~ PAREN_OPEN ~ expression_arguments? ~ PAREN_CLOSE }
-expression_function_name = { namespaced_func_name | builtin_func_name | identifier }
-namespaced_func_name = { identifier ~ (NAMESPACE_SEP ~ identifier)+ } // Plain identifiers could be namespaced
+expression_function_name = { namespaced_identifier | builtin_func_name | identifier }
+namespaced_identifier = { identifier ~ (NAMESPACE_SEP ~ identifier)+ } // Plain identifiers could be namespaced
 expression_arguments = { expression ~ ( COMMA ~ expression )* ~ COMMA? }
 
 expression_list = { expression_list_subrange | expression_list_new }

--- a/rust/parser/typeql.pest
+++ b/rust/parser/typeql.pest
@@ -537,7 +537,6 @@ FLOOR = @{ "floor" ~ WB }
 LEN = @{ "len" ~ WB }
 ROUND = @{ "round" ~ WB }
 
-// NAMESPACED FUNCTIONS
 NAMESPACE_SEP = @{ "::" }
 
 // GROUP AND AGGREGATE QUERY KEYWORDS


### PR DESCRIPTION
## Product change and motivation
Allows function names to be of the form `first::second::third` and so on, allowing us to expand our set of functions without worrying about polluting the global namespace
